### PR TITLE
WEBDEV-5532 Show weekly view counts on list items when sorting by them

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1213,6 +1213,7 @@ export class CollectionBrowser
         ),
         volume: result.volume?.value,
         viewCount: result.downloads?.value ?? 0,
+        weeklyViewCount: result.week?.value,
         loginRequired,
         contentWarning,
       });

--- a/src/models.ts
+++ b/src/models.ts
@@ -24,6 +24,7 @@ export interface TileModel {
   title: string;
   viewCount: number;
   volume?: string;
+  weeklyViewCount?: number;
   loginRequired: boolean;
   contentWarning: boolean;
 }

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -55,9 +55,7 @@ export class TileListCompact extends LitElement {
           >
           </mediatype-icon>
         </div>
-        <div id="views">
-          ${formatCount(this.model?.viewCount ?? 0, this.formatSize)}
-        </div>
+        <div id="views">${formatCount(this.views ?? 0, this.formatSize)}</div>
       </div>
     `;
   }
@@ -78,6 +76,12 @@ export class TileListCompact extends LitElement {
       default:
         return this.model?.dateArchived; // publicdate
     }
+  }
+
+  private get views(): number | undefined {
+    return this.sortParam?.field === 'week'
+      ? this.model?.weeklyViewCount // weekly views
+      : this.model?.viewCount; // all-time views
   }
 
   private get classSize(): string {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -247,8 +247,13 @@ export class TileList extends LitElement {
   }
 
   private get viewsTemplate() {
+    const viewCount =
+      this.sortParam?.field === 'week'
+        ? this.model?.weeklyViewCount // weekly views
+        : this.model?.viewCount; // all-time views
+
     return this.metadataTemplate(
-      `${formatCount(this.model?.viewCount ?? 0, this.formatSize)}`,
+      `${formatCount(viewCount ?? 0, this.formatSize)}`,
       'Views'
     );
   }

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -246,6 +246,49 @@ describe('Collection Browser', () => {
     ).to.contains('Results');
   });
 
+  it('queries the search service with facets selected/negated', async () => {
+    const searchService = new MockSearchService();
+    const selectedFacets: SelectedFacets = {
+      subject: {
+        foo: {
+          key: 'foo',
+          count: 1,
+          state: 'selected',
+        },
+        bar: {
+          key: 'bar',
+          count: 2,
+          state: 'hidden',
+        },
+      },
+      lending: {},
+      mediatype: {},
+      language: {
+        en: {
+          key: 'en',
+          count: 1,
+          state: 'selected',
+        },
+      },
+      creator: {},
+      collection: {},
+      year: {},
+    };
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.selectedFacets = selectedFacets;
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.query).to.equal(
+      'collection:foo AND (subject:("foo" OR -"bar") AND language:("en"))'
+    );
+  });
+
   it('fails gracefully if no search service provided', async () => {
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser></collection-browser>`

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -4,6 +4,7 @@ import { html } from 'lit';
 import type { TileListCompact } from '../../../src/tiles/list/tile-list-compact';
 
 import '../../../src/tiles/list/tile-list-compact';
+import type { TileModel } from '../../../src/models';
 
 describe('List Tile Compact', () => {
   it('should render initial component', async () => {
@@ -48,5 +49,100 @@ describe('List Tile Compact', () => {
     const viewsColumn = el.shadowRoot?.getElementById('views');
     expect(viewsColumn).to.exist;
     expect(viewsColumn?.textContent?.trim()).to.equal('10');
+  });
+
+  it('should render 0 for views if missing model', async () => {
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact .sortParam=${{ field: 'week', direction: 'desc' }}>
+      </tile-list-compact>
+    `);
+
+    const viewsColumn = el.shadowRoot?.getElementById('views');
+    expect(viewsColumn).to.exist;
+    expect(viewsColumn?.textContent?.trim()).to.equal('0');
+  });
+
+  it('should render published date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-01'),
+      dateArchived: new Date('2011-01-01'),
+      datePublished: new Date('2012-01-01'),
+      dateReviewed: new Date('2013-01-01'),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2012');
+  });
+
+  it('should render added date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-01'),
+      dateArchived: new Date('2011-01-01'),
+      datePublished: new Date('2012-01-01'),
+      dateReviewed: new Date('2013-01-01'),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2010');
+  });
+
+  it('should render archived date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-01'),
+      dateArchived: new Date('2011-01-01'),
+      datePublished: new Date('2012-01-01'),
+      dateReviewed: new Date('2013-01-01'),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'publicdate', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2011');
+  });
+
+  it('should render reviewed date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-01'),
+      dateArchived: new Date('2011-01-01'),
+      datePublished: new Date('2012-01-01'),
+      dateReviewed: new Date('2013-01-01'),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'reviewdate', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2013');
   });
 });

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -35,4 +35,18 @@ describe('List Tile Compact', () => {
 
     expect(creator).to.exist;
   });
+
+  it('should render weekly views when sorting by week', async () => {
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${{ viewCount: 50, weeklyViewCount: 10 }}
+        .sortParam=${{ field: 'week', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const viewsColumn = el.shadowRoot?.getElementById('views');
+    expect(viewsColumn).to.exist;
+    expect(viewsColumn?.textContent?.trim()).to.equal('10');
+  });
 });

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -69,4 +69,18 @@ describe('List Tile', () => {
       '/details/foo'
     );
   });
+
+  it('should render weekly views when sorting by week', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${{ viewCount: 50, weeklyViewCount: 10 }}
+        .sortParam=${{ field: 'week', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const viewsRow = el.shadowRoot?.getElementById('views-line');
+    expect(viewsRow).to.exist;
+    expect(viewsRow?.textContent?.trim()).to.equal('Views:  10');
+  });
 });

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -5,6 +5,7 @@ import type { TileList } from '../../../src/tiles/list/tile-list';
 
 import '../../../src/tiles/list/tile-list';
 import { MockCollectionNameCache } from '../../mocks/mock-collection-name-cache';
+import type { TileModel } from '../../../src/models';
 
 describe('List Tile', () => {
   it('should render initial component', async () => {
@@ -82,5 +83,26 @@ describe('List Tile', () => {
     const viewsRow = el.shadowRoot?.getElementById('views-line');
     expect(viewsRow).to.exist;
     expect(viewsRow?.textContent?.trim()).to.equal('Views:  10');
+  });
+
+  it('should render added date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-01'),
+      dateArchived: new Date('2011-01-01'),
+      datePublished: new Date('2012-01-01'),
+      dateReviewed: new Date('2013-01-01'),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Added:  Jan 01, 2010');
   });
 });


### PR DESCRIPTION
Items in both list view and compact view are incorrectly showing all-time view counts even when sorting by weekly views. This PR adds weekly views to the tile models and displays them on list items when sorting by weekly views.