### PR TITLE
WEBDEV-5501 Fix bugs on toggling search options

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1183,6 +1183,10 @@ export class CollectionBrowser
    * page are visible, but if the page is not currenlty visible, we don't need to reload
    */
   private get currentVisiblePageNumbers(): number[] {
+    if (!this.infiniteScroller) {
+      return [];
+    }
+
     const visibleCells = this.infiniteScroller.getVisibleCellIndices();
     const visiblePages = new Set<number>();
     visibleCells.forEach(cellIndex => {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -993,7 +993,7 @@ export class CollectionBrowser
    * If this doesn't change, we don't need to re-fetch the histogram date range
    */
   private get fullQueryNoDateKey() {
-    return `${this.fullQueryWithoutDate}-${this.sortParam?.field}-${this.sortParam?.direction}`;
+    return `${this.fullQueryWithoutDate}-${this.searchType}-${this.sortParam?.field}-${this.sortParam?.direction}`;
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1183,11 +1183,7 @@ export class CollectionBrowser
    * page are visible, but if the page is not currenlty visible, we don't need to reload
    */
   private get currentVisiblePageNumbers(): number[] {
-    if (!this.infiniteScroller) {
-      return [];
-    }
-
-    const visibleCells = this.infiniteScroller.getVisibleCellIndices();
+    const visibleCells = this.infiniteScroller?.getVisibleCellIndices() ?? [];
     const visiblePages = new Set<number>();
     visibleCells.forEach(cellIndex => {
       const visiblePage = Math.floor(cellIndex / this.pageSize) + 1;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -538,7 +538,7 @@ export class CollectionBrowser
         .searchType=${this.searchType}
         .aggregations=${this.aggregations}
         .fullYearsHistogramAggregation=${this.fullYearsHistogramAggregation}
-        .previousSearchType=${this.previousSearchType}
+        .moreLinksVisible=${this.previousSearchType !== SearchType.FULLTEXT}
         .minSelectedDate=${this.minSelectedDate}
         .maxSelectedDate=${this.maxSelectedDate}
         .selectedFacets=${this.selectedFacets}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1055,7 +1055,7 @@ export class CollectionBrowser
    * no longer relevant.
    */
   private get pageFetchQueryKey() {
-    return `${this.fullQuery}-${this.sortParam?.field}-${this.sortParam?.direction}`;
+    return `${this.fullQuery}-${this.searchType}-${this.sortParam?.field}-${this.sortParam?.direction}`;
   }
 
   // this maps the query to the pages being fetched for that query

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -278,6 +278,14 @@ export class CollectionBrowser
     this.sortDirection = null;
   }
 
+  /**
+   * Manually requests to perform a search, which will only be executed if one of
+   * the query, the search type, or the sort has changed.
+   */
+  requestSearch() {
+    this.handleQueryChange();
+  }
+
   render() {
     this.setPlaceholderType();
     return html`

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -163,6 +163,13 @@ export class CollectionBrowser
 
   @state() private fullYearsHistogramAggregation: Aggregation | undefined;
 
+  /**
+   * The search type of the previous search (i.e., the currently displayed
+   * search results), which may differ from the one that is currently selected
+   * to be used for the next search.
+   */
+  @state() private previousSearchType?: SearchType;
+
   @state() private totalResults?: number;
 
   @state() private mobileView = false;
@@ -523,6 +530,7 @@ export class CollectionBrowser
         .searchType=${this.searchType}
         .aggregations=${this.aggregations}
         .fullYearsHistogramAggregation=${this.fullYearsHistogramAggregation}
+        .previousSearchType=${this.previousSearchType}
         .minSelectedDate=${this.minSelectedDate}
         .maxSelectedDate=${this.maxSelectedDate}
         .selectedFacets=${this.selectedFacets}
@@ -935,6 +943,7 @@ export class CollectionBrowser
     };
 
     this.facetsLoading = true;
+    this.previousSearchType = this.searchType;
     const results = await this.searchService?.search(params, this.searchType);
     this.facetsLoading = false;
 

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -48,6 +48,8 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object }) fullYearsHistogramAggregation?: Aggregation;
 
+  @property({ type: Number }) previousSearchType?: SearchType;
+
   @property({ type: String }) minSelectedDate?: string;
 
   @property({ type: String }) maxSelectedDate?: string;
@@ -398,7 +400,7 @@ export class CollectionFacets extends LitElement {
     facetGroup: FacetGroup
   ): TemplateResult | typeof nothing {
     // Don't render More... links for FTS searches
-    if (this.searchType === SearchType.FULLTEXT) {
+    if (this.previousSearchType === SearchType.FULLTEXT) {
       return nothing;
     }
 

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -8,7 +8,7 @@ import {
   TemplateResult,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import {
+import type {
   Aggregation,
   Bucket,
   SearchServiceInterface,
@@ -48,11 +48,11 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object }) fullYearsHistogramAggregation?: Aggregation;
 
-  @property({ type: Number }) previousSearchType?: SearchType;
-
   @property({ type: String }) minSelectedDate?: string;
 
   @property({ type: String }) maxSelectedDate?: string;
+
+  @property({ type: Boolean }) moreLinksVisible = true;
 
   @property({ type: Boolean }) facetsLoading = false;
 
@@ -400,7 +400,7 @@ export class CollectionFacets extends LitElement {
     facetGroup: FacetGroup
   ): TemplateResult | typeof nothing {
     // Don't render More... links for FTS searches
-    if (this.previousSearchType === SearchType.FULLTEXT) {
+    if (!this.moreLinksVisible) {
       return nothing;
     }
 

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -227,6 +227,29 @@ describe('Collection Browser', () => {
     ).to.contains('Results');
   });
 
+  it('can search on demand if only search type has changed', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .searchType=${SearchType.METADATA}
+      ></collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    await el.updateComplete;
+
+    el.searchType = SearchType.FULLTEXT;
+    await el.updateComplete;
+
+    // Haven't performed the search yet
+    expect(searchService.searchType).to.equal(SearchType.METADATA);
+
+    el.requestSearch();
+    expect(searchService.searchType).to.equal(SearchType.FULLTEXT);
+  });
+
   it('queries for collection names after a fetch', async () => {
     const searchService = new MockSearchService();
     const collectionNameCache = new MockCollectionNameCache();
@@ -239,7 +262,7 @@ describe('Collection Browser', () => {
       </collection-browser>`
     );
 
-    el.baseQuery = 'blahblah';
+    el.baseQuery = 'collection:foo';
     await el.updateComplete;
 
     expect(collectionNameCache.preloadIdentifiersRequested).to.deep.equal([


### PR DESCRIPTION
- Switching to full text search option shouldn't immediately clear More... facet links (it should wait until new search performed)
- Switching to a different search type should allow performing the same search query again with the new search type. Shouldn't have to change the search query.