### PR TITLE
WEBDEV-5549 Show placeholder tiles upon each new search performed

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1037,9 +1037,7 @@ export class CollectionBrowser
     this.aggregations = results?.success?.response.aggregations;
 
     // If we're not fetching year histogram data separately, set it from the newly-fetched aggregations
-    console.log('should', this.shouldRequestYearHistogram);
     if (!this.shouldRequestYearHistogram) {
-      console.log('Setting histogram data from facet request');
       this.fullYearsHistogramAggregation =
         results?.success?.response?.aggregations?.year_histogram ??
         results?.success?.response?.aggregations?.['year-histogram']; // Temp fix until PPS FTS key is fixed to use underscore
@@ -1096,7 +1094,6 @@ export class CollectionBrowser
     const results = await this.searchService?.search(params, this.searchType);
     this.fullYearAggregationLoading = false;
 
-    console.log('Setting histogram data from year request');
     this.fullYearsHistogramAggregation =
       results?.success?.response?.aggregations?.year_histogram ??
       results?.success?.response?.aggregations?.['year-histogram']; // Temp fix until PPS FTS key is fixed to use underscore

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -778,6 +778,11 @@ export class CollectionBrowser
     this.pageFetchesInProgress = {};
     this.endOfDataReached = false;
     this.pagesToRender = this.initialPageNumber;
+
+    // Reset the infinite scroller's item count, so that it
+    // shows tile placeholders until the new query's results load in
+    this.infiniteScroller?.reload();
+
     if (!this.initialQueryChangeHappened && this.initialPageNumber > 1) {
       this.scrollToPage(this.initialPageNumber);
     }


### PR DESCRIPTION
When going from a blank search (empty placeholder) to a new search, the “loading placeholder” tile tombstones appear while the results load, as expected. But if you perform another search after that, the tile tombstones don’t appear anymore – the old results stay up until the new ones arrive. So there’s no indication that results are loading.

This PR ensures the search results always show placeholder tombstones immediately upon performing a new search, regardless of whether or not there were other search results present beforehand.