### PR TITLE
WEBDEV-5509 Add `sin` URL param to restoration state

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.1-alpha.1",
+    "@internetarchive/collection-name-cache": "^0.2.1-alpha.2",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.1-alpha.1",
+    "@internetarchive/search-service": "^0.4.1-alpha.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.1-alpha.3",
+    "@internetarchive/collection-name-cache": "^0.2.1-alpha.4",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.1",
+    "@internetarchive/search-service": "^0.4.2-alpha.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -133,23 +133,27 @@ export class AppRoot extends LitElement {
 
         <div id="search-types">
           Search type:
-          <input
-            type="radio"
-            id="metadata-search"
-            name="search-type"
-            value="metadata"
-            checked
-            @click=${this.searchTypeChanged}
-          />
-          <label for="metadata-search">Metadata</label>
-          <input
-            type="radio"
-            id="fulltext-search"
-            name="search-type"
-            value="fulltext"
-            @click=${this.searchTypeChanged}
-          />
-          <label for="fulltext-search">Full text</label>
+          <span class="search-type">
+            <input
+              type="radio"
+              id="metadata-search"
+              name="search-type"
+              value="metadata"
+              checked
+              @click=${this.searchTypeChanged}
+            />
+            <label for="metadata-search">Metadata</label>
+          </span>
+          <span class="search-type">
+            <input
+              type="radio"
+              id="fulltext-search"
+              name="search-type"
+              value="fulltext"
+              @click=${this.searchTypeChanged}
+            />
+            <label for="fulltext-search">Full text</label>
+          </span>
         </div>
 
         <div id="toggle-controls">
@@ -187,7 +191,7 @@ export class AppRoot extends LitElement {
         <div id="cell-controls" class="hidden">
           <div id="cell-size-control">
             <div>
-              <label for="cell-width-slider">Minimum cell width:</label>
+              <label for="cell-width-slider">Min cell width:</label>
               <input
                 type="range"
                 min="10"
@@ -211,40 +215,6 @@ export class AppRoot extends LitElement {
                 @input=${this.heightChanged}
               />
               <span>${this.cellHeight}rem</span>
-            </div>
-            <div>
-              <label for="show-outline-check">Show outlines:</label>
-              <input
-                type="checkbox"
-                id="show-outline-check"
-                @click=${this.outlineChanged}
-              />
-            </div>
-            <div>
-              <label for="show-facet-group-outline-check"
-                >Show Facet Group Outlines:</label
-              >
-              <input
-                type="checkbox"
-                id="show-facet-group-outline-check"
-                @click=${this.toggleFacetGroupOutline}
-              />
-            </div>
-            <div>
-              <label for="simulate-login">Simulate Login:</label>
-              <input
-                type="checkbox"
-                id="simulate-login"
-                @click=${this.loginChanged}
-              />
-            </div>
-            <div>
-              <label for="show-dummy-snippets">Show dummy snippets:</label>
-              <input
-                type="checkbox"
-                id="show-dummy-snippets"
-                @click=${this.snippetsChanged}
-              />
             </div>
           </div>
           <div id="cell-gap-control">
@@ -274,6 +244,42 @@ export class AppRoot extends LitElement {
               />
               <span>${this.colGap}rem</span>
             </div>
+          </div>
+        </div>
+        <div id="checkbox-controls">
+          <div class="checkbox-control">
+            <input
+              type="checkbox"
+              id="show-outline-check"
+              @click=${this.outlineChanged}
+            />
+            <label for="show-outline-check">Show cell outlines</label>
+          </div>
+          <div class="checkbox-control">
+            <input
+              type="checkbox"
+              id="show-facet-group-outline-check"
+              @click=${this.toggleFacetGroupOutline}
+            />
+            <label for="show-facet-group-outline-check">
+              Show facet group outlines
+            </label>
+          </div>
+          <div class="checkbox-control">
+            <input
+              type="checkbox"
+              id="simulate-login"
+              @click=${this.loginChanged}
+            />
+            <label for="simulate-login">Simulate login</label>
+          </div>
+          <div class="checkbox-control">
+            <input
+              type="checkbox"
+              id="show-dummy-snippets"
+              @click=${this.snippetsChanged}
+            />
+            <label for="show-dummy-snippets">Show dummy snippets</label>
           </div>
         </div>
       </div>
@@ -505,8 +511,17 @@ export class AppRoot extends LitElement {
       display: flex;
     }
 
+    #search-and-page-inputs > form {
+      margin-right: 1rem;
+    }
+
+    .search-type {
+      margin-right: 1rem;
+    }
+
     #cell-controls {
       display: flex;
+      flex-wrap: wrap;
     }
 
     #cell-controls label {
@@ -514,8 +529,23 @@ export class AppRoot extends LitElement {
       width: 10rem;
     }
 
+    #cell-size-control,
+    #cell-gap-control {
+      flex-basis: calc(50% - 1rem);
+      flex-grow: 1;
+    }
+
     #cell-gap-control {
       margin-left: 1rem;
