### PR TITLE
Add logged in and content warning to model

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -32,7 +32,7 @@ export class AppRoot extends LitElement {
 
   @state() private colGap: number = 1.7;
 
-  @state() private LoggedIn: boolean = false;
+  @state() private loggedIn: boolean = false;
 
   @query('#base-query-field') private baseQueryField!: HTMLInputElement;
 
@@ -170,7 +170,7 @@ export class AppRoot extends LitElement {
           .resizeObserver=${this.resizeObserver}
           .collectionNameCache=${this.collectionNameCache}
           .showHistogramDatePicker=${true}
-          .loggedIn=${this.LoggedIn}
+          .loggedIn=${this.loggedIn}
           @visiblePageChanged=${this.visiblePageChanged}
           @baseQueryChanged=${this.baseQueryChanged}
         >
@@ -186,9 +186,9 @@ export class AppRoot extends LitElement {
   private loginChanged(e: Event) {
     const target = e.target as HTMLInputElement;
     if (target.checked) {
-      this.LoggedIn = true;
+      this.loggedIn = true;
     } else {
-      this.LoggedIn = false;
+      this.loggedIn = false;
     }
   }
 

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -32,6 +32,8 @@ export class AppRoot extends LitElement {
 
   @state() private colGap: number = 1.7;
 
+  @state() private LoggedIn: boolean = false;
+
   @query('#base-query-field') private baseQueryField!: HTMLInputElement;
 
   @query('#page-number-input') private pageNumberInput!: HTMLInputElement;
@@ -120,6 +122,14 @@ export class AppRoot extends LitElement {
                 @click=${this.outlineChanged}
               />
             </div>
+            <div>
+              <label for="simulate-login">Simulate Login:</label>
+              <input
+                type="checkbox"
+                id="simulate-login"
+                @click=${this.loginChanged}
+              />
+            </div>
           </div>
           <div id="cell-gap-control">
             <div>
@@ -160,6 +170,7 @@ export class AppRoot extends LitElement {
           .resizeObserver=${this.resizeObserver}
           .collectionNameCache=${this.collectionNameCache}
           .showHistogramDatePicker=${true}
+          .loggedIn=${this.LoggedIn}
           @visiblePageChanged=${this.visiblePageChanged}
           @baseQueryChanged=${this.baseQueryChanged}
         >
@@ -170,6 +181,15 @@ export class AppRoot extends LitElement {
 
   private baseQueryChanged(e: CustomEvent<{ baseQuery?: string }>) {
     this.searchQuery = e.detail.baseQuery;
+  }
+
+  private loginChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    if (target.checked) {
+      this.LoggedIn = true;
+    } else {
+      this.LoggedIn = false;
+    }
   }
 
   private outlineChanged(e: Event) {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -111,6 +111,8 @@ export class CollectionBrowser
 
   @property({ type: Number }) mobileBreakpoint = 600;
 
+  @property({ type: Boolean }) loggedIn = false;
+
   /**
    * The page that the consumer wants to load.
    */
@@ -984,6 +986,26 @@ export class CollectionBrowser
     const tiles: TileModel[] = [];
     docs?.forEach(doc => {
       if (!doc.identifier) return;
+
+      let loginRequired = false;
+      let contentWarning = false;
+      // Check if item and item in "modifying" collection, setting above flags
+      if (
+        doc.collections_raw?.values &&
+        doc.mediatype?.value !== 'collection'
+      ) {
+        for (const collection of doc.collections_raw?.values) {
+          if (collection === 'loggedin') {
+            loginRequired = true;
+            if (contentWarning) break;
+          }
+          if (collection === 'no-preview') {
+            contentWarning = true;
+            if (loginRequired) break;
+          }
+        }
+      }
+
       tiles.push({
         averageRating: doc.avg_rating?.value,
         collections: doc.collections_raw?.values ?? [],
@@ -1009,6 +1031,8 @@ export class CollectionBrowser
         ),
         volume: doc.volume?.value,
         viewCount: doc.downloads?.value ?? 0,
+        loginRequired,
+        contentWarning,
       });
     });
     datasource[pageNumber] = tiles;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -114,6 +114,11 @@ export class CollectionBrowser
   @property({ type: Boolean }) loggedIn = false;
 
   /**
+   * If item management UI active
+   */
+  @property({ type: Boolean }) isManageView = false;
+
+  /**
    * The page that the consumer wants to load.
    */
   private initialPageNumber = 1;
@@ -991,7 +996,7 @@ export class CollectionBrowser
       let contentWarning = false;
       // Check if item and item in "modifying" collection, setting above flags
       if (
-        doc.collections_raw?.values &&
+        doc.collections_raw?.values.length &&
         doc.mediatype?.value !== 'collection'
       ) {
         for (const collection of doc.collections_raw?.values) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -23,6 +23,8 @@ export interface TileModel {
   title: string;
   viewCount: number;
   volume?: string;
+  loginRequired: boolean;
+  contentWarning: boolean;
 }
 
 export type CollectionDisplayMode = 'grid' | 'list-compact' | 'list-detail';

--- a/src/tiles/item-image.ts
+++ b/src/tiles/item-image.ts
@@ -1,11 +1,4 @@
-import {
-  css,
-  CSSResultGroup,
-  html,
-  nothing,
-  PropertyValues,
-  LitElement,
-} from 'lit';
+import { css, CSSResultGroup, html, nothing, LitElement } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { restrictedIcon } from '../assets/img/icons/restricted';
@@ -21,25 +14,9 @@ export class ItemImage extends LitElement {
 
   @property({ type: Boolean }) isCompactTile = false;
 
-  @state() private isDeemphasize = false;
-
   @state() private isWaveform = false;
 
   @query('.item-image') private itemImageWaveform!: HTMLImageElement;
-
-  protected updated(changed: PropertyValues): void {
-    if (changed.has('model')) {
-      this.setDeemphasize();
-    }
-  }
-
-  // Don't deemphasize if item is a collection
-  private setDeemphasize() {
-    this.isDeemphasize =
-      (this.model?.mediatype !== 'collection' &&
-        this.model?.collections.includes('deemphasize')) ??
-      false;
-  }
 
   render() {
     return html`
@@ -96,14 +73,14 @@ export class ItemImage extends LitElement {
   }
 
   private get restrictedIconTemplate() {
-    if (!this.isDeemphasize) {
+    if (!this.model?.contentWarning) {
       return nothing;
     }
     return html` ${restrictedIcon} `;
   }
 
   private get tileActionTemplate() {
-    if (!this.isDeemphasize) {
+    if (!this.model?.contentWarning) {
       return nothing;
     }
     return html`
@@ -122,7 +99,9 @@ export class ItemImage extends LitElement {
 
   // Classes
   private get imageClass() {
-    return `item-image ${this.isDeemphasize ? 'deemphasize' : 'default'}`;
+    return `item-image ${
+      this.model?.contentWarning ? 'deemphasize' : 'default'
+    }`;
   }
 
   private get listImageClass() {
@@ -133,9 +112,11 @@ export class ItemImage extends LitElement {
 
   private get imageBoxClass() {
     if (this.isListTile) {
-      return `list-image-box${this.isDeemphasize ? ' deemphasize' : ''}`;
+      return `list-image-box${
+        this.model?.contentWarning ? ' deemphasize' : ''
+      }`;
     }
-    if (this.isDeemphasize) {
+    if (this.model?.contentWarning) {
       return 'item-image-box';
     }
     return undefined;


### PR DESCRIPTION
Our previous understanding of "deemphasize" has changed.

The collection `loggedin` flags tiles to be blurred and a different warning for items depending if user logged in or not.
The collection `no-preview` flags a blur and content warning.

Moved determination of these states to model and added properties to model.

Created "Simulate Login" to allow testing in demo.