### PR TITLE
Fix loggedIn icon overlay in grid and compact display mode

### DIFF
--- a/src/tiles/image-block.ts
+++ b/src/tiles/image-block.ts
@@ -22,9 +22,8 @@ export class ImageBlock extends LitElement {
   @property({ type: String }) viewSize: string = 'desktop';
 
   render() {
-    if (!this.model?.identifier) {
-      return nothing;
-    }
+    if (!this.model?.identifier) return nothing;
+
     return html`
       <div class=${classMap(this.baseClass)}>
         <item-image
@@ -52,9 +51,9 @@ export class ImageBlock extends LitElement {
   private get iconOverlayTemplate() {
     if (!this.isListTile) return nothing;
 
-    if (!this.model?.loginRequired && !this.model?.contentWarning) {
+    if (!this.model?.loginRequired && !this.model?.contentWarning)
       return nothing;
-    }
+
     return html`
       <icon-overlay
         .loggedIn=${this.loggedIn}
@@ -65,13 +64,11 @@ export class ImageBlock extends LitElement {
   }
 
   private get textOverlayTemplate() {
-    if (this.isListTile) {
-      return nothing;
-    }
+    if (this.isListTile) return nothing;
 
-    if (!this.model?.loginRequired && !this.model?.contentWarning) {
+    if (!this.model?.loginRequired && !this.model?.contentWarning)
       return nothing;
-    }
+
     return html`
       <text-overlay
         .loggedIn=${this.loggedIn}

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -38,6 +38,7 @@ export class TileListCompact extends LitElement {
           .isCompactTile=${true}
           .isListTile=${true}
           .viewSize=${this.classSize}
+          .loggedIn=${this.loggedIn}
         >
         </image-block>
         <div id="title">${DOMPurify.sanitize(this.model?.title ?? '')}</div>

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -125,6 +125,7 @@ export class TileList extends LitElement {
         .isCompactTile=${false}
         .isListTile=${true}
         .viewSize=${this.classSize}
+        .loggedIn=${this.loggedIn}
       >
       </image-block>
     `;

--- a/src/tiles/overlay/icon-overlay.ts
+++ b/src/tiles/overlay/icon-overlay.ts
@@ -11,10 +11,9 @@ export class IconOverlay extends LitElement {
   @property({ type: Boolean }) loginRequired = false;
 
   render() {
-    if (this.loginRequired && !this.loggedIn) {
-      return html`${loginRequiredIcon} `;
-    }
-    return html`${restrictedIcon}`;
+    return this.loginRequired && !this.loggedIn
+      ? html`${loginRequiredIcon}`
+      : html`${restrictedIcon}`;
   }
 
   static get styles(): CSSResultGroup {

--- a/test/image-block.test.ts
+++ b/test/image-block.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-duplicates */
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { ImageBlock } from '../src/tiles/image-block';
+
+import '../src/tiles/image-block';
+
+describe('Image block component', () => {
+  it('should render component grid display mode', async () => {
+    const el = await fixture<ImageBlock>(html`
+      <image-block
+        .model=${{
+          loggedInRequired: true,
+          contentWarning: true,
+          identifier: 'goody',
+        }}
+        .baseImageUrl=${'https://archive.org'}
+        .isCompactTile=${false}
+        .isListTile=${false}
+        .viewSize=${'grid'}
+        .loggedIn=${false}
+      >
+      </image-block>
+    `);
+
+    const viewSize = el.shadowRoot?.querySelector('.grid');
+    const itemImage = el.shadowRoot?.querySelector('item-image');
+    const textOverlay = el.shadowRoot?.querySelector('text-overlay');
+
+    expect(viewSize).to.exist;
+    expect(itemImage).to.exist;
+    expect(textOverlay).to.exist;
+  });
+
+  it('should render component list display mode', async () => {
+    const el = await fixture<ImageBlock>(html`
+      <image-block
+        .model=${{
+          loggedInRequired: true,
+          contentWarning: true,
+          identifier: 'goody',
+        }}
+        .baseImageUrl=${'https://archive.org'}
+        .isCompactTile=${false}
+        .isListTile=${true}
+        .viewSize=${'desktop'}
+        .loggedIn=${false}
+      >
+      </image-block>
+    `);
+
+    const viewSize = el.shadowRoot?.querySelector('.list.desktop');
+    const itemImage = el.shadowRoot?.querySelector('item-image');
+    const iconOverlay = el.shadowRoot?.querySelector('icon-overlay');
+
+    expect(viewSize).to.exist;
+    expect(itemImage).to.exist;
+    expect(iconOverlay).to.exist;
+  });
+
+  it('should render component compact display mode', async () => {
+    const el = await fixture<ImageBlock>(html`
+      <image-block
+        .model=${{
+          loggedInRequired: true,
+          contentWarning: true,
+          identifier: 'goody',
+        }}
+        .baseImageUrl=${'https://archive.org'}
+        .isCompactTile=${true}
+        .isListTile=${true}
+        .viewSize=${'desktop'}
+        .loggedIn=${false}
+      >
+      </image-block>
+    `);
+
+    const viewSize = el.shadowRoot?.querySelector('.list-compact.desktop');
+    const itemImage = el.shadowRoot?.querySelector('item-image');
+    const iconOverlay = el.shadowRoot?.querySelector('icon-overlay');
+
+    expect(viewSize).to.exist;
+    expect(itemImage).to.exist;
+    expect(iconOverlay).to.exist;
+  });
+});

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-duplicates */
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { TileListCompact } from '../../../src/tiles/list/tile-list-compact';
+
+import '../../../src/tiles/list/tile-list-compact';
+
+describe('List Tile Compact', () => {
+  it('should render initial component', async () => {
+    const el = await fixture<TileListCompact>(
+      html`<tile-list-compact></tile-list-compact>`
+    );
+
+    const listContainer = el.shadowRoot?.querySelector('#list-line');
+    const itemTitle = el.shadowRoot?.querySelector('#title');
+    const imageBlock = el.shadowRoot?.querySelector('image-block');
+    const itemIcon = el.shadowRoot?.querySelector('#icon');
+    const itemViews = el.shadowRoot?.querySelector('#views');
+
+    expect(listContainer).to.exist;
+    expect(itemTitle).to.exist;
+    expect(imageBlock).to.exist;
+    expect(itemIcon).to.exist;
+    expect(itemViews).to.exist;
+  });
+
+  it('should render with creator element with title', async () => {
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${{ creators: ['someone'] }}
+      ></tile-list-compact>
+    `);
+
+    const creator = el.shadowRoot?.querySelector('#creator');
+
+    expect(creator).to.exist;
+  });
+});


### PR DESCRIPTION
When logged out, the message should be "Log in to view this content" and the icon should be the login icon.

When logged in, the message should say "Content may be inappropriate" and the icon should be the caution triangle