### PR TITLE
align checkbox w eye icon by setting the checkbox height/width, ++

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -97,22 +97,34 @@ export class AppRoot extends LitElement {
   render() {
     return html`
       <div id="dev-tools">
-        <form @submit=${this.searchPressed}>
-          Query:
-          <input
-            type="text"
-            id="base-query-field"
-            .value=${this.searchQuery ?? ''}
-          />
-          <input type="submit" value="Search" />
-        </form>
-
-        <form @submit=${this.changePagePressed}>
-          Page: <input type="number" value="1" id="page-number-input" />
-          <input type="submit" value="Go" />
-        </form>
-
-        <div id="last-event">
+        <div id="search-and-page-inputs">
+          <form @submit=${this.searchPressed}>
+            Query:
+            <input
+              type="text"
+              id="base-query-field"
+              .value=${this.searchQuery ?? ''}
+            />
+            <input type="submit" value="Search" />
+          </form>
+          <form @submit=${this.changePagePressed}>
+            Page: <input type="number" value="1" id="page-number-input" />
+            <input type="submit" value="Go" />
+          </form>
+        </div>
+        <div id="toggle-controls">
+          <button
+            @click=${() => {
+              const details =
+                this.shadowRoot?.getElementById('cell-size-control');
+              details?.classList.toggle('hidden');
+              const rowGapControls =
+                this.shadowRoot?.getElementById('cell-gap-control');
+              rowGapControls?.classList.toggle('hidden');
+            }}
+          >
+            Toggle Cell Controls
+          </button>
           <button
             @click=${() => {
               const details = this.shadowRoot?.getElementById(
@@ -123,13 +135,16 @@ export class AppRoot extends LitElement {
           >
             Last Event Captured
           </button>
+        </div>
+
+        <div id="last-event">
           <pre id="latest-event-details" class="hidden">
             ${JSON.stringify(this.latestAction, null, 2)}
           </pre
           >
         </div>
 
-        <div id="cell-controls">
+        <div id="cell-controls" class="hidden">
           <div id="cell-size-control">
             <div>
               <label for="cell-width-slider">Minimum cell width:</label>
@@ -163,6 +178,16 @@ export class AppRoot extends LitElement {
                 type="checkbox"
                 id="show-outline-check"
                 @click=${this.outlineChanged}
+              />
+            </div>
+            <div>
+              <label for="show-facet-group-outline-check"
+                >Show Facet Group Outlines:</label
+              >
+              <input
+                type="checkbox"
+                id="show-facet-group-outline-check"
+                @click=${this.toggleFacetGroupOutline}
               />
             </div>
             <div>
@@ -257,6 +282,17 @@ export class AppRoot extends LitElement {
       this.collectionBrowser.style.removeProperty(
         '--infiniteScrollerCellOutline'
       );
+    }
+  }
+
+  private toggleFacetGroupOutline(e: Event) {
+    const target = e.target as HTMLInputElement;
+    if (target.checked) {
+      this.collectionBrowser.classList.add('showFacetGroupOutlines');
+      this.modalManager.classList.add('showFacetGroupOutlines');
+    } else {
+      this.collectionBrowser.classList.remove('showFacetGroupOutlines');
+      this.modalManager.classList.remove('showFacetGroupOutlines');
     }
   }
 
@@ -388,6 +424,12 @@ export class AppRoot extends LitElement {
       margin-top: 20rem;
     }
 
+    modal-manager.showFacetGroupOutlines,
+    collection-browser.showFacetGroupOutlines {
+      --facet-row-border-top: 1px solid red;
+      --facet-row-border-bottom: 1px solid blue;
+    }
+
     #base-query-field {
       width: 300px;
     }
@@ -401,6 +443,11 @@ export class AppRoot extends LitElement {
       backdrop-filter: blur(10px);
       padding: 0.5rem 1rem;
       border: 1px solid black;
+      font-size: 1.4rem;
+    }
+
+    #dev-tools > * {
+      display: flex;
     }
 
     #cell-controls {
@@ -424,6 +471,12 @@ export class AppRoot extends LitElement {
 
     .hidden {
       display: none;
+    }
+
+    #toggle-controls {
+      background-color: lightskyblue;
+      padding: 5px;
+      margin: 5px auto;
     }
   `;
 }

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import {
   AnalyticsEvent,
   AnalyticsManager,

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -198,9 +198,6 @@ export class FacetsTemplate extends LitElement {
         column-width: 25rem;
         column-gap: 15px;
       }
-      .facets-on-page .select-facet-checkbox {
-        margin-left: 0;
-      }
       async-collection-name {
         display: contents;
       }
@@ -215,20 +212,28 @@ export class FacetsTemplate extends LitElement {
       }
       .facet-checkbox {
         margin: 0 5px 0 0;
-        display: inline-block;
-        align-items: baseline;
+        display: flex;
+        align-items: center;
+      }
+      .facet-checkbox input:first-child {
+        margin-right: 5px;
+      }
+      .facet-checkbox input {
+        height: 15px;
+        width: 15px;
+        margin: 0;
       }
       .facet-row {
         display: flex;
         font-weight: 500;
         font-size: 1.2rem;
+        margin: 2.5px auto;
       }
       .facet-info-display {
         display: flex;
         flex: 1 1 0%;
         cursor: pointer;
         flex-wrap: wrap;
-        align-content: center;
       }
       .facet-title {
         word-break: break-word;

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -229,8 +229,8 @@ export class FacetsTemplate extends LitElement {
         font-size: 1.2rem;
         margin: 2.5px auto;
         height: auto;
-        border-top: var(--facet-row-border-top, none);
-        border-bottom: var(--facet-row-border-bottom, none);
+        border-top: var(--facet-row-border-top, 1px solid transparent);
+        border-bottom: var(--facet-row-border-bottom, 1px solid transparent);
       }
       .facet-info-display {
         display: flex;

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -213,6 +213,7 @@ export class FacetsTemplate extends LitElement {
       .facet-checkbox {
         margin: 0 5px 0 0;
         display: flex;
+        height: 15px;
       }
       .facet-checkbox input:first-child {
         margin-right: 5px;
@@ -227,12 +228,9 @@ export class FacetsTemplate extends LitElement {
         font-weight: 500;
         font-size: 1.2rem;
         margin: 2.5px auto;
-        height: 15px;
+        height: auto;
         border-top: var(--facet-row-border-top, none);
         border-bottom: var(--facet-row-border-bottom, none);
-      }
-      .facet-row > * {
-        height: inherit;
       }
       .facet-info-display {
         display: flex;

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -218,7 +218,7 @@ export class FacetsTemplate extends LitElement {
         margin-right: 5px;
       }
       .facet-checkbox input {
-        height: 15px;
+        height: inherit;
         width: 15px;
         margin: 0;
       }
@@ -227,6 +227,12 @@ export class FacetsTemplate extends LitElement {
         font-weight: 500;
         font-size: 1.2rem;
         margin: 2.5px auto;
+        height: 15px;
+        border-top: var(--facet-row-border-top, none);
+        border-bottom: var(--facet-row-border-bottom, none);
+      }
+      .facet-row > * {
+        height: inherit;
       }
       .facet-info-display {
         display: flex;
@@ -251,10 +257,11 @@ export class FacetsTemplate extends LitElement {
       }
       .hide-facet-icon {
         width: 15px;
-        height: 15px;
+        height: inherit;
         cursor: pointer;
         opacity: 0.3;
         display: inline-block;
+        margin-top: -1px;
       }
       .hide-facet-icon:hover,
       .active {

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -213,7 +213,6 @@ export class FacetsTemplate extends LitElement {
       .facet-checkbox {
         margin: 0 5px 0 0;
         display: flex;
-        align-items: center;
       }
       .facet-checkbox input:first-child {
         margin-right: 5px;

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -219,7 +219,7 @@ export class FacetsTemplate extends LitElement {
         margin-right: 5px;
       }
       .facet-checkbox input {
-        height: inherit;
+        height: 15px;
         width: 15px;
         margin: 0;
       }
@@ -255,11 +255,10 @@ export class FacetsTemplate extends LitElement {
       }
       .hide-facet-icon {
         width: 15px;
-        height: inherit;
+        height: 15px;
         cursor: pointer;
         opacity: 0.3;
         display: inline-block;
-        margin-top: -1px;
       }
       .hide-facet-icon:hover,
       .active {

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -460,7 +460,7 @@ export class MoreFacetsContent extends LitElement {
       }
       .scrollable-content {
         overflow-y: auto;
-        max-height: 65vh;
+        max-height: 60vh;
       }
       .facets-content {
         font-size: 1.2rem;


### PR DESCRIPTION
Updates in this PR:
- in-repo demo app https://internetarchive.github.io/iaux-collection-browser/pr/pr-117/?query=beyonce
- Facet group alignment
   - eye icon and checkbox line up so that when using negative facet, the tail of the eye icon does not go below the checkbox's baseline
   - checkbox and eye icon are of height 15px
   - this continues to allow text to grow while count, input & eye icon stays in place
<img width="560" alt="image" src="https://user-images.githubusercontent.com/7840857/192593507-1f5913f3-53da-4fce-800e-b558a619f033.png">


- normalizing style for facet groups across views (desktop, mobile, more facets modal) & browsers (Safari, Chrome, FF)
- update demo to help Toggle show/hide of cell controls
  - <img width="300" alt="image" src="https://user-images.githubusercontent.com/7840857/192441316-78a8f485-9b6d-4406-8da5-d2fe007bb69e.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/7840857/192441362-398cc9ca-01e4-4589-9671-b3fecfbd9a5e.png">
  - Selecting `Show Facet Group Outlines` checkbox shows top & bottom borders of facet group
    - <img width="300" alt="image" src="https://user-images.githubusercontent.com/7840857/192591472-dff94ef3-cfc5-49e4-b1dd-667cab941682.png">



 
 
WEBDEV-5483