### PR TITLE
WEBDEV-5520 Reinstate previously-missing search result fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.1-alpha.1",
+    "@internetarchive/collection-name-cache": "^0.2.1-alpha.3",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.1-alpha.1",
+    "@internetarchive/search-service": "^0.4.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1206,26 +1206,23 @@ export class CollectionBrowser
       }
 
       tiles.push({
-        // TODO the commented items are not currently being returned by the PPS and
-        // we will need to have them added to the PPS hit schemas where appropriate
-
-        // averageRating: result.avg_rating?.value,
+        averageRating: result.avg_rating?.value,
         collections: result.collection?.values ?? [],
         commentCount: result.num_reviews?.value ?? 0,
         creator: result.creator?.value,
         creators: result.creator?.values ?? [],
-        // dateAdded: result.addeddate?.value,
+        dateAdded: result.addeddate?.value,
         dateArchived: result.publicdate?.value,
         datePublished: result.date?.value,
         dateReviewed: result.reviewdate?.value,
         description: result.description?.value,
         favCount: result.num_favorites?.value ?? 0,
         identifier: result.identifier,
-        // issue: result.issue?.value,
-        itemCount: 0, // result.item_count?.value ?? 0,
+        issue: result.issue?.value,
+        itemCount: result.item_count?.value ?? 0,
         mediatype: result.mediatype?.value ?? 'data',
         snippets: result.highlight?.values ?? [],
-        // source: result.source?.value,
+        source: result.source?.value,
         subjects: result.subject?.values ?? [],
         title: this.etreeTitle(
           result.title?.value,

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1088,27 +1088,6 @@ export class CollectionBrowser
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
       query: this.fullQuery,
-      fields: [
-        'addeddate',
-        'avg_rating',
-        'collections_raw',
-        'creator',
-        'date',
-        'description',
-        'downloads',
-        'identifier',
-        'issue',
-        'item_count',
-        'mediatype',
-        'num_favorites',
-        'num_reviews',
-        'publicdate',
-        'reviewdate',
-        'source',
-        'subject', // topic
-        'title',
-        'volume',
-      ],
       page: pageNumber,
       rows: this.pageSize,
       sort: sortParams,

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.1-alpha.1":
-  version "0.2.1-alpha.1"
-  resolved "https://registry.npmjs.org/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.1.tgz"
-  integrity sha512-r25q8nPshpNPu7kjPzLMDFlfiOZkfbyKHAMYbfG9kjAbkRKNBHkS4yfeO9GQsZvOfqAMeOYTFYYr5/MF6mKIKA==
+"@internetarchive/collection-name-cache@^0.2.1-alpha.3":
+  version "0.2.1-alpha.3"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1-alpha.3.tgz#5986cdabef56963d7fa5ff02a501fc55764c7b9a"
+  integrity sha512-NX4PeNONdJxavfA7G7JVWVaFgi6px2Bg1+jpNQoaSTvhGuDJ9j/MfBDh4JFncysxaCjHDLzgaN9rNiT1+EubWw==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.1-alpha.1"
+    "@internetarchive/search-service" "^0.4.1"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.1-alpha.1":
-  version "0.4.1-alpha.1"
-  resolved "https://registry.npmjs.org/@internetarchive/search-service/-/search-service-0.4.1-alpha.1.tgz"
-  integrity sha512-7kz1NMuYq/aqyCW7fFFHVpYVLQlsszUp9LPEQCcIjMJt2Y6bsFJd82IicxSXAtI22lO/TxsMcnSAelcqRNAqgw==
+"@internetarchive/search-service@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.1.tgz#20ff15826ae5e0d6e21ce5898c660f64356cfa51"
+  integrity sha512-b4LailLEge6eeiexu90sqrNg8gHricHGi0QcOtVHZEeHXm2p5XIfZI/JWTDotHCseF6DoGrXtWBaqW7HAnureA==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
A handful of search result fields that we used to fetch from `advancedsearch.php` were initially not available on PPS result hits. However, these are now being served by the PPS and can be used to populate the tile models again.
- `addeddate`
- `avg_rating`
- `issue`
- `item_count`
- `source`

This PR reinstates support for these fields so that they appear correctly on result tiles/list items.