### PR TITLE
more facets tweak: 35 results/page, 1 col @560px, 3 col after WEBDEV-5489

### DIFF
--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -232,6 +232,7 @@ export class FacetsTemplate extends LitElement {
         height: auto;
         border-top: var(--facet-row-border-top, 1px solid transparent);
         border-bottom: var(--facet-row-border-bottom, 1px solid transparent);
+        overflow: hidden;
       }
       .facet-info-display {
         display: flex;

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -190,13 +190,14 @@ export class FacetsTemplate extends LitElement {
 
   static get styles(): CSSResultGroup {
     return css`
+      @media (max-width: 560px) {
+        .facets-on-modal {
+          column-count: 1 !important;
+        }
+      }
       .facets-on-modal {
-        /* For Chrome, Safari, Opera browsers */
-        -webkit-column-width: 100px;
-        /* For Firefox browser */
-        -moz-column-width: 100px;
-        column-width: 25rem;
         column-gap: 15px;
+        column-count: 3;
       }
       async-collection-name {
         display: contents;

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -73,7 +73,7 @@ export class MoreFacetsContent extends LitElement {
 
   @state() facetsType = 'modal';
 
-  private facetsPerPage = 50; // TODO: Q. how many items we want to have on popup view
+  private facetsPerPage = 35;
 
   updated(changed: PropertyValues) {
     if (changed.has('facetKey')) {
@@ -402,9 +402,11 @@ export class MoreFacetsContent extends LitElement {
       ${this.facetsLoading
         ? this.loaderTemplate
         : html`
-            <div class="header-content">${this.getModalHeaderTemplate}</div>
-            <div class="facets-content">${this.getMoreFacetsTemplate}</div>
-            ${this.footerTemplate}
+            <section id="more-facets">
+              <div class="header-content">${this.getModalHeaderTemplate}</div>
+              <div class="facets-content">${this.getMoreFacetsTemplate}</div>
+              ${this.footerTemplate}
+            </section>
           `}
     `;
   }
@@ -428,10 +430,17 @@ export class MoreFacetsContent extends LitElement {
 
     return css`
       @media (max-width: 560px) {
+        section#more-facets {
+          max-height: 450px;
+        }
         .facets-content {
           overflow-y: auto;
           height: 300px;
         }
+      }
+      section#more-facets {
+        overflow: auto;
+        padding: 10px; // leaves room for scroll bar to appear without overlaying on content
       }
       .header-content .title {
         display: block;
@@ -442,7 +451,9 @@ export class MoreFacetsContent extends LitElement {
       }
       .facets-content {
         font-size: 1.2rem;
-        margin: 10px;
+        max-height: 300px;
+        overflow: auto;
+        padding: 10px;
       }
       .page-number {
         background: none;

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -73,7 +73,7 @@ export class MoreFacetsContent extends LitElement {
 
   @state() facetsType = 'modal';
 
-  private facetsPerPage = 60; // TODO: Q. how many items we want to have on popup view
+  private facetsPerPage = 50; // TODO: Q. how many items we want to have on popup view
 
   updated(changed: PropertyValues) {
     if (changed.has('facetKey')) {
@@ -403,9 +403,7 @@ export class MoreFacetsContent extends LitElement {
         ? this.loaderTemplate
         : html`
             <div class="header-content">${this.getModalHeaderTemplate}</div>
-            <div class="scrollable-content">
-              <div class="facets-content">${this.getMoreFacetsTemplate}</div>
-            </div>
+            <div class="facets-content">${this.getMoreFacetsTemplate}</div>
             ${this.footerTemplate}
           `}
     `;
@@ -429,16 +427,18 @@ export class MoreFacetsContent extends LitElement {
     const modalSubmitButton = css`var(--primaryButtonBGColor, #194880)`;
 
     return css`
+      @media (max-width: 560px) {
+        .facets-content {
+          overflow-y: auto;
+          height: 300px;
+        }
+      }
       .header-content .title {
         display: block;
         text-align: left;
         font-size: 1.8rem;
         padding: 0 10px;
         font-weight: bold;
-      }
-      .scrollable-content {
-        overflow-y: auto;
-        max-height: 60vh;
       }
       .facets-content {
         font-size: 1.2rem;

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -306,6 +306,7 @@ export class TileList extends LitElement {
   }
 
   // Utility functions
+  // eslint-disable-next-line default-param-last
   private metadataTemplate(text: any, label = '', id?: string) {
     if (!text) return nothing;
     return html`

--- a/src/utils/format-count.ts
+++ b/src/utils/format-count.ts
@@ -31,6 +31,7 @@ function magnitude(number: number, numberFormat: NumberFormat): Divisor {
  * Round a number given passed magnitude.
  * Significant digits of value less than 10 get a decimal.
  */
+// eslint-disable-next-line default-param-last
 function round(number: number = 0, divisor: Divisor): number {
   const result = number / divisor;
   const roundToOne = result < 10;


### PR DESCRIPTION
### More modal facets updates:
- Each page displays 35 facets
- Desktop view for the modal:
  - UI: Facets displays in 3 columns, modal has fixed height
  - during paging, there is less vertical scrolling to view the facets on-page
- Mobile view
  - UI: Facets displays in 1 scrollable column per page, modal has fixed height
  - shrink width of modal to see facets displayed in 1 column.
- Scrollable facet group area:
  - when the facet group area is scrollable, its scroll bar does not overlap on facet data
- Note: Modal has max height, will not shrink if window height reduces

#### Testing:
- https://internetarchive.github.io/iaux-collection-browser/pr/pr-123/?query=collection%3Ainlibrary
  - Check "Show Facet Group Outlines" checkbox - each facet group has red top border, blue bottom border
  - Open "More..." **Collection** Facets
  - ✅  when facets wrap, the whole facet block stays together
    - Collection Facets, Page 1, 750px BrowserWidth:  "Washington Research Library Consortium" facet block stays together and wraps to 3rd column (see pic)
<img width="883" alt="image" src="https://user-images.githubusercontent.com/7840857/193374342-dee654d4-662c-4545-888a-1761a6cef438.png">


#### Original Problem:
- [solved]: more facets modal facet group elements does not wrap to next column properly.
  
##### Adjacent issues:
- More facets pager system is currently based on setting N facets per page.
  - Fix: showing 35 results per page reduces the need of "vertical scroll" overflow when there are too many facets displayed at once inside of small modal window.

##### Constraints:
- new paginator behaviour on the way. this update is specifically to up-level current UI.
- when facets are in the modal, they are at a light dom level in <modal-manager>, therefore cannot use coll-brwsr state around mobileView.
  - using CSS media query helps navigate this lack of connection without having to heavily inject the sharedResizeObserver.
  - using "global-level" media query is OK at modal level since there is only 1 modal on the page showing at a time. 👍 

