### PR TITLE
WEBDEV-5541 Make clicking facet labels check their checkbox

### DIFF
--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -168,7 +168,7 @@ export class FacetsTemplate extends LitElement {
                     <span class="eye-closed">${eyeClosedIcon}</span>
                   </label>
                 </div>
-                <div
+                <label
                   for=${showOnlyCheckboxId}
                   class="facet-info-display"
                   title=${onlyShowText}
@@ -177,7 +177,7 @@ export class FacetsTemplate extends LitElement {
                   <div class="facet-count">
                     ${bucket.count.toLocaleString()}
                   </div>
-                </div>
+                </label>
               </div>
             `;
           }


### PR DESCRIPTION
Currently, clicking the label of a facet does nothing, despite it showing the interactive "pointer" cursor. This PR makes clicking on those labels behave the same as if the facet's checkbox were clicked.