### PR TITLE
WEBDEV-5572 Only send separate year_histogram requests when necessary

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -421,6 +421,13 @@ export class AppRoot extends LitElement {
   private datePickerChanged(e: Event) {
     const target = e.target as HTMLInputElement;
     this.collectionBrowser.showHistogramDatePicker = target.checked;
+
+    // When disabling the date picker from the demo app, also clear any existing date range params
+    if (!this.collectionBrowser.showHistogramDatePicker) {
+      this.collectionBrowser.minSelectedDate = undefined;
+      this.collectionBrowser.maxSelectedDate = undefined;
+      this.collectionBrowser.dateRangeQueryClause = undefined;
+    }
   }
 
   private rowGapChanged(e: Event) {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -160,15 +160,15 @@ export class AppRoot extends LitElement {
         <div id="toggle-controls">
           <button
             @click=${() => {
-              const details =
-                this.shadowRoot?.getElementById('cell-size-control');
-              details?.classList.toggle('hidden');
-              const rowGapControls =
-                this.shadowRoot?.getElementById('cell-gap-control');
-              rowGapControls?.classList.toggle('hidden');
+              const cellControls =
+                this.shadowRoot?.getElementById('cell-controls');
+              cellControls?.classList.toggle('hidden');
+              const checkboxControls =
+                this.shadowRoot?.getElementById('checkbox-controls');
+              checkboxControls?.classList.toggle('hidden');
             }}
           >
-            Toggle Cell Controls
+            Toggle Controls
           </button>
           <button
             @click=${() => {
@@ -189,7 +189,7 @@ export class AppRoot extends LitElement {
           >
         </div>
 
-        <div id="cell-controls" class="hidden">
+        <div id="cell-controls">
           <div id="cell-size-control">
             <div>
               <label for="cell-width-slider">Min cell width:</label>
@@ -281,6 +281,15 @@ export class AppRoot extends LitElement {
               @click=${this.snippetsChanged}
             />
             <label for="show-dummy-snippets">Show dummy snippets</label>
+          </div>
+          <div class="checkbox-control">
+            <input
+              type="checkbox"
+              id="enable-date-picker"
+              checked
+              @click=${this.datePickerChanged}
+            />
+            <label for="enable-date-picker">Enable date picker</label>
           </div>
         </div>
       </div>
@@ -407,6 +416,11 @@ export class AppRoot extends LitElement {
       setTimeout(res, 0);
     });
     this.searchQuery = oldQuery; // Re-apply the original query
+  }
+
+  private datePickerChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.collectionBrowser.showHistogramDatePicker = target.checked;
   }
 
   private rowGapChanged(e: Event) {
@@ -563,7 +577,8 @@ export class AppRoot extends LitElement {
     }
 
     .hidden {
-      display: none;
+      /* If this class is present, we want the element hidden regardless of specificity */
+      display: none !important;
     }
 
     #toggle-controls {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -646,6 +646,48 @@ describe('Collection Browser', () => {
     expect(el.selectedSort).to.equal(SortField.title);
   });
 
+  it('sets sort filter properties when user selects title filter', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.selectedTitleFilter = 'X';
+    await el.updateComplete;
+
+    // Wait an extra tick
+    await new Promise(res => {
+      setTimeout(res, 0);
+    });
+
+    expect(searchService.searchParams?.query).to.equal(
+      'collection:foo AND firstTitle:X'
+    );
+  });
+
+  it('sets sort filter properties when user selects creator filter', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.selectedCreatorFilter = 'X';
+    await el.updateComplete;
+
+    // Wait an extra tick
+    await new Promise(res => {
+      setTimeout(res, 0);
+    });
+
+    expect(searchService.searchParams?.query).to.equal(
+      'collection:foo AND firstCreator:X'
+    );
+  });
+
   it('sets date range query when date picker selection changed', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -289,6 +289,98 @@ describe('Collection Browser', () => {
     );
   });
 
+  it('fires a separate date histogram query when year facets are applied', async () => {
+    const searchService = new MockSearchService();
+    const selectedFacets: SelectedFacets = {
+      subject: {},
+      lending: {},
+      mediatype: {},
+      language: {},
+      creator: {},
+      collection: {},
+      year: {
+        '2000': {
+          key: '2000',
+          state: 'selected',
+          count: 123,
+        },
+      },
+    };
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.showHistogramDatePicker = true;
+    el.selectedFacets = selectedFacets;
+    await el.updateComplete;
+
+    expect(
+      searchService.searchParams?.aggregations?.simpleParams
+    ).to.deep.equal(['year']); // Explicitly requests year aggregations
+    expect(searchService.searchParams?.query).to.equal(
+      'collection:foo' // No date clause on query
+    );
+  });
+
+  it('fires a separate date histogram query when a date range is applied', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.showHistogramDatePicker = true;
+    el.dateRangeQueryClause = 'year:[1995 TO 2005]';
+    await el.updateComplete;
+
+    expect(
+      searchService.searchParams?.aggregations?.simpleParams
+    ).to.deep.equal(['year']); // Explicitly requests year aggregations
+    expect(searchService.searchParams?.query).to.equal(
+      'collection:foo' // No date clause on query
+    );
+  });
+
+  it('does not fire a separate date histogram query when no date filters are applied', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.showHistogramDatePicker = true;
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.aggregations?.simpleParams).to.satisfy(
+      (aggTypes: string[]) => !aggTypes || !aggTypes.includes('year') // Not requesting year aggregations explicitly
+    );
+  });
+
+  it('does not fire a separate date histogram query when date picker is disabled', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection:foo';
+    el.showHistogramDatePicker = false;
+    el.dateRangeQueryClause = 'year:[1995 TO 2005]';
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.aggregations?.simpleParams).to.satisfy(
+      (aggTypes: string[]) => !aggTypes || !aggTypes.includes('year') // Not requesting year aggregations explicitly
+    );
+  });
+
   it('fails gracefully if no search service provided', async () => {
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser></collection-browser>`

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -4,6 +4,7 @@ import { html } from 'lit';
 import sinon from 'sinon';
 import type { InfiniteScroller } from '@internetarchive/infinite-scroller';
 import { SearchType } from '@internetarchive/search-service';
+import type { HistogramDateRange } from '@internetarchive/histogram-date-range';
 import type { CollectionBrowser } from '../src/collection-browser';
 import '../src/collection-browser';
 import {
@@ -17,6 +18,7 @@ import { MockCollectionNameCache } from './mocks/mock-collection-name-cache';
 import { MockAnalyticsHandler } from './mocks/mock-analytics-handler';
 import { analyticsCategories } from '../src/utils/analytics-events';
 import type { TileDispatcher } from '../src/tiles/tile-dispatcher';
+import type { CollectionFacets } from '../src/collection-facets';
 
 describe('Collection Browser', () => {
   beforeEach(async () => {
@@ -642,6 +644,55 @@ describe('Collection Browser', () => {
     await el.updateComplete;
 
     expect(el.selectedSort).to.equal(SortField.title);
+  });
+
+  it('sets date range query when date picker selection changed', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'years'; // Includes year_histogram aggregation in response
+    el.showHistogramDatePicker = true;
+    await el.updateComplete;
+
+    const facets = el.shadowRoot?.querySelector(
+      'collection-facets'
+    ) as CollectionFacets;
+    await facets?.updateComplete;
+
+    // Wait for the date picker to be rendered (which may take until the next tick)
+    await new Promise(res => {
+      setTimeout(res, 0);
+    });
+
+    const histogram = facets?.shadowRoot?.querySelector(
+      'histogram-date-range'
+    ) as HistogramDateRange;
+    expect(histogram).to.exist;
+
+    // Enter a new min date into the date picker
+    const minDateInput = histogram.shadowRoot?.querySelector(
+      '#date-min'
+    ) as HTMLInputElement;
+
+    const pressEnterEvent = new KeyboardEvent('keyup', {
+      key: 'Enter',
+    });
+
+    minDateInput.value = '1960';
+    minDateInput.dispatchEvent(pressEnterEvent);
+
+    // Wait for the histogram's update delay
+    await new Promise(res => {
+      setTimeout(res, histogram.updateDelay + 50);
+    });
+
+    // Ensure that the histogram change propagated to the collection browser's
+    // date query correctly.
+    await el.updateComplete;
+    expect(el.dateRangeQueryClause).to.equal('year:[1960 TO 2000]');
   });
 
   it('scrolls to page', async () => {

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -1,5 +1,6 @@
 import type { Result } from '@internetarchive/result-type';
 import {
+  Aggregation,
   ItemHit,
   SearchResponse,
   SearchServiceError,
@@ -32,6 +33,51 @@ export const mockSuccessSingleResult: Result<
           },
         }),
       ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
+export const mockSuccessWithYearHistogramAggs: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'years',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'years',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      aggregations: {
+        subject: new Aggregation({
+          buckets: [
+            {
+              key: 'foo',
+              doc_count: 3,
+            },
+          ],
+        }),
+        year_histogram: new Aggregation({
+          buckets: [1, 2, 3, 3, 2, 1],
+          first_bucket_key: 1950,
+          last_bucket_key: 2000,
+          interval: 10,
+          number_buckets: 6,
+        }),
+      },
+      results: [],
     },
     responseHeader: {
       succeeded: true,

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -13,6 +13,7 @@ import {
   mockSuccessLoggedInResult,
   mockSuccessNoPreviewResult,
   mockSuccessLoggedInAndNoPreviewResult,
+  mockSuccessWithYearHistogramAggs,
 } from './mock-search-responses';
 
 export class MockSearchService implements SearchServiceInterface {
@@ -46,6 +47,8 @@ export class MockSearchService implements SearchServiceInterface {
     switch (this.searchParams?.query) {
       case 'single-result':
         return mockSuccessSingleResult;
+      case 'years':
+        return mockSuccessWithYearHistogramAggs;
       case 'loggedin':
         return mockSuccessLoggedInResult;
       case 'no-preview':


### PR DESCRIPTION
Currently a separate PPS request is sent to obtain year histogram data for the date picker, regardless of whether the date picker is present on the page.

Moreover, the request that retrieves all the other facets also includes the year histogram data, which is correct as long as there are no year facets or date range filters applied. In those cases, there is no need for a separate year histogram request. The additional request is only necessary if the user has selected a year facet or specified a date range.

This PR ensures a separate year histogram facet request is only sent if the date picker is actually enabled and there is a selected year facet or a date range filter applied. It also refactors some of the facet-query-building getters to decouple the with-date query from the without-date one since these logic fixes make the existing "build one from the other" approach a bit messy.