### PR TITLE
WEBDEV-5537 Fix formatting on "Results" header and facet counts

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1404,7 +1404,7 @@ export class CollectionBrowser
 
     #results-total {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       margin-bottom: 5rem;
     }
 
@@ -1419,9 +1419,8 @@ export class CollectionBrowser
     }
 
     #big-results-label {
-      font-size: 1rem;
+      font-size: 1.4rem;
       font-weight: 200;
-      text-transform: uppercase;
     }
 
     #list-header {

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -174,7 +174,9 @@ export class FacetsTemplate extends LitElement {
                   title=${onlyShowText}
                 >
                   <div class="facet-title">${bucketTextDisplay}</div>
-                  <div class="facet-count">${bucket.count}</div>
+                  <div class="facet-count">
+                    ${bucket.count.toLocaleString()}
+                  </div>
                 </div>
               </div>
             `;

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -49,17 +49,19 @@ describe('Render facets', () => {
     expect(el.shadowRoot?.querySelector('.facets-on-modal')).to.exist;
   });
 
-  it('find facet-title and facet-count for perticular facet group', async () => {
+  it('find facet-title and facet-count for particular facet group', async () => {
     const el = await fixture<FacetsTemplate>(
       html`<facets-template .facetGroup=${facetGroup}></facets-template>`
     );
     await el.updateComplete;
 
     const facetInfo = el.shadowRoot?.querySelector('.facet-info-display');
-    expect(facetInfo?.querySelector('.facet-title')?.textContent).equal(
+    expect(facetInfo?.querySelector('.facet-title')?.textContent).to.equal(
       'audio'
     );
-    expect(facetInfo?.querySelector('.facet-count')?.textContent).equal('1001');
+    expect(
+      facetInfo?.querySelector('.facet-count')?.textContent?.trim()
+    ).to.equal('1,001');
   });
 
   it('find the hidden facet item', async () => {


### PR DESCRIPTION
The big "Results" header should be title-cased (not all-caps) and it should be baseline-aligned with the result count (not center-aligned). The counts for facet buckets should also have the same localized formatting as the big result count (according to the user's browser default locale). This PR fixes these items.