### PR TITLE
WEBDEV-5546 Only show placeholder for date picker when it's enabled

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -113,9 +113,8 @@ export class CollectionFacets extends LitElement {
   render() {
     return html`
       <div id="container" class="${this.facetsLoading ? 'loading' : ''}">
-        ${(this.showHistogramDatePicker &&
-          this.fullYearsHistogramAggregation) ||
-        this.fullYearAggregationLoading
+        ${this.showHistogramDatePicker &&
+        (this.fullYearsHistogramAggregation || this.fullYearAggregationLoading)
           ? html`
               <div class="facet-group">
                 <h1>Year Published <feature-feedback></feature-feedback></h1>

--- a/test/collection-facets.test.ts
+++ b/test/collection-facets.test.ts
@@ -34,6 +34,73 @@ describe('Collection Facets', () => {
       el.shadowRoot?.querySelector('#container')?.classList.contains('loading')
     ).to.be.false;
   });
+
+  it('renders a date picker loading placeholder when date picker enabled', async () => {
+    const el = await fixture<CollectionFacets>(
+      html`<collection-facets></collection-facets>`
+    );
+
+    el.fullYearAggregationLoading = true;
+    el.showHistogramDatePicker = true;
+    await el.updateComplete;
+
+    const histogramLoader = el.shadowRoot?.querySelector(
+      '.histogram-loading-indicator'
+    );
+    expect(histogramLoader).to.exist;
+  });
+
+  it('does not render a date picker loading placeholder when date picker disabled', async () => {
+    const el = await fixture<CollectionFacets>(
+      html`<collection-facets></collection-facets>`
+    );
+
+    el.fullYearAggregationLoading = true;
+    el.showHistogramDatePicker = false;
+    await el.updateComplete;
+
+    const histogramLoader = el.shadowRoot?.querySelector(
+      '.histogram-loading-indicator'
+    );
+    expect(histogramLoader).to.be.null;
+  });
+
+  it('renders the date picker when enabled with data present', async () => {
+    const el = await fixture<CollectionFacets>(
+      html`<collection-facets></collection-facets>`
+    );
+
+    el.fullYearAggregationLoading = false;
+    el.showHistogramDatePicker = true;
+    el.fullYearsHistogramAggregation = new Aggregation({
+      buckets: [1, 2, 3],
+      first_bucket_key: 0,
+      last_bucket_key: 2,
+    });
+    await el.updateComplete;
+
+    const histogram = el.shadowRoot?.querySelector('histogram-date-range');
+    expect(histogram).to.exist;
+  });
+
+  it('does not render the date picker when disabled', async () => {
+    const el = await fixture<CollectionFacets>(
+      html`<collection-facets></collection-facets>`
+    );
+
+    el.fullYearAggregationLoading = false;
+    el.showHistogramDatePicker = false;
+    el.fullYearsHistogramAggregation = new Aggregation({
+      buckets: [1, 2, 3],
+      first_bucket_key: 0,
+      last_bucket_key: 2,
+    });
+    await el.updateComplete;
+
+    const histogram = el.shadowRoot?.querySelector('histogram-date-range');
+    expect(histogram).to.be.null;
+  });
+
   it('renders aggregations as facets', async () => {
     const el = await fixture<CollectionFacets>(
       html`<collection-facets></collection-facets>`


### PR DESCRIPTION
With the facet tombstones update, there’s a placeholder block being shown for the date picker while it loads. However, when the date picker is disabled, that placeholder is confusing and shouldn’t show up. This PR ensures the facet tombstones do not include a placeholder block for the date picker when the feature is disabled.