### PR TITLE
Analytics updates

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -58,6 +58,7 @@ export class AppRoot extends LitElement {
   };
 
   private sendAnalytics(ae: AnalyticsEvent) {
+    console.log('Analytics Recieved ----', ae);
     this.latestAction = ae;
     this.analyticsManager?.sendEventNoSampling(ae);
   }
@@ -77,11 +78,6 @@ export class AppRoot extends LitElement {
   }
 
   protected override updated(changed: PropertyValues): void {
-    if (changed.has('latestAction')) {
-      console.log('UPDATED: OLD latestAction: ', changed.get('latestAction'));
-      console.log('UPDATED: NEW latestAction: ', this.latestAction);
-    }
-
     if (changed.has('currentPage') && this.currentPage) {
       this.pageNumberInput.value = this.currentPage.toString();
     }

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -59,7 +59,6 @@ export class AppRoot extends LitElement {
 
   private sendAnalytics(ae: AnalyticsEvent) {
     this.latestAction = ae;
-    console.log('latestAction: ', this.latestAction);
     this.analyticsManager?.sendEventNoSampling(ae);
   }
 
@@ -79,8 +78,10 @@ export class AppRoot extends LitElement {
 
   protected override updated(changed: PropertyValues): void {
     if (changed.has('latestAction')) {
-      console.log('UPDATED: latestAction: ', this.latestAction);
+      console.log('UPDATED: OLD latestAction: ', changed.get('latestAction'));
+      console.log('UPDATED: NEW latestAction: ', this.latestAction);
     }
+
     if (changed.has('currentPage') && this.currentPage) {
       this.pageNumberInput.value = this.currentPage.toString();
     }

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -5,7 +5,7 @@ import {
 import { SearchService } from '@internetarchive/search-service';
 import { LocalCache } from '@internetarchive/local-cache';
 import { html, css, LitElement, PropertyValues } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import { CollectionNameCache } from '@internetarchive/collection-name-cache';
 
@@ -41,7 +41,7 @@ export class AppRoot extends LitElement {
 
   @state() private loggedIn: boolean = false;
 
-  @state() private actionBlob?: string;
+  @property({ type: Object, reflect: false }) latestAction?: AnalyticsEvent;
 
   @query('#base-query-field') private baseQueryField!: HTMLInputElement;
 
@@ -52,14 +52,14 @@ export class AppRoot extends LitElement {
   private analyticsManager = new AnalyticsManager();
 
   private analyticsHandler: AnalyticsHandlerInterface = {
-    sendPing: this.sendAnalytics,
-    sendEvent: this.sendAnalytics,
-    sendEventNoSampling: this.sendAnalytics,
+    sendPing: this.sendAnalytics.bind(this),
+    sendEvent: this.sendAnalytics.bind(this),
+    sendEventNoSampling: this.sendAnalytics.bind(this),
   };
 
   private sendAnalytics(ae: AnalyticsEvent) {
-    this.actionBlob = `{category: ${ae.category}, action: ${ae.action}, label: ${ae.label}}`;
-    console.log('actionBlob: ', this.actionBlob);
+    this.latestAction = ae;
+    console.log('latestAction: ', this.latestAction);
     this.analyticsManager?.sendEventNoSampling(ae);
   }
 
@@ -77,7 +77,10 @@ export class AppRoot extends LitElement {
     this.collectionBrowser.goToPage(this.currentPage);
   }
 
-  protected updated(changed: PropertyValues): void {
+  protected override updated(changed: PropertyValues): void {
+    if (changed.has('latestAction')) {
+      console.log('UPDATED: latestAction: ', this.latestAction);
+    }
     if (changed.has('currentPage') && this.currentPage) {
       this.pageNumberInput.value = this.currentPage.toString();
     }
@@ -109,7 +112,21 @@ export class AppRoot extends LitElement {
           <input type="submit" value="Go" />
         </form>
 
-        <h3>Last Event Captured:: ${this.actionBlob}</h3>
+        <div id="last-event">
+          <button
+            @click=${() => {
+              const details = this.shadowRoot?.getElementById(
+                'latest-event-details'
+              );
+              details?.classList.toggle('hidden');
+            }}
+          >
+            Last Event Captured
+          </button>
+          <pre id="latest-event-details">
+${JSON.stringify(this.latestAction, null, 2)}</pre
+          >
+        </div>
 
         <div id="cell-controls">
           <div id="cell-size-control">
@@ -368,6 +385,16 @@ export class AppRoot extends LitElement {
 
     #cell-gap-control {
       margin-left: 1rem;
+    }
+
+    #last-event {
+      background-color: aliceblue;
+      padding: 5px;
+      margin: 5px auto;
+    }
+
+    .hidden {
+      display: none;
     }
   `;
 }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -43,6 +43,7 @@ import {
   defaultSelectedFacets,
   TileModel,
   CollectionDisplayMode,
+  FacetOption,
 } from './models';
 import {
   RestorationStateHandlerInterface,
@@ -389,7 +390,7 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEventNoSampling({
       category: this.analyticsCategories.default,
       action: this.analyticsActions.sortBy,
-      label: `${sortField} - ${this.sortDirection}`,
+      label: `${sortField}-${this.sortDirection}`,
     });
   }
 
@@ -401,7 +402,7 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEventNoSampling({
       category: this.analyticsCategories.default,
       action: this.analyticsActions.displayMode,
-      label: this.displayMode,
+      label: this.displayMode || '',
     });
   }
 
@@ -413,7 +414,7 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEventNoSampling({
       category: this.analyticsCategories.default,
       action: this.analyticsActions.sortByTitle,
-      label: `${this.titleQuery}`,
+      label: this.titleQuery || '',
     });
   }
 
@@ -425,7 +426,7 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEventNoSampling({
       category: this.analyticsCategories.default,
       action: this.analyticsActions.sortByCreator,
-      label: `${this.creatorQuery}`,
+      label: this.creatorQuery || '',
     });
   }
 
@@ -482,6 +483,7 @@ export class CollectionBrowser
         ?collapsableFacets=${this.mobileView}
         ?facetsLoading=${this.facetDataLoading}
         ?fullYearAggregationLoading=${this.fullYearAggregationLoading}
+        @onFacetClick=${this.facetClickHandler}
         .analyticsHandler=${this.analyticsHandler}
         .analyticsCategories=${this.analyticsCategories}
         .analyticsActions=${this.analyticsActions}
@@ -540,7 +542,7 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEventNoSampling({
       category: this.analyticsCategories.default,
       action: this.analyticsActions.histogramChanged,
-      label: this.dateRangeQueryClause,
+      label: this.dateRangeQueryClause || '',
     });
   }
 
@@ -829,6 +831,15 @@ export class CollectionBrowser
 
   facetsChanged(e: CustomEvent<SelectedFacets>) {
     this.selectedFacets = e.detail;
+  }
+
+  facetClickHandler(name: FacetOption, negative: boolean): void {
+    const negativeFacetActivated = negative ? '-negative' : '';
+    this.analyticsHandler?.sendEventNoSampling({
+      category: this.analyticsCategories?.default,
+      action: this.analyticsActions?.facetsChanged,
+      label: `${name}${negativeFacetActivated}`,
+    });
   }
 
   private async fetchFacets() {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -889,7 +889,9 @@ export class CollectionBrowser
     if (negative) {
       this.analyticsHandler?.sendEventNoSampling({
         category: this.analyticsCategories?.default,
-        action: this.analyticsActions.negativeFacetSelected,
+        action: facetSelected
+          ? this.analyticsActions.facetNegativeSelected
+          : this.analyticsActions.facetNegativeDeselected,
         label: name,
       });
     } else {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -520,7 +520,7 @@ export class CollectionBrowser
         ?collapsableFacets=${this.mobileView}
         ?facetsLoading=${this.facetDataLoading}
         ?fullYearAggregationLoading=${this.fullYearAggregationLoading}
-        @onFacetClick=${this.facetClickHandler}
+        .onFacetClick=${this.facetClickHandler}
         .analyticsHandler=${this.analyticsHandler}
         .analyticsCategories=${this.analyticsCategories}
         .analyticsActions=${this.analyticsActions}
@@ -881,13 +881,26 @@ export class CollectionBrowser
     this.selectedFacets = e.detail;
   }
 
-  facetClickHandler(name: FacetOption, negative: boolean): void {
-    const negativeFacetActivated = negative ? '-negative' : '';
-    this.analyticsHandler?.sendEventNoSampling({
-      category: this.analyticsCategories?.default,
-      action: this.analyticsActions?.facetsChanged,
-      label: `${name}${negativeFacetActivated}`,
-    });
+  facetClickHandler(
+    name: FacetOption,
+    facetSelected: boolean,
+    negative: boolean
+  ): void {
+    if (negative) {
+      this.analyticsHandler?.sendEventNoSampling({
+        category: this.analyticsCategories?.default,
+        action: this.analyticsActions.negativeFacetSelected,
+        label: name,
+      });
+    } else {
+      this.analyticsHandler?.sendEventNoSampling({
+        category: this.analyticsCategories?.default,
+        action: facetSelected
+          ? this.analyticsActions?.facetSelected
+          : this.analyticsActions?.facetDeselected,
+        label: name,
+      });
+    }
   }
 
   private async fetchFacets() {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1248,6 +1248,21 @@ export class CollectionBrowser
     return title ?? '';
   }
 
+  /** callback when a result is selected */
+  resultSelected(event: CustomEvent<TileModel>): void {
+    this.analyticsHandler?.sendEventNoSampling({
+      category: this.analyticsCategories.default,
+      action: this.analyticsActions.resultSelected,
+      label: event.detail.mediatype === 'collection' ? 'collection' : 'item',
+    });
+
+    this.analyticsHandler?.sendEventNoSampling({
+      category: this.analyticsCategories.default,
+      action: this.analyticsActions.resultSelected,
+      label: `page-${this.currentPage}`,
+    });
+  }
+
   cellForIndex(index: number): TemplateResult | undefined {
     const model = this.tileModelAtCellIndex(index);
     if (!model) return undefined;
@@ -1263,6 +1278,7 @@ export class CollectionBrowser
         .sortParam=${this.sortParam}
         .mobileBreakpoint=${this.mobileBreakpoint}
         .loggedIn=${this.loggedIn}
+        @resultSelected=${(e: CustomEvent) => this.resultSelected(e)}
       >
       </tile-dispatcher>
     `;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -415,7 +415,7 @@ export class CollectionBrowser
     }
   }
 
-  /** Send Analytics when sorting by title
+  /** Send Analytics when sorting by title's first letter
    * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
    * */
   private sendFilterByTitleAnalytics(prevSelectedLetter: string | null): void {
@@ -439,6 +439,9 @@ export class CollectionBrowser
       : undefined;
   }
 
+  /** Send Analytics when filtering by creator's first letter
+   * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
+   * */
   private sendFilterByCreatorAnalytics(
     prevSelectedLetter: string | null
   ): void {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -378,10 +378,7 @@ export class CollectionBrowser
     this.currentPage = 1;
   }
 
-  private sendSortFieldAnalytics(
-    prevSelectedSort: SortField,
-    prevSortDirection: SortDirection | null
-  ): void {
+  private sendSortByAnaltyics(prevSortDirection: SortDirection | null): void {
     const directionCleared = prevSortDirection && !this.sortDirection;
 
     this.analyticsHandler?.sendEventNoSampling({
@@ -421,9 +418,7 @@ export class CollectionBrowser
   /** Send Analytics when sorting by title
    * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
    * */
-  private sendSelectedTitleLetterChangedAnalytics(
-    prevSelectedLetter: string | null
-  ): void {
+  private sendFilterByTitleAnalytics(prevSelectedLetter: string | null): void {
     if (!prevSelectedLetter && !this.selectedTitleFilter) {
       return;
     }
@@ -444,7 +439,7 @@ export class CollectionBrowser
       : undefined;
   }
 
-  private sendSelectedCreatorFilterAnalytics(
+  private sendFilterByCreatorAnalytics(
     prevSelectedLetter: string | null
   ): void {
     if (!prevSelectedLetter && !this.selectedCreatorFilter) {
@@ -617,19 +612,18 @@ export class CollectionBrowser
       this.handleQueryChange();
     }
     if (changed.has('selectedSort') || changed.has('sortDirection')) {
-      const prevSelectedSort = changed.get('selectedSort') as SortField;
       const prevSortDirection = changed.get('sortDirection') as SortDirection;
-      this.sendSortFieldAnalytics(prevSelectedSort, prevSortDirection);
+      this.sendSortByAnaltyics(prevSortDirection);
       this.selectedSortChanged();
     }
     if (changed.has('selectedTitleFilter')) {
-      this.sendSelectedTitleLetterChangedAnalytics(
+      this.sendFilterByTitleAnalytics(
         changed.get('selectedTitleFilter') as string
       );
       this.selectedTitleLetterChanged();
     }
     if (changed.has('selectedCreatorFilter')) {
-      this.sendSelectedCreatorFilterAnalytics(
+      this.sendFilterByCreatorAnalytics(
         changed.get('selectedCreatorFilter') as string
       );
       this.selectedCreatorLetterChanged();

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -444,18 +444,27 @@ export class CollectionBrowser
       : undefined;
   }
 
+  private sendSelectedCreatorFilterAnalytics(
+    prevSelectedLetter: string | null
+  ): void {
+    if (!prevSelectedLetter && !this.selectedCreatorFilter) {
+      return;
+    }
+    const cleared = prevSelectedLetter && this.selectedCreatorFilter === null;
+
+    this.analyticsHandler?.sendEventNoSampling({
+      category: this.analyticsCategories.default,
+      action: this.analyticsActions.filterByCreator,
+      label: cleared
+        ? `clear-${prevSelectedLetter}`
+        : `${prevSelectedLetter || 'start'}-${this.selectedCreatorFilter}`,
+    });
+  }
+
   private selectedCreatorLetterChanged(): void {
     this.creatorQuery = this.selectedCreatorFilter
       ? `firstCreator:${this.selectedCreatorFilter}`
       : undefined;
-
-    if (this.creatorQuery) {
-      this.analyticsHandler?.sendEventNoSampling({
-        category: this.analyticsCategories.default,
-        action: this.analyticsActions.sortByCreator,
-        label: this.creatorQuery,
-      });
-    }
   }
 
   private titleLetterSelected(e: CustomEvent<{ selectedLetter: string }>) {
@@ -620,6 +629,9 @@ export class CollectionBrowser
       this.selectedTitleLetterChanged();
     }
     if (changed.has('selectedCreatorFilter')) {
+      this.sendSelectedCreatorFilterAnalytics(
+        changed.get('selectedCreatorFilter') as string
+      );
       this.selectedCreatorLetterChanged();
     }
     if (changed.has('pagesToRender')) {

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -82,6 +82,7 @@ export class CollectionFacets extends LitElement {
   /** Fires when a facet is clicked */
   @property({ type: Function }) onFacetClick?: (
     name: FacetOption,
+    facetChecked: boolean,
     negative: boolean
   ) => void;
 
@@ -443,7 +444,7 @@ export class CollectionFacets extends LitElement {
     }
 
     if (this.onFacetClick) {
-      this.onFacetClick(name as FacetOption, negative);
+      this.onFacetClick(name as FacetOption, checked, negative);
     }
   }
 

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -14,7 +14,6 @@ import '@internetarchive/histogram-date-range';
 import '@internetarchive/feature-feedback';
 import '@internetarchive/collection-name-cache';
 import type { CollectionNameCacheInterface } from '@internetarchive/collection-name-cache';
-import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
 import eyeIcon from './assets/img/icons/eye';
 import eyeClosedIcon from './assets/img/icons/eye-closed';
 import chevronIcon from './assets/img/icons/chevron';
@@ -26,11 +25,6 @@ import {
   defaultSelectedFacets,
 } from './models';
 import type { LanguageCodeHandlerInterface } from './language-code-handler/language-code-handler';
-
-import {
-  analyticsActions,
-  analyticsCategories,
-} from './utils/analytics-category-event';
 
 const facetDisplayOrder: FacetOption[] = [
   'mediatype',
@@ -85,6 +79,12 @@ export class CollectionFacets extends LitElement {
   @property({ type: Object })
   collectionNameCache?: CollectionNameCacheInterface;
 
+  /** Fires when a facet is clicked */
+  @property({ type: Function }) onFacetClick?: (
+    name: FacetOption,
+    negative: boolean
+  ) => void;
+
   @state() openFacets: Record<FacetOption, boolean> = {
     subject: false,
     mediatype: false,
@@ -95,12 +95,6 @@ export class CollectionFacets extends LitElement {
   };
 
   @property({ type: Object, attribute: false })
-  private analyticsHandler?: AnalyticsManagerInterface;
-
-  private analyticsCategories = analyticsCategories;
-
-  private analyticsActions = analyticsActions;
-
   render() {
     return html`
       <div id="container" class="${this.facetsLoading ? 'loading' : ''}">
@@ -439,7 +433,7 @@ export class CollectionFacets extends LitElement {
     `;
   }
 
-  private facetClicked(e: Event, bucket: FacetBucket, negative: boolean) {
+  private facetClicked(e: Event, bucket: FacetBucket, negative: boolean): void {
     const target = e.target as HTMLInputElement;
     const { checked, name, value } = target;
     if (checked) {
@@ -448,11 +442,9 @@ export class CollectionFacets extends LitElement {
       this.facetUnchecked(name as FacetOption, value);
     }
 
-    this.analyticsHandler?.sendEventNoSampling({
-      category: this.analyticsCategories?.default,
-      action: this.analyticsActions?.facetsChanged,
-      label: `${name} - ${value}`,
-    });
+    if (this.onFacetClick) {
+      this.onFacetClick(name as FacetOption, negative);
+    }
   }
 
   private facetChecked(key: FacetOption, value: string, negative: boolean) {

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -81,6 +81,10 @@ export class TileDispatcher
       <a
         href="${this.baseNavigationUrl}/details/${this.model?.identifier}"
         title=${ifDefined(this.model?.title)}
+        @click=${() =>
+          this.dispatchEvent(
+            new CustomEvent('resultSelected', { detail: this.model })
+          )}
       >
         ${this.tile}
       </a>

--- a/src/utils/analytics-category-event.ts
+++ b/src/utils/analytics-category-event.ts
@@ -12,6 +12,7 @@ export const analyticsActions = {
   displayMode: 'displayMode',
   facetSelected: 'facetSelected',
   facetDeselected: 'facetDeselected',
-  negativeFacetSelected: 'negativeFacetSelected',
+  facetNegativeSelected: 'facetNegativeSelected',
+  facetNegativeDeselected: 'facetNegativeDeselected',
   histogramChanged: 'histogramChanged',
 };

--- a/src/utils/analytics-category-event.ts
+++ b/src/utils/analytics-category-event.ts
@@ -1,15 +1,15 @@
 /**
  * Analytics categories and events. Used when building actions in
  */
- export const analyticsCategories = {
-  default: 'collection-browser'
+export const analyticsCategories = {
+  default: 'collection-browser',
 };
 
 export const analyticsActions = {
   sortBy: 'sortBy',
   sortByCreator: 'sortByCreator',
-  sortByTitle: 'sortByTitle',
+  filterByTitle: 'filterByTitle',
   displayMode: 'displayMode',
   facetsChanged: 'facetsChanged', // group + value
-  histogramChanged: 'histogramChanged'
+  histogramChanged: 'histogramChanged',
 };

--- a/src/utils/analytics-category-event.ts
+++ b/src/utils/analytics-category-event.ts
@@ -7,7 +7,7 @@ export const analyticsCategories = {
 
 export const analyticsActions = {
   sortBy: 'sortBy',
-  sortByCreator: 'sortByCreator',
+  filterByCreator: 'filterByCreator',
   filterByTitle: 'filterByTitle',
   displayMode: 'displayMode',
   facetsChanged: 'facetsChanged', // group + value

--- a/src/utils/analytics-category-event.ts
+++ b/src/utils/analytics-category-event.ts
@@ -10,6 +10,8 @@ export const analyticsActions = {
   filterByCreator: 'filterByCreator',
   filterByTitle: 'filterByTitle',
   displayMode: 'displayMode',
-  facetsChanged: 'facetsChanged', // group + value
+  facetSelected: 'facetSelected',
+  facetDeselected: 'facetDeselected',
+  negativeFacetSelected: 'negativeFacetSelected',
   histogramChanged: 'histogramChanged',
 };

--- a/src/utils/analytics-category-event.ts
+++ b/src/utils/analytics-category-event.ts
@@ -15,4 +15,5 @@ export const analyticsActions = {
   facetNegativeSelected: 'facetNegativeSelected',
   facetNegativeDeselected: 'facetNegativeDeselected',
   histogramChanged: 'histogramChanged',
+  resultSelected: 'resultSelected',
 };


### PR DESCRIPTION
Fires analytics events when patron clicks on facets, sorters, filters, view mode changes, and result clicks

updates: 
- update demo to show in control panel
- removes <collection-facet> analytics calls, opt for callback
- adds result click handler to fire analytic
- more granular events around de/selecting facets & their negative counterparts