### PR TITLE
Date sort display, short date format

### DIFF
--- a/src/tiles/list/date-label.ts
+++ b/src/tiles/list/date-label.ts
@@ -1,0 +1,12 @@
+export function dateLabel(sortField: string | undefined): string {
+  switch (sortField) {
+    case 'date':
+      return 'Published';
+    case 'reviewdate':
+      return 'Reviewed';
+    case 'addeddate':
+      return 'Added';
+    default:
+      return 'Archived';
+  }
+}

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { SortParam } from '@internetarchive/search-service';
+import { dateLabel } from './date-label';
 import { TileModel } from '../../models';
 
 @customElement('tile-list-compact-header')
@@ -19,24 +20,11 @@ export class TileListCompactHeader extends LitElement {
         <div id="thumb"></div>
         <div id="title">Title</div>
         <div id="creator">Creator</div>
-        <div id="date">${this.dateLabel}</div>
+        <div id="date">${dateLabel(this.sortParam?.field)}</div>
         <div id="icon"></div>
         <div id="views">Views</div>
       </div>
     `;
-  }
-
-  private get dateLabel(): string {
-    switch (this.sortParam?.field) {
-      case 'date':
-        return 'Date Published';
-      case 'reviewdate':
-        return 'Date Reviewed';
-      case 'addeddate':
-        return 'Date Added';
-      default:
-        return 'Date Archived';
-    }
   }
 
   private get classSize(): string {

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -66,7 +66,7 @@ export class TileListCompactHeader extends LitElement {
       }
 
       #list-line-header.mobile {
-        grid-template-columns: 36px 3fr 2fr 58px;
+        grid-template-columns: 36px 3fr 2fr 91px;
       }
 
       #list-line-header.desktop {

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -180,7 +180,7 @@ export class TileListCompact extends LitElement {
       }
 
       #list-line.mobile {
-        grid-template-columns: 36px 3fr 2fr 29px 19px;
+        grid-template-columns: 36px 3fr 2fr 62px 19px;
         padding-top: 2px;
         padding-bottom: 2px;
       }

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -6,6 +6,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { SortParam } from '@internetarchive/search-service';
 import DOMPurify from 'dompurify';
 import { CollectionNameCacheInterface } from '@internetarchive/collection-name-cache';
+import { dateLabel } from './date-label';
 import { TileModel } from '../../models';
 import { formatCount, NumberFormat } from '../../utils/format-count';
 import { formatDate, DateFormat } from '../../utils/format-date';
@@ -39,10 +40,11 @@ export class TileList extends LitElement {
           <div id="title">${this.titleTemplate}</div>
           ${this.itemLineTemplate} ${this.creatorTemplate}
           <div id="date" class="metadata">
-            <span class="label">Published:</span> ${formatDate(
+            <span class="label">Published: </span> ${formatDate(
               this.date,
-              this.formatSize
+              'long'
             )}
+            ${this.sortDateTemplate}
           </div>
           <div id="views-line">
             ${this.viewsTemplate} ${this.ratingTemplate} ${this.reviewsTemplate}
@@ -128,6 +130,23 @@ export class TileList extends LitElement {
         )}
       </div>
     `;
+  }
+
+  // Show date value if sorted by that date type
+  private get sortDateTemplate() {
+    if (
+      this.sortParam &&
+      (this.sortParam.field === 'addeddate' ||
+        this.sortParam.field === 'reviewdate' ||
+        this.sortParam.field === 'publicdate')
+    ) {
+      return html`
+        <span class="label">${dateLabel(this.sortParam.field)}: </span>
+        ${formatDate(this.date, 'long')}
+      </div>
+    `;
+    }
+    return nothing;
   }
 
   private get viewsTemplate() {

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -19,6 +19,7 @@ export function formatDate(
   };
   switch (format) {
     case 'short':
+      options.month = 'short';
       options.year = 'numeric';
       break;
     case 'long':

--- a/test/utils/format-date.test.ts
+++ b/test/utils/format-date.test.ts
@@ -9,7 +9,7 @@ describe('formatDate', () => {
   });
 
   it('returns short date when no DateFormat', () => {
-    expect(formatDate(testDate)).to.equal('12/20');
+    expect(formatDate(testDate)).to.equal('Dec 2020');
   });
 
   it('returns long date when long DateFormat', () => {


### PR DESCRIPTION
DRY date-label method
Add display of date label + value if sorted on that date type in detailed list tile
Change short date format from 'yyyy' to 'Jan yyyy'