### PR TITLE
WEBDEV-5575 Clarify loading state and empty search data model on new search

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -778,6 +778,9 @@ export class CollectionBrowser
     this.previousQueryKey = this.pageFetchQueryKey;
 
     this.dataSource = {};
+    this.totalResults = undefined;
+    this.aggregations = undefined;
+    this.fullYearsHistogramAggregation = undefined;
     this.pageFetchesInProgress = {};
     this.endOfDataReached = false;
     this.pagesToRender = this.initialPageNumber;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -323,6 +323,9 @@ export class CollectionBrowser
   }
 
   private get collectionBrowserTemplate() {
+    const shouldShowSearching =
+      this.searchResultsLoading || this.totalResults === undefined;
+    const resultsLabel = this.totalResults === 1 ? 'Result' : 'Results';
     return html`<div
         id="left-column"
         class="column${this.isResizeToMobile ? ' preload' : ''}"
@@ -331,12 +334,12 @@ export class CollectionBrowser
           ${this.mobileView ? this.mobileFacetsTemplate : nothing}
           <div id="results-total">
             <span id="big-results-count">
-              ${this.totalResults !== undefined
-                ? this.totalResults.toLocaleString()
-                : '-'}
+              ${shouldShowSearching
+                ? html`Searching&hellip;`
+                : this.totalResults?.toLocaleString()}
             </span>
             <span id="big-results-label">
-              ${this.totalResults === 1 ? 'Result' : 'Results'}
+              ${shouldShowSearching ? nothing : resultsLabel}
             </span>
           </div>
         </div>

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -325,6 +325,7 @@ export class CollectionBrowser
   private get collectionBrowserTemplate() {
     const shouldShowSearching =
       this.searchResultsLoading || this.totalResults === undefined;
+    const resultsCount = this.totalResults?.toLocaleString();
     const resultsLabel = this.totalResults === 1 ? 'Result' : 'Results';
     return html`<div
         id="left-column"
@@ -334,9 +335,7 @@ export class CollectionBrowser
           ${this.mobileView ? this.mobileFacetsTemplate : nothing}
           <div id="results-total">
             <span id="big-results-count">
-              ${shouldShowSearching
-                ? html`Searching&hellip;`
-                : this.totalResults?.toLocaleString()}
+              ${shouldShowSearching ? html`Searching&hellip;` : resultsCount}
             </span>
             <span id="big-results-label">
               ${shouldShowSearching ? nothing : resultsLabel}

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -20,7 +20,15 @@ import { analyticsCategories } from '../src/utils/analytics-events';
 import type { TileDispatcher } from '../src/tiles/tile-dispatcher';
 import type { CollectionFacets } from '../src/collection-facets';
 
-/** Wait for the next tick of the event loop */
+/**
+ * Wait for the next tick of the event loop.
+ *
+ * This is necessary in some of the tests because certain collection browser
+ * updates take more than one tick to render (e.g., date picker & query changes).
+ * These delays are non-ideal and should eventually be investigated and fixed,
+ * but they are minor enough that waiting for the next tick is a reasonable
+ * testing solution for now.
+ */
 const nextTick = () =>
   new Promise(resolve => {
     setTimeout(resolve, 0);

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -20,6 +20,12 @@ import { analyticsCategories } from '../src/utils/analytics-events';
 import type { TileDispatcher } from '../src/tiles/tile-dispatcher';
 import type { CollectionFacets } from '../src/collection-facets';
 
+/** Wait for the next tick of the event loop */
+const nextTick = () =>
+  new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+
 describe('Collection Browser', () => {
   beforeEach(async () => {
     // Apparently query params set by one test can bleed into other tests.
@@ -199,6 +205,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
+    await nextTick();
 
     expect(searchService.searchParams?.query).to.equal('collection:foo');
     expect(
@@ -219,6 +226,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
+    await nextTick();
 
     expect(searchService.searchParams?.query).to.equal('collection:foo');
     expect(searchService.searchType).to.equal(SearchType.METADATA);
@@ -240,6 +248,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
+    await nextTick();
 
     expect(searchService.searchParams?.query).to.equal('collection:foo');
     expect(searchService.searchType).to.equal(SearchType.FULLTEXT);
@@ -840,6 +849,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'single-result';
     await el.updateComplete;
+    await nextTick();
 
     expect(
       el.shadowRoot?.querySelector('#big-results-label')?.textContent


### PR DESCRIPTION
This PR changes the "- Results" label to reflect the loading state by changing to "Searching..." when a new set of results is loading as a result of a query change. The data model (incl. results, total result count, and aggregations) is now also fully emptied as soon as a new search is performed, rather than persisting until the new search results arrive.