### PR TITLE
Reload the infinite scroller when baseImageUrl changes

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -449,7 +449,11 @@ export class CollectionBrowser
   }
 
   updated(changed: PropertyValues) {
-    if (changed.has('displayMode') || changed.has('baseNavigationUrl')) {
+    if (
+      changed.has('displayMode') ||
+      changed.has('baseNavigationUrl') ||
+      changed.has('baseImageUrl')
+    ) {
       this.infiniteScroller.reload();
     }
     if (changed.has('baseQuery')) {


### PR DESCRIPTION
Since this modifies the content of the cells, the infinite scroller needs to reload them to get the updated values