### PR TITLE
Morefacets pager updates

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -360,6 +360,9 @@ export class CollectionFacets extends LitElement {
       class="more-link"
       @click=${() => {
         this.showMoreFacetsModal(facetGroup);
+        this.dispatchEvent(
+          new CustomEvent('showMoreFacets', { detail: facetGroup.key })
+        );
       }}
     >
       More...

--- a/src/collection-facets/more-facets-pagination.ts
+++ b/src/collection-facets/more-facets-pagination.ts
@@ -42,26 +42,40 @@ export class MoreFacetsPagination extends LitElement {
     this.pages = []; /* `0` is elipses marker */
 
     const paginatorMaxPagesToShow = 7;
-    const atMinThreshold = this.size === paginatorMaxPagesToShow;
+    const atMinThreshold = this.size <= paginatorMaxPagesToShow;
 
     /** Display outliers  */
+    if (this.size < 5) {
+      // display all pages
+      this.pages = [...Array(this.size).keys()].map(i => i + 1);
+      return;
+    }
+
     if (this.currentPage === 1) {
+      // first page
       this.pages = [1, 2, 3, 0, this.size];
       return;
     }
 
-    if (this.currentPage === 2) {
+    if (this.currentPage === this.size) {
+      // last page
+      this.pages = [1, 0, this.size - 2, this.size - 1, this.size];
+      return;
+    }
+
+    if (this.currentPage === 2 && this.size === paginatorMaxPagesToShow) {
       this.pages = [1, 2, 3, 4, 0, this.size];
       return;
     }
 
-    if (this.currentPage === this.size) {
-      this.pages = [1, 0, this.size - 2, this.size - 1, this.size];
+    if (this.currentPage === 6 && this.size === paginatorMaxPagesToShow) {
+      this.pages = [1, 0, 4, 5, this.size - 1, this.size];
       return;
     }
+
     if (
       atMinThreshold &&
-      this.currentPage > 2 &&
+      this.currentPage > 1 &&
       this.currentPage < paginatorMaxPagesToShow
     ) {
       this.pages = [...Array(this.size).keys()].map(i => i + 1);


### PR DESCRIPTION
when starting at 1, show 1 2 3 ... N
<img width="438" alt="image" src="https://user-images.githubusercontent.com/7840857/189832288-42801b42-098d-40d1-b605-60bc2f575567.png">

when under 7 pages, and selected on either [3, 4, 5, 6] => show all pages 1 2 3 4 5 6 7
<img width="478" alt="image" src="https://user-images.githubusercontent.com/7840857/189832549-5ab9ba39-6092-4c32-8680-45ee240fc265.png">

at end, show prev 2
<img width="446" alt="image" src="https://user-images.githubusercontent.com/7840857/189832597-23e697f1-eea0-4544-88df-db113bffa1d4.png">

shows all pages if count is under 5
<img width="391" alt="image" src="https://user-images.githubusercontent.com/7840857/189833943-fc772688-31d0-426a-9d9a-af71ed967e28.png">


