### PR TITLE
WEBDEV-5513 Don't render certain collections as facets or list items

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -946,6 +946,8 @@ export class CollectionBrowser
     const params: SearchParams = {
       query: this.fullQuery,
       rows: 0,
+      // Fetch a few extra buckets beyond the 6 we show, in case some get suppressed
+      aggregationsSize: 10,
       // Note: we don't need an aggregations param to fetch the default aggregations from the PPS.
       // The default aggregations for the search_results page type should be what we need here.
     };

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -34,6 +34,7 @@ import {
   lendingFacetDisplayNames,
   lendingFacetKeysVisibility,
   LendingFacetKey,
+  suppressedCollections,
 } from './models';
 import type { LanguageCodeHandlerInterface } from './language-code-handler/language-code-handler';
 import './collection-facets/more-facets-content';
@@ -263,7 +264,7 @@ export class CollectionFacets extends LitElement {
 
         const buckets: FacetBucket[] = Object.entries(selectedFacets).map(
           ([value, facetData]) => {
-            let displayText = value;
+            let displayText: string = value;
             // for selected languages, we store the language code instead of the
             // display name, so look up the name from the mapping
             if (option === 'language') {
@@ -310,12 +311,17 @@ export class CollectionFacets extends LitElement {
       const title = facetTitles[option];
       if (!title) return;
 
-      const castedBuckets = buckets.buckets as Bucket[];
+      let castedBuckets = buckets.buckets as Bucket[];
 
-      // we are not showing fav- items in facets
-      castedBuckets?.filter(
-        bucket => bucket?.key?.toString()?.startsWith('fav-') === false
-      );
+      if (option === 'collection') {
+        // we are not showing fav- collections or certain deemphasized collections in facets
+        castedBuckets = castedBuckets?.filter(bucket => {
+          const bucketKey = bucket?.key?.toString();
+          return (
+            !suppressedCollections[bucketKey] && !bucketKey?.startsWith('fav-')
+          );
+        });
+      }
 
       const facetBuckets: FacetBucket[] = castedBuckets.map(bucket => {
         let bucketKey = bucket.key;

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -27,6 +27,7 @@ import {
   FacetBucket,
   FacetOption,
   facetTitles,
+  suppressedCollections,
 } from '../models';
 import type { LanguageCodeHandlerInterface } from '../language-code-handler/language-code-handler';
 import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
@@ -266,10 +267,13 @@ export class MoreFacetsContent extends LitElement {
       ) as Bucket[];
 
       if (option === 'collection') {
-        // we are not showing fav- collection items in facets
-        castedBuckets = castedBuckets?.filter(
-          bucket => bucket?.key?.toString().startsWith('fav-') === false
-        );
+        // we are not showing fav- collections or certain deemphasized collections in facets
+        castedBuckets = castedBuckets?.filter(bucket => {
+          const bucketKey = bucket?.key?.toString();
+          return (
+            !suppressedCollections[bucketKey] && !bucketKey?.startsWith('fav-')
+          );
+        });
 
         // asynchronously load the collection name
         this.preloadCollectionNames(castedBuckets);

--- a/src/models.ts
+++ b/src/models.ts
@@ -214,3 +214,12 @@ export const lendingFacetDisplayNames: Partial<
   available_to_borrow: 'Borrow 14 Days',
   is_readable: 'Always Available',
 };
+
+/**
+ * A record of which collections should be suppressed from being displayed
+ * as facets or in an item's list of collections.
+ */
+export const suppressedCollections: Record<string, boolean> = {
+  deemphasize: true,
+  community: true,
+};

--- a/src/models.ts
+++ b/src/models.ts
@@ -216,10 +216,19 @@ export const lendingFacetDisplayNames: Partial<
 };
 
 /**
- * A record of which collections should be suppressed from being displayed
+ * A record of which admin-only collections should be suppressed from being displayed
  * as facets or in an item's list of collections.
  */
 export const suppressedCollections: Record<string, boolean> = {
   deemphasize: true,
   community: true,
+  stream_only: true,
+  samples_only: true,
+  test_collection: true,
+  printdisabled: true,
+  'openlibrary-ol': true,
+  nationalemergencylibrary: true,
+  china: true,
+  americana: true,
+  toronto: true,
 };

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -14,7 +14,7 @@ import DOMPurify from 'dompurify';
 
 import type { CollectionNameCacheInterface } from '@internetarchive/collection-name-cache';
 import type { SortParam } from '@internetarchive/search-service';
-import type { TileModel } from '../../models';
+import { suppressedCollections, TileModel } from '../../models';
 
 import { dateLabel } from './date-label';
 import { accountLabel } from './account-label';
@@ -64,19 +64,22 @@ export class TileList extends LitElement {
     // Note: quirk of Lit: need to replace collectionLinks array,
     // otherwise it will not re-render. Can't simply alter the array.
     this.collectionLinks = [];
-    const newCollellectionLinks: TemplateResult[] = [];
+    const newCollectionLinks: TemplateResult[] = [];
     const promises: Promise<void>[] = [];
     for (const collection of this.model.collections) {
-      promises.push(
-        this.collectionNameCache?.collectionNameFor(collection).then(name => {
-          newCollellectionLinks.push(
-            this.detailsLink(collection, name ?? collection)
-          );
-        })
-      );
+      // Don't include collections that are meant to be suppressed
+      if (!suppressedCollections[collection]) {
+        promises.push(
+          this.collectionNameCache?.collectionNameFor(collection).then(name => {
+            newCollectionLinks.push(
+              this.detailsLink(collection, name ?? collection)
+            );
+          })
+        );
+      }
     }
     await Promise.all(promises);
-    this.collectionLinks = newCollellectionLinks;
+    this.collectionLinks = newCollectionLinks;
   }
 
   render() {

--- a/test/collection-facets.test.ts
+++ b/test/collection-facets.test.ts
@@ -153,6 +153,45 @@ describe('Collection Facets', () => {
     );
   });
 
+  it('does not render suppressed collection facets', async () => {
+    const el = await fixture<CollectionFacets>(
+      html`<collection-facets></collection-facets>`
+    );
+
+    const aggs: Record<string, Aggregation> = {
+      collection: new Aggregation({
+        buckets: [
+          {
+            key: 'deemphasize',
+            doc_count: 5,
+          },
+          {
+            key: 'community',
+            doc_count: 5,
+          },
+          {
+            key: 'foo',
+            doc_count: 5,
+          },
+        ],
+      }),
+    };
+
+    el.aggregations = aggs;
+    await el.updateComplete;
+
+    const collectionFacets = el.shadowRoot
+      ?.querySelector('facets-template')
+      ?.shadowRoot?.querySelectorAll('.facet-row');
+    expect(collectionFacets?.length).to.equal(1);
+
+    // The first (and only) collection link should be for 'foo'
+    const collectionLink = collectionFacets
+      ?.item(0)
+      .querySelector(`a[href='/details/foo']`);
+    expect(collectionLink).to.exist;
+  });
+
   it('renders language facets with their human-readable names', async () => {
     const el = await fixture<CollectionFacets>(
       html`<collection-facets></collection-facets>`

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -4,6 +4,7 @@ import { html } from 'lit';
 import type { TileList } from '../../../src/tiles/list/tile-list';
 
 import '../../../src/tiles/list/tile-list';
+import { MockCollectionNameCache } from '../../mocks/mock-collection-name-cache';
 
 describe('List Tile', () => {
   it('should render initial component', async () => {
@@ -47,5 +48,25 @@ describe('List Tile', () => {
     const snippetBlock = el.shadowRoot?.querySelector('text-snippet-block');
 
     expect(snippetBlock).to.not.exist;
+  });
+
+  it('should not render suppressed collections', async () => {
+    const collectionNameCache = new MockCollectionNameCache();
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${{ collections: ['deemphasize', 'community', 'foo'] }}
+        .collectionNameCache=${collectionNameCache}
+      >
+      </tile-list>
+    `);
+
+    const collectionsRow = el.shadowRoot?.getElementById('collections');
+    expect(collectionsRow).to.exist;
+
+    const collectionLinks = collectionsRow?.querySelectorAll('a[href]');
+    expect(collectionLinks?.length).to.equal(1);
+    expect(collectionLinks?.item(0).getAttribute('href')).to.equal(
+      '/details/foo'
+    );
   });
 });


### PR DESCRIPTION
Certain meta-collections (currently `deemphasize` and `community`) shouldn't be rendered in the facet sidebar or in item collection lists. This PR ensures such collections are not displayed in those two places.