### PR TITLE
WEBDEV-5499: Merge all facet requests into a single request for the default list

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -304,7 +304,10 @@ export class CollectionBrowser
       this.placeholderType = 'empty-query';
     }
 
-    if (!this.searchResultsLoading && this.totalResults === 0) {
+    if (
+      (!this.searchResultsLoading && this.totalResults === 0) ||
+      !this.searchService
+    ) {
       this.placeholderType = 'null-result';
     }
   }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -998,7 +998,8 @@ export class CollectionBrowser
     this.fullYearAggregationLoading = false;
 
     this.fullYearsHistogramAggregation =
-      results?.success?.response?.aggregations?.year_histogram;
+      results?.success?.response?.aggregations?.year_histogram ??
+      results?.success?.response?.aggregations?.['year-histogram']; // Temp fix until PPS FTS key is fixed to use underscore
   }
 
   private scrollToPage(pageNumber: number) {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -154,8 +154,11 @@ describe('Collection Browser', () => {
   });
 
   it('should render with a sort bar, facets, and infinite scroller', async () => {
+    const searchService = new MockSearchService();
+
     const el = await fixture<CollectionBrowser>(
-      html`<collection-browser></collection-browser>`
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
     );
 
     el.baseQuery = 'hello';
@@ -238,6 +241,9 @@ describe('Collection Browser', () => {
 
     // This shouldn't throw an error
     expect(el.fetchPage(2)).to.exist;
+
+    // Should continue showing the empty placeholder
+    expect(el.shadowRoot?.querySelector('empty-placeholder')).to.exist;
   });
 
   it('applies loggedin flag to tile models if needed', async () => {
@@ -444,8 +450,11 @@ describe('Collection Browser', () => {
   });
 
   it('sets sort properties when user changes sort', async () => {
+    const searchService = new MockSearchService();
+
     const el = await fixture<CollectionBrowser>(
-      html`<collection-browser></collection-browser>`
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
     );
 
     expect(el.selectedSort).to.equal(SortField.relevance);
@@ -471,8 +480,11 @@ describe('Collection Browser', () => {
   });
 
   it('scrolls to page', async () => {
+    const searchService = new MockSearchService();
+
     const el = await fixture<CollectionBrowser>(
-      html`<collection-browser></collection-browser>`
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
     );
 
     const infiniteScroller = el.shadowRoot?.querySelector(

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -16,6 +16,7 @@ import { MockSearchService } from './mocks/mock-search-service';
 import { MockCollectionNameCache } from './mocks/mock-collection-name-cache';
 import { MockAnalyticsHandler } from './mocks/mock-analytics-handler';
 import { analyticsCategories } from '../src/utils/analytics-events';
+import type { TileDispatcher } from '../src/tiles/tile-dispatcher';
 
 describe('Collection Browser', () => {
   it('clear existing filter for facets & sort-bar', async () => {
@@ -225,6 +226,79 @@ describe('Collection Browser', () => {
     expect(
       el.shadowRoot?.querySelector('#big-results-label')?.textContent
     ).to.contains('Results');
+  });
+
+  it('fails gracefully if no search service provided', async () => {
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser></collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    await el.updateComplete;
+
+    // This shouldn't throw an error
+    expect(el.fetchPage(2)).to.exist;
+  });
+
+  it('applies loggedin flag to tile models if needed', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'loggedin';
+    await el.updateComplete;
+
+    const cellTemplate = el.cellForIndex(0);
+    expect(cellTemplate).to.exist;
+
+    const cell = await fixture<TileDispatcher>(cellTemplate!);
+    expect(cell).to.exist;
+
+    expect(cell.model?.loginRequired).to.be.true;
+  });
+
+  it('applies no-preview flag to tile models if needed', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'no-preview';
+    await el.updateComplete;
+
+    const cellTemplate = el.cellForIndex(0);
+    expect(cellTemplate).to.exist;
+
+    const cell = await fixture<TileDispatcher>(cellTemplate!);
+    expect(cell).to.exist;
+
+    expect(cell.model?.contentWarning).to.be.true;
+  });
+
+  it('both loggedin and no-preview flags can be set simultaneously', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'loggedin-no-preview';
+    await el.updateComplete;
+
+    const cellTemplate = el.cellForIndex(0);
+    expect(cellTemplate).to.exist;
+
+    const cell = await fixture<TileDispatcher>(cellTemplate!);
+    expect(cell).to.exist;
+
+    expect(cell.model?.loginRequired).to.be.true;
+    expect(cell.model?.contentWarning).to.be.true;
   });
 
   it('can search on demand if only search type has changed', async () => {

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -40,6 +40,113 @@ export const mockSuccessSingleResult: Result<
   },
 };
 
+export const mockSuccessLoggedInResult: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'loggedin',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'loggedin',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            collection: ['foo', 'loggedin', 'bar'],
+            title: 'foo',
+            mediatype: 'data',
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
+export const mockSuccessNoPreviewResult: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'no-preview',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'no-preview',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            collection: ['foo', 'no-preview', 'bar'],
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
+export const mockSuccessLoggedInAndNoPreviewResult: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'loggedin-no-preview',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'loggedin-no-preview',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            collection: ['foo', 'loggedin', 'no-preview', 'bar'],
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
 export const getMockSuccessSingleResultWithSort: (
   resultsSpy: Function
 ) => Result<SearchResponse, SearchServiceError> = (resultsSpy: Function) => ({

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -10,6 +10,9 @@ import {
   mockSuccessSingleResult,
   mockSuccessMultipleResults,
   getMockSuccessSingleResultWithSort,
+  mockSuccessLoggedInResult,
+  mockSuccessNoPreviewResult,
+  mockSuccessLoggedInAndNoPreviewResult,
 } from './mock-search-responses';
 
 export class MockSearchService implements SearchServiceInterface {
@@ -40,14 +43,19 @@ export class MockSearchService implements SearchServiceInterface {
       });
     }
 
-    if (this.searchParams?.query === 'single-result') {
-      return mockSuccessSingleResult;
+    switch (this.searchParams?.query) {
+      case 'single-result':
+        return mockSuccessSingleResult;
+      case 'loggedin':
+        return mockSuccessLoggedInResult;
+      case 'no-preview':
+        return mockSuccessNoPreviewResult;
+      case 'loggedin-no-preview':
+        return mockSuccessLoggedInAndNoPreviewResult;
+      case 'with-sort':
+        return getMockSuccessSingleResultWithSort(this.resultsSpy);
+      default:
+        return mockSuccessMultipleResults;
     }
-
-    if (this.searchParams?.query === 'with-sort') {
-      return getMockSuccessSingleResultWithSort(this.resultsSpy);
-    }
-
-    return mockSuccessMultipleResults;
   }
 }


### PR DESCRIPTION
The PPS now includes lending and year_histogram aggregations in the default list of aggregations, so these no longer need to be fetched separately. This PR makes use of these bundled aggregations and removes the old additional requests.