### PR TITLE
WEBDEV-5567 Show 3-line descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.1",
+    "@internetarchive/collection-name-cache": "^0.2.2",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.2-alpha.1",
+    "@internetarchive/search-service": "^0.4.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -78,6 +78,7 @@ export class AppRoot extends LitElement {
   private initSearchServiceFromUrlParams() {
     const params = new URL(window.location.href).searchParams;
     return new SearchService({
+      includeCredentials: false,
       baseUrl: params.get('search_base_url') ?? undefined,
       servicePath: params.get('search_service_path') ?? undefined,
       debuggingEnabled: !!params.get('debugging') ?? undefined,

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1290,7 +1290,7 @@ export class CollectionBrowser
         dateArchived: result.publicdate?.value,
         datePublished: result.date?.value,
         dateReviewed: result.reviewdate?.value,
-        description: result.description?.value,
+        description: result.description?.values.join('\n'),
         favCount: result.num_favorites?.value ?? 0,
         identifier: result.identifier,
         issue: result.issue?.value,

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -296,14 +296,9 @@ export class TileList extends LitElement {
 
   private get descriptionTemplate() {
     return this.metadataTemplate(
-      // Sanitize away all tags except <br>, no attrs allowed (and convert line breaks to <br>).
-      // Using <br> for this allows us keep using CSS line-clamp for ellipses,
-      // which doesn't work if the text lines are split out into separate sub-elements.
+      // Sanitize away any HTML tags and convert line breaks to spaces.
       unsafeHTML(
-        DOMPurify.sanitize(
-          this.model?.description?.replace(/\n/g, '<br>') ?? '',
-          { ALLOWED_TAGS: ['br'] }
-        )
+        DOMPurify.sanitize(this.model?.description?.replace(/\n/g, ' ') ?? '')
       ),
       '',
       'description'

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -9,6 +9,7 @@ import {
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { join } from 'lit/directives/join.js';
 import { map } from 'lit/directives/map.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import DOMPurify from 'dompurify';
 
@@ -295,7 +296,15 @@ export class TileList extends LitElement {
 
   private get descriptionTemplate() {
     return this.metadataTemplate(
-      DOMPurify.sanitize(this.model?.description ?? ''),
+      // Sanitize away all tags except <br>, no attrs allowed (and convert line breaks to <br>).
+      // Using <br> for this allows us keep using CSS line-clamp for ellipses,
+      // which doesn't work if the text lines are split out into separate sub-elements.
+      unsafeHTML(
+        DOMPurify.sanitize(
+          this.model?.description?.replace(/\n/g, '<br>') ?? '',
+          { ALLOWED_TAGS: ['br'] }
+        )
+      ),
       '',
       'description'
     );

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -475,6 +475,28 @@ describe('Collection Browser', () => {
     expect(cell.model?.contentWarning).to.be.true;
   });
 
+  it('joins full description array into a single string with line breaks', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    // This query receives an array description like ['line1', 'line2']
+    el.baseQuery = 'multi-line-description';
+    await el.updateComplete;
+
+    const cellTemplate = el.cellForIndex(0);
+    expect(cellTemplate).to.exist;
+
+    const cell = await fixture<TileDispatcher>(cellTemplate!);
+    expect(cell).to.exist;
+
+    // Actual model description should be joined
+    expect(cell.model?.description).to.equal('line1\nline2');
+  });
+
   it('can search on demand if only search type has changed', async () => {
     const searchService = new MockSearchService();
 

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -270,3 +270,39 @@ export const mockSuccessMultipleResults: Result<
     },
   },
 };
+
+export const mockSuccessMultiLineDescription: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'multi-line-description',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'multi-line-description',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            collection: ['foo', 'bar'],
+            description: ['line1', 'line2'],
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -14,6 +14,7 @@ import {
   mockSuccessNoPreviewResult,
   mockSuccessLoggedInAndNoPreviewResult,
   mockSuccessWithYearHistogramAggs,
+  mockSuccessMultiLineDescription,
 } from './mock-search-responses';
 
 export class MockSearchService implements SearchServiceInterface {
@@ -49,6 +50,8 @@ export class MockSearchService implements SearchServiceInterface {
         return mockSuccessSingleResult;
       case 'years':
         return mockSuccessWithYearHistogramAggs;
+      case 'multi-line-description':
+        return mockSuccessMultiLineDescription;
       case 'loggedin':
         return mockSuccessLoggedInResult;
       case 'no-preview':

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -136,14 +136,13 @@ describe('List Tile', () => {
     );
   });
 
-  it('should render multi-line descriptions', async () => {
+  it('should render multi-line descriptions with spaces b/w lines', async () => {
     const el = await fixture<TileList>(html`
       <tile-list .model=${{ description: 'line1\nline2' }}> </tile-list>
     `);
 
     const descriptionBlock = el.shadowRoot?.getElementById('description');
     expect(descriptionBlock).to.exist;
-    expect(descriptionBlock?.children.item(0)?.nodeName).to.equal('BR'); // <br> replaces line break
-    expect(descriptionBlock?.textContent?.trim()).to.equal('line1line2'); // <br> not included in text content
+    expect(descriptionBlock?.textContent?.trim()).to.equal('line1 line2'); // line break replaced by space
   });
 });

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -135,4 +135,15 @@ describe('List Tile', () => {
       `/search?query=${encodeURIComponent('source:"baz"')}`
     );
   });
+
+  it('should render multi-line descriptions', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list .model=${{ description: 'line1\nline2' }}> </tile-list>
+    `);
+
+    const descriptionBlock = el.shadowRoot?.getElementById('description');
+    expect(descriptionBlock).to.exist;
+    expect(descriptionBlock?.children.item(0)?.nodeName).to.equal('BR'); // <br> replaces line break
+    expect(descriptionBlock?.textContent?.trim()).to.equal('line1line2'); // <br> not included in text content
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.1.tgz#a025c954b4c3084bfce6eb31faa0410a3454c889"
-  integrity sha512-3cdTNVKv/v2Gh8+i0xczdqgz+MGgvoL+x3RK0zyorzk6MMCpatndfhfp47ryUzs+iUAjy6DGA1xL9KD/g/4azQ==
+"@internetarchive/collection-name-cache@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.2.tgz#31e342d2d271b1c737122ca2de22adb3ac67c45c"
+  integrity sha512-v32uBVH69Nod9M+MjQGDsQ5UPmIN+ds4EB9guN2WfwXbVNyZ8B7BKtZLitIq71KMeNik2vvt+eqeg6SNqJC5cg==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.2-alpha.1"
+    "@internetarchive/search-service" "^0.4.2"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.2-alpha.1":
-  version "0.4.2-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.2-alpha.1.tgz#e528a31ad918f7dbbefaf490df76317f10cd8050"
-  integrity sha512-q/PtcvxVoUq2u7cRRaHN7isvhiayf39XsFUmeSjROMune9lsxklC1iC+uHO1klmBJ20XnLPI5Awzx3SmbQEpuw==
+"@internetarchive/search-service@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.2.tgz#caf9fdd05b6cc540993baa41981434f259699f78"
+  integrity sha512-/ybeQuXRLbhRRgB1U4VIzUBUEKRvWYCcwxSNWrlVF2tuxlcllH3Z+AAaCfWcKma2GL1Lvlq9/2JV8Us1w8PoAw==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
These changes ensure that the tile model receives the full description value (which may be an array consisting of many lines), rather than just the first line. Then, when the description is rendered in extended list view, this PR ensures these line breaks are correctly rendered and each line is correctly sanitized. While only 3 lines of description will ever be visible in the tile preview, this ensures we are not prematurely truncating the preview at the first line break.

This PR also updates the demo app & search service version to avoid running into CORS errors when specifying a custom `search_base_url` (e.g., for testing against a review app).