### PR TITLE
collection browser, update when `loggedIn` updates

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -497,7 +497,8 @@ export class CollectionBrowser
     if (
       changed.has('displayMode') ||
       changed.has('baseNavigationUrl') ||
-      changed.has('baseImageUrl')
+      changed.has('baseImageUrl') ||
+      changed.has('loggedIn')
     ) {
       this.infiniteScroller?.reload();
     }


### PR DESCRIPTION
For dynamic updates, allow collection browser to rehydrate when loggedin property gets updated

### Testing:
- go to demo app: https://internetarchive.github.io/iaux-collection-browser/pr/pr-95/?query=collection%3Aloggedin
- toggle "simulate logged in state", note tile image covers go between login required & content warning

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/7840857/183744406-7811d97b-244e-4adb-b724-50bd6039f439.gif)

this allows demo to dynamically update given "simulate login checkbox"