### PR TITLE
WEBDEV-5538 Upgrade list view tile links to point to beta search (not search.php)

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -340,7 +340,7 @@ export class TileList extends LitElement {
     // Note: single ' for href='' to wrap " in query var gets changed back by yarn format
 
     // eslint-disable-next-line lit/no-invalid-html
-    return html`<a href="${this.baseNavigationUrl}/search.php?query=${query}">
+    return html`<a href="${this.baseNavigationUrl}/search?query=${query}">
       ${DOMPurify.sanitize(searchTerm)}</a
     >`;
   }

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -105,4 +105,34 @@ describe('List Tile', () => {
     expect(dateRow).to.exist;
     expect(dateRow?.textContent?.trim()).to.contain('Added:  Jan 01, 2010');
   });
+
+  it('should render links to /search pages (not search.php) for subject, creator, and source', async () => {
+    const model: Partial<TileModel> = {
+      subjects: ['foo'],
+      creators: ['bar'],
+      source: 'baz',
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list .model=${model}></tile-list>
+    `);
+
+    const subjectLink = el.shadowRoot?.querySelector('#topics a[href]');
+    expect(subjectLink).to.exist;
+    expect(subjectLink?.getAttribute('href')).to.equal(
+      `/search?query=${encodeURIComponent('subject:"foo"')}`
+    );
+
+    const creatorLink = el.shadowRoot?.querySelector('#creator a[href]');
+    expect(creatorLink).to.exist;
+    expect(creatorLink?.getAttribute('href')).to.equal(
+      `/search?query=${encodeURIComponent('creator:"bar"')}`
+    );
+
+    const sourceLink = el.shadowRoot?.querySelector('#source a[href]');
+    expect(sourceLink).to.exist;
+    expect(sourceLink?.getAttribute('href')).to.equal(
+      `/search?query=${encodeURIComponent('source:"baz"')}`
+    );
+  });
 });


### PR DESCRIPTION
Some links on list view tiles were still pointing to old search.php pages (e.g., creator links, subject links). These are updated by this PR to point to the new beta search page.