### PR TITLE
WEBDEV-5514 Show facet tombstones while facets are loading

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -529,7 +529,6 @@ export class CollectionBrowser
 
   private get facetsTemplate() {
     return html`
-      ${this.facetsLoading ? this.loadingTemplate : nothing}
       <collection-facets
         @facetsChanged=${this.facetsChanged}
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -348,7 +348,6 @@ export class CollectionBrowser
         </div>
       </div>
       <div id="right-column" class="column">
-        ${this.searchResultsLoading ? this.loadingTemplate : nothing}
         ${this.sortFilterBarTemplate}
         ${this.displayMode === `list-compact`
           ? this.listHeaderTemplate

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -113,7 +113,9 @@ export class CollectionFacets extends LitElement {
   render() {
     return html`
       <div id="container" class="${this.facetsLoading ? 'loading' : ''}">
-        ${this.showHistogramDatePicker && this.fullYearsHistogramAggregation
+        ${(this.showHistogramDatePicker &&
+          this.fullYearsHistogramAggregation) ||
+        this.fullYearAggregationLoading
           ? html`
               <div class="facet-group">
                 <h1>Year Published <feature-feedback></feature-feedback></h1>

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -148,19 +148,21 @@ export class CollectionFacets extends LitElement {
 
   private get histogramTemplate() {
     const { fullYearsHistogramAggregation } = this;
-    return html`
-      <histogram-date-range
-        .minDate=${fullYearsHistogramAggregation?.first_bucket_key}
-        .maxDate=${fullYearsHistogramAggregation?.last_bucket_key}
-        .minSelectedDate=${this.minSelectedDate}
-        .maxSelectedDate=${this.maxSelectedDate}
-        .updateDelay=${100}
-        missingDataMessage="..."
-        .width=${180}
-        .bins=${fullYearsHistogramAggregation?.buckets as number[]}
-        @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
-      ></histogram-date-range>
-    `;
+    return this.fullYearAggregationLoading
+      ? html`<div class="histogram-loading-indicator">&hellip;</div>` // Ellipsis block
+      : html`
+          <histogram-date-range
+            .minDate=${fullYearsHistogramAggregation?.first_bucket_key}
+            .maxDate=${fullYearsHistogramAggregation?.last_bucket_key}
+            .minSelectedDate=${this.minSelectedDate}
+            .maxSelectedDate=${this.maxSelectedDate}
+            .updateDelay=${100}
+            missingDataMessage="..."
+            .width=${180}
+            .bins=${fullYearsHistogramAggregation?.buckets as number[]}
+            @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
+          ></histogram-date-range>
+        `;
   }
 
   private histogramDateRangeUpdated(
@@ -548,6 +550,14 @@ export class CollectionFacets extends LitElement {
     return css`
       #container.loading {
         opacity: 0.5;
+      }
+
+      .histogram-loading-indicator {
+        width: 100%;
+        height: 2.25rem;
+        margin-top: 1.75rem;
+        font-size: 1.4rem;
+        text-align: center;
       }
 
       .collapser {

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -8,6 +8,7 @@ import {
   TemplateResult,
 } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { map } from 'lit/directives/map.js';
 import type {
   Aggregation,
   Bucket,
@@ -39,6 +40,7 @@ import {
 import type { LanguageCodeHandlerInterface } from './language-code-handler/language-code-handler';
 import './collection-facets/more-facets-content';
 import './collection-facets/facets-template';
+import './collection-facets/facet-tombstone-row';
 import {
   analyticsActions,
   analyticsCategories,
@@ -366,7 +368,8 @@ export class CollectionFacets extends LitElement {
   private getFacetGroupTemplate(
     facetGroup: FacetGroup
   ): TemplateResult | typeof nothing {
-    if (facetGroup.buckets.length === 0) return nothing;
+    if (!this.facetsLoading && facetGroup.buckets.length === 0) return nothing;
+
     const { key } = facetGroup;
     const isOpen = this.openFacets[key];
     const collapser = html`
@@ -390,13 +393,29 @@ export class CollectionFacets extends LitElement {
           >
             ${this.collapsableFacets ? collapser : nothing} ${facetGroup.title}
           </h1>
-          ${this.moreFacetsSortingIcon(facetGroup)}
+          ${this.facetsLoading
+            ? nothing
+            : this.moreFacetsSortingIcon(facetGroup)}
         </div>
         <div class="facet-group-content ${isOpen ? 'open' : ''}">
-          ${this.getFacetTemplate(facetGroup)}
-          ${this.searchMoreFacetsLink(facetGroup)}
+          ${this.facetsLoading
+            ? this.getTombstoneFacetGroupTemplate()
+            : html`
+                ${this.getFacetTemplate(facetGroup)}
+                ${this.searchMoreFacetsLink(facetGroup)}
+              `}
         </div>
       </div>
+    `;
+  }
+
+  private getTombstoneFacetGroupTemplate(): TemplateResult {
+    // Render five tombstone rows
+    return html`
+      ${map(
+        Array(5).fill(null),
+        () => html`<facet-tombstone-row></facet-tombstone-row>`
+      )}
     `;
   }
 

--- a/src/collection-facets/facet-tombstone-row.ts
+++ b/src/collection-facets/facet-tombstone-row.ts
@@ -1,0 +1,36 @@
+import { css, html, LitElement, CSSResultGroup } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+@customElement('facet-tombstone-row')
+export class FacetTombstoneRow extends LitElement {
+  render() {
+    return html`
+      <div id="row">
+        <input type="checkbox" disabled />
+        <div class="tombstone-line"></div>
+        <div class="tombstone-line"></div>
+      </div>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      #row {
+        display: grid;
+        grid-template-columns: 13px 1fr 38px;
+        grid-gap: 9px 6px;
+        align-items: center;
+      }
+
+      .tombstone-line {
+        background: #ddd;
+        height: 6px;
+        border-radius: 50px;
+      }
+
+      input[type='checkbox'] {
+        width: 100%;
+      }
+    `;
+  }
+}

--- a/src/collection-facets/facet-tombstone-row.ts
+++ b/src/collection-facets/facet-tombstone-row.ts
@@ -17,9 +17,11 @@ export class FacetTombstoneRow extends LitElement {
     return css`
       #row {
         display: grid;
-        grid-template-columns: 13px 1fr 38px;
+        grid-template-columns: 15px 1fr 36px;
         grid-gap: 9px 6px;
         align-items: center;
+        margin: 2.5px auto;
+        border: 1px solid transparent;
       }
 
       .tombstone-line {
@@ -29,7 +31,9 @@ export class FacetTombstoneRow extends LitElement {
       }
 
       input[type='checkbox'] {
-        width: 100%;
+        width: 15px;
+        height: 15px;
+        margin: 0;
       }
     `;
   }


### PR DESCRIPTION
This PR hides the circular loading indicators when search results and facets are loading, and renders placeholder "tombstones" in place of facet buckets until they load in.