+    }
+
+    #checkbox-controls {
+      padding-top: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .checkbox-control {
+      flex-basis: 50%;
     }
 
     #last-event {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -5,6 +5,7 @@ import {
 } from '@internetarchive/analytics-manager';
 import {
   SearchService,
+  SearchServiceInterface,
   SearchType,
   StringField,
 } from '@internetarchive/search-service';
@@ -22,7 +23,8 @@ import '../src/collection-browser';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
-  private searchService = SearchService.default;
+  private searchService: SearchServiceInterface =
+    this.initSearchServiceFromUrlParams();
 
   private resizeObserver = new SharedResizeObserver();
 
@@ -71,6 +73,15 @@ export class AppRoot extends LitElement {
     console.log('Analytics Received ----', ae);
     this.latestAction = ae;
     this.analyticsManager?.sendEventNoSampling(ae);
+  }
+
+  private initSearchServiceFromUrlParams() {
+    const params = new URL(window.location.href).searchParams;
+    return new SearchService({
+      baseUrl: params.get('search_base_url') ?? undefined,
+      servicePath: params.get('search_service_path') ?? undefined,
+      debuggingEnabled: !!params.get('debugging') ?? undefined,
+    });
   }
 
   private searchPressed(e: Event) {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -139,9 +139,8 @@ export class AppRoot extends LitElement {
               id="metadata-search"
               name="search-type"
               value="metadata"
-              ?checked=${this.collectionBrowser?.searchType ===
-              SearchType.METADATA}
-              @click=${this.searchTypeChanged}
+              ?checked=${this.searchType === SearchType.METADATA}
+              @click=${this.searchTypeSelected}
             />
             <label for="metadata-search">Metadata</label>
           </span>
@@ -151,9 +150,8 @@ export class AppRoot extends LitElement {
               id="fulltext-search"
               name="search-type"
               value="fulltext"
-              ?checked=${this.collectionBrowser?.searchType ===
-              SearchType.FULLTEXT}
-              @click=${this.searchTypeChanged}
+              ?checked=${this.searchType === SearchType.FULLTEXT}
+              @click=${this.searchTypeSelected}
             />
             <label for="fulltext-search">Full text</label>
           </span>
@@ -301,6 +299,7 @@ export class AppRoot extends LitElement {
           .analyticsHandler=${this.analyticsHandler}
           @visiblePageChanged=${this.visiblePageChanged}
           @baseQueryChanged=${this.baseQueryChanged}
+          @searchTypeChanged=${this.searchTypeChanged}
         >
         </collection-browser>
       </div>
@@ -308,11 +307,17 @@ export class AppRoot extends LitElement {
     `;
   }
 
-  private baseQueryChanged(e: CustomEvent<{ baseQuery?: string }>) {
+  private baseQueryChanged(e: CustomEvent<{ baseQuery?: string }>): void {
     this.searchQuery = e.detail.baseQuery;
   }
 
-  private searchTypeChanged(e: Event) {
+  /** Handler for search type changes coming from collection browser */
+  private searchTypeChanged(e: CustomEvent<SearchType>): void {
+    this.searchType = e.detail;
+  }
+
+  /** Handler for user input selecting a search type */
+  private searchTypeSelected(e: Event) {
     const target = e.target as HTMLInputElement;
     this.searchType =
       target.value === 'fulltext' ? SearchType.FULLTEXT : SearchType.METADATA;

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -139,7 +139,8 @@ export class AppRoot extends LitElement {
               id="metadata-search"
               name="search-type"
               value="metadata"
-              checked
+              ?checked=${this.collectionBrowser?.searchType ===
+              SearchType.METADATA}
               @click=${this.searchTypeChanged}
             />
             <label for="metadata-search">Metadata</label>
@@ -150,6 +151,8 @@ export class AppRoot extends LitElement {
               id="fulltext-search"
               name="search-type"
               value="fulltext"
+              ?checked=${this.collectionBrowser?.searchType ===
+              SearchType.FULLTEXT}
               @click=${this.searchTypeChanged}
             />
             <label for="fulltext-search">Full text</label>

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -627,6 +627,9 @@ export class CollectionBrowser
     if (changed.has('baseQuery')) {
       this.emitBaseQueryChanged();
     }
+    if (changed.has('searchType')) {
+      this.emitSearchTypeChanged();
+    }
     if (changed.has('currentPage') || changed.has('displayMode')) {
       this.persistState();
     }
@@ -698,6 +701,14 @@ export class CollectionBrowser
         detail: {
           baseQuery: this.baseQuery,
         },
+      })
+    );
+  }
+
+  private emitSearchTypeChanged() {
+    this.dispatchEvent(
+      new CustomEvent<SearchType>('searchTypeChanged', {
+        detail: this.searchType,
       })
     );
   }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -811,7 +811,8 @@ export class CollectionBrowser
   private restoreState() {
     const restorationState = this.restorationStateHandler.getRestorationState();
     this.displayMode = restorationState.displayMode;
-    this.searchType = restorationState.searchType ?? SearchType.METADATA;
+    if (restorationState.searchType != null)
+      this.searchType = restorationState.searchType;
     this.selectedSort = restorationState.selectedSort ?? SortField.relevance;
     this.sortDirection = restorationState.sortDirection ?? null;
     this.selectedTitleFilter = restorationState.selectedTitleFilter ?? null;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -775,6 +775,7 @@ export class CollectionBrowser
     this.initialQueryChangeHappened = true;
     // if the query changed as part of a window.history pop event, we don't want to
     // persist the state because it overwrites the forward history
+
     if (!this.historyPopOccurred) {
       this.persistState();
       this.historyPopOccurred = false;
@@ -810,6 +811,7 @@ export class CollectionBrowser
   private restoreState() {
     const restorationState = this.restorationStateHandler.getRestorationState();
     this.displayMode = restorationState.displayMode;
+    this.searchType = restorationState.searchType ?? SearchType.METADATA;
     this.selectedSort = restorationState.selectedSort ?? SortField.relevance;
     this.sortDirection = restorationState.sortDirection ?? null;
     this.selectedTitleFilter = restorationState.selectedTitleFilter ?? null;
@@ -831,6 +833,7 @@ export class CollectionBrowser
   private persistState() {
     const restorationState: RestorationState = {
       displayMode: this.displayMode,
+      searchType: this.searchType,
       sortParam: this.sortParam ?? undefined,
       selectedSort: this.selectedSort,
       sortDirection: this.sortDirection ?? undefined,
@@ -1088,27 +1091,6 @@ export class CollectionBrowser
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
       query: this.fullQuery,
-      fields: [
-        'addeddate',
-        'avg_rating',
-        'collections_raw',
-        'creator',
-        'date',
-        'description',
-        'downloads',
-        'identifier',
-        'issue',
-        'item_count',
-        'mediatype',
-        'num_favorites',
-        'num_reviews',
-        'publicdate',
-        'reviewdate',
-        'source',
-        'subject', // topic
-        'title',
-        'volume',
-      ],
       page: pageNumber,
       rows: this.pageSize,
       sort: sortParams,

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -189,7 +189,7 @@ export class RestorationStateHandler
 
     if (searchInside) {
       restorationState.searchType =
-        searchInside === 'TXT' ? SearchType.FULLTEXT : SearchType.METADATA;
+        searchInside === 'TXT' ? SearchType.FULLTEXT : undefined; // No explicit metadata sin
     }
     if (pageNumber) {
       const parsed = parseInt(pageNumber, 10);

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -189,7 +189,7 @@ export class RestorationStateHandler
 
     if (searchInside) {
       restorationState.searchType =
-        searchInside === 'TXT' ? SearchType.FULLTEXT : undefined; // No explicit metadata sin
+        searchInside === 'TXT' ? SearchType.FULLTEXT : SearchType.METADATA;
     }
     if (pageNumber) {
       const parsed = parseInt(pageNumber, 10);

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -18,6 +18,21 @@ import { MockAnalyticsHandler } from './mocks/mock-analytics-handler';
 import { analyticsCategories } from '../src/utils/analytics-events';
 
 describe('Collection Browser', () => {
+  beforeEach(async () => {
+    // Apparently query params set by one test can bleed into other tests.
+    // Since collection browser restores its state from certain query params, we need
+    // to clear these before each test to ensure they run in isolation from one another.
+    const url = new URL(window.location.href);
+    const { searchParams } = url;
+    searchParams.delete('sin');
+    searchParams.delete('sort');
+    searchParams.delete('query');
+    searchParams.delete('page');
+    searchParams.delete('and[]');
+    searchParams.delete('not[]');
+    window.history.replaceState({}, '', url);
+  });
+
   it('clear existing filter for facets & sort-bar', async () => {
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser></collection-browser>`
@@ -370,8 +385,11 @@ describe('Collection Browser', () => {
   });
 
   it('sets sort properties when user changes sort', async () => {
+    const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
-      html`<collection-browser></collection-browser>`
+      html`<collection-browser
+        .searchService=${searchService}
+      ></collection-browser>`
     );
 
     expect(el.selectedSort).to.equal(SortField.relevance);
@@ -397,9 +415,16 @@ describe('Collection Browser', () => {
   });
 
   it('scrolls to page', async () => {
+    const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
-      html`<collection-browser></collection-browser>`
+      html`<collection-browser
+        .searchService=${searchService}
+      ></collection-browser>`
     );
+
+    // Infinite scroller won't exist unless there's a base query
+    el.baseQuery = 'collection:foo';
+    await el.updateComplete;
 
     const infiniteScroller = el.shadowRoot?.querySelector(
       'infinite-scroller'
@@ -434,6 +459,10 @@ describe('Collection Browser', () => {
       ></collection-browser>`
     );
     const infiniteScrollerRefreshSpy = sinon.spy();
+
+    // Infinite scroller won't exist unless there's a base query
+    el.baseQuery = 'collection:foo';
+    await el.updateComplete;
 
     const infiniteScroller = el.shadowRoot?.querySelector('infinite-scroller');
     (infiniteScroller as InfiniteScroller).reload = infiniteScrollerRefreshSpy;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -261,6 +261,22 @@ describe('Collection Browser', () => {
     expect(el.shadowRoot?.querySelector('empty-placeholder')).to.exist;
   });
 
+  it('restores search type from URL param', async () => {
+    // Add a sin=TXT param to the URL
+    const url = new URL(window.location.href);
+    url.searchParams.append('sin', 'TXT');
+    window.history.replaceState({}, '', url);
+
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    expect(el.searchType).to.equal(SearchType.FULLTEXT);
+  });
+
   it('applies loggedin flag to tile models if needed', async () => {
     const searchService = new MockSearchService();
 

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -1,3 +1,4 @@
+import { SearchType } from '@internetarchive/search-service';
 import { expect } from '@open-wc/testing';
 import { RestorationStateHandler } from '../src/restoration-state-handler';
 
@@ -11,6 +12,17 @@ describe('Restoration state handler', () => {
 
     const restorationState = handler.getRestorationState();
     expect(restorationState.baseQuery).to.equal('boop');
+  });
+
+  it('should restore full text search type from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?sin=TXT';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.searchType).to.equal(SearchType.FULLTEXT);
   });
 
   it('should restore page number from URL', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.1-alpha.1":
-  version "0.2.1-alpha.1"
-  resolved "https://registry.npmjs.org/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.1.tgz"
-  integrity sha512-r25q8nPshpNPu7kjPzLMDFlfiOZkfbyKHAMYbfG9kjAbkRKNBHkS4yfeO9GQsZvOfqAMeOYTFYYr5/MF6mKIKA==
+"@internetarchive/collection-name-cache@^0.2.1-alpha.2":
+  version "0.2.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.2.tgz#4eb4b6cab8cbcf8f72aecefd9ddf4c3c0516b8a5"
+  integrity sha512-j8LJg2SwUGMD/jwhvFTVpAtzcVT3JJqjMakfC3kVFnhM7WTl7vtRnFxxmcn8aQj2MkkLylY5p/uoRNafRAE1Ug==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.1-alpha.1"
+    "@internetarchive/search-service" "^0.4.1-alpha.2"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.1-alpha.1":
-  version "0.4.1-alpha.1"
-  resolved "https://registry.npmjs.org/@internetarchive/search-service/-/search-service-0.4.1-alpha.1.tgz"
-  integrity sha512-7kz1NMuYq/aqyCW7fFFHVpYVLQlsszUp9LPEQCcIjMJt2Y6bsFJd82IicxSXAtI22lO/TxsMcnSAelcqRNAqgw==
+"@internetarchive/search-service@^0.4.1-alpha.2":
+  version "0.4.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.1-alpha.2.tgz#b9f57407db8256127ecf63e1915804f887d2f282"
+  integrity sha512-MaQx7Tw+dYE3iE9DY/IhN65JPqOig1NgNTNIsqAyb420hn7OIW5KuEbP3V9FcBu5z+5zSWNWPNVqejxkPCu8rg==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.1-alpha.3":
-  version "0.2.1-alpha.3"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.3.tgz#5986cdabef56963d7fa5ff02a501fc55764c7b9a"
-  integrity sha512-NX4PeNONdJxavfA7G7JVWVaFgi6px2Bg1+jpNQoaSTvhGuDJ9j/MfBDh4JFncysxaCjHDLzgaN9rNiT1+EubWw==
+"@internetarchive/collection-name-cache@^0.2.1-alpha.4":
+  version "0.2.1-alpha.4"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.4.tgz#fd062a55c64f218d448f87caabc57e069e624c92"
+  integrity sha512-dkRsDnYtEkfGHQb+YeU51yVJ1ZBV3+Ho1Ytr2T7sQz+x/D/58kpH9mrnk1MBXkdupgiQ97ROWrzNtxOZFHrn0g==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.1"
+    "@internetarchive/search-service" "^0.4.2-alpha.1"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.1.tgz#20ff15826ae5e0d6e21ce5898c660f64356cfa51"
-  integrity sha512-b4LailLEge6eeiexu90sqrNg8gHricHGi0QcOtVHZEeHXm2p5XIfZI/JWTDotHCseF6DoGrXtWBaqW7HAnureA==
+"@internetarchive/search-service@^0.4.2-alpha.1":
+  version "0.4.2-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.2-alpha.1.tgz#e528a31ad918f7dbbefaf490df76317f10cd8050"
+  integrity sha512-q/PtcvxVoUq2u7cRRaHN7isvhiayf39XsFUmeSjROMune9lsxklC1iC+uHO1klmBJ20XnLPI5Awzx3SmbQEpuw==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
This PR makes the restoration state handler load and save the `sin` param that determines the search type of a results page.

The demo app is also updated to make the dev tools panel more compact and readable, and to handle some other URL params that will allow easier testing of the search service through collection browser demos.