### PR TITLE
WEBDEV-5512 Fix alignment of image and title text in listview mode

### DIFF
--- a/src/styles/item-image-styles.ts
+++ b/src/styles/item-image-styles.ts
@@ -22,6 +22,7 @@ export const baseItemImageStyles = css`
 
   .contain {
     object-fit: contain;
+    object-position: top;
     height: 100%;
     width: 100%;
   }


### PR DESCRIPTION
### Testing steps:

- go search for `happy face`
- switch to list view display mode 

Note - this issue usually occurs when:
- there’s no default thumbnail/image is set in an item or it has the default IA logo with black background
- the thumbnail image is not 100px height size



**Previous:**

![image](https://user-images.githubusercontent.com/1281581/195187504-3baa5916-5e69-4748-89f4-440b188935b4.png)

**New:**
![Screen Shot 2022-10-12 at 04 02 54](https://user-images.githubusercontent.com/1281581/195187579-f321b455-4341-4c8f-ac55-e5496dd38ed4.png)
