### PR TITLE
WEBDEV-5487 Fix errors reading facet state from URL params

### DIFF
--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -1,0 +1,179 @@
+/* eslint-disable import/no-duplicates */
+import { expect } from '@open-wc/testing';
+import { RestorationStateHandler } from '../src/restoration-state-handler';
+
+import '../src/tiles/grid/tile-stats';
+
+describe('Restoration state handler', () => {
+  it('should restore query from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?query=boop';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.baseQuery).to.equal('boop');
+  });
+
+  it('should restore page number from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?page=42';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.currentPage).to.equal(42);
+  });
+
+  it('should restore selected year facets from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=year:"2018"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.year['2018'].state).to.equal(
+      'selected'
+    );
+  });
+
+  it('should restore selected date range facets from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=year:"2018+TO+2021"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.minSelectedDate).to.equal('2018');
+    expect(restorationState.maxSelectedDate).to.equal('2021');
+    expect(restorationState.dateRangeQueryClause).to.equal(
+      'year:"2018 TO 2021"'
+    );
+  });
+
+  it('should restore creator filter from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=firstCreator:F';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedCreatorFilter).to.equal('F');
+  });
+
+  it('should restore title filter from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=firstTitle:F';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedTitleFilter).to.equal('F');
+  });
+
+  it('should restore other selected facets from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=subject:"foo"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.subject.foo.state).to.equal(
+      'selected'
+    );
+  });
+
+  it('should restore negative facets from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?not[]=year:2018';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.year['2018'].state).to.equal(
+      'hidden'
+    );
+  });
+
+  it('should restore multiple selected/negative facets from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search =
+      '?and[]=collection:"foo"&and[]=collection:"bar"&not[]=collection:"baz"&not[]=collection:"boop"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+
+    expect(restorationState.selectedFacets.collection.foo.state).to.equal(
+      'selected'
+    );
+    expect(restorationState.selectedFacets.collection.bar.state).to.equal(
+      'selected'
+    );
+
+    expect(restorationState.selectedFacets.collection.baz.state).to.equal(
+      'hidden'
+    );
+    expect(restorationState.selectedFacets.collection.boop.state).to.equal(
+      'hidden'
+    );
+  });
+
+  it('negative facets take precedence if both present in URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[]=collection:"foo"&not[]=collection:"foo"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.collection.foo.state).to.equal(
+      'hidden'
+    );
+  });
+
+  it('should restore sort from URL (space format)', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?sort=date+desc';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedSort).to.equal('date');
+    expect(restorationState.sortDirection).to.equal('desc');
+  });
+
+  it('should restore sort from URL (prefix format, desc)', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?sort=-date';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedSort).to.equal('date');
+    expect(restorationState.sortDirection).to.equal('desc');
+  });
+
+  it('should restore sort from URL (prefix format, asc)', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?sort=date';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedSort).to.equal('date');
+    expect(restorationState.sortDirection).to.equal('asc');
+  });
+});

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-duplicates */
 import { expect } from '@open-wc/testing';
 import { RestorationStateHandler } from '../src/restoration-state-handler';
 

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -2,8 +2,6 @@
 import { expect } from '@open-wc/testing';
 import { RestorationStateHandler } from '../src/restoration-state-handler';
 
-import '../src/tiles/grid/tile-stats';
-
 describe('Restoration state handler', () => {
   it('should restore query from URL', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });


### PR DESCRIPTION
When navigating to a URL that loads collection browser with `and[]` parameters, in certain cases it would throw an error from trying to set the state of facet buckets that didn't exist yet. This fix prevents those errors by constructing temporary facet buckets for the `and[]` parameters with the appropriate state, which will eventually be replaced by the real facet buckets (with correct count) once the search result aggregations load in.

Also adds a bunch of unit tests for the restoration state handler building its state based on the page URL, to prevent future regressions of this nature.