### PR TITLE
WEBDEV-5518 Change all links color

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -585,7 +585,7 @@ export class CollectionFacets extends LitElement {
         padding: 0;
         background: inherit;
         border: 0;
-        color: #4b64ff;
+        color: var(--ia-theme-link-color, #4b64ff);
         cursor: pointer;
       }
 

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -585,9 +585,10 @@ export class CollectionFacets extends LitElement {
         padding: 0;
         background: inherit;
         border: 0;
-        color: blue;
+        color: #4b64ff;
         cursor: pointer;
       }
+
       .sorting-icon {
         height: 15px;
         cursor: pointer;

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -399,6 +399,7 @@ export class TileList extends LitElement {
 
       div a {
         text-decoration: none;
+        color: #4b64ff;
       }
 
       .label {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -399,7 +399,7 @@ export class TileList extends LitElement {
 
       div a {
         text-decoration: none;
-        color: #4b64ff;
+        color: var(--ia-theme-link-color, #4b64ff);
       }
 
       .label {


### PR DESCRIPTION
### Testing Steps

- go and search for `puppies`
- switch to list view
- note the link color is incorrect for links to “More…” facets, item titles, creators, topics, collections

   - Color is #0000ee, should be #4b64ff

![image](https://user-images.githubusercontent.com/1281581/195189549-d7997173-028d-48ef-af41-412be4323b6e.png)

**Updated:**
![Screen Shot 2022-10-12 at 04 15 17](https://user-images.githubusercontent.com/1281581/195189635-fbb6297c-db27-443f-a12b-a5ff061b60c2.png)


