### PR TITLE
WEBDEV-5581 Hide fav- collections in list view tiles

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -68,8 +68,11 @@ export class TileList extends LitElement {
     const newCollectionLinks: TemplateResult[] = [];
     const promises: Promise<void>[] = [];
     for (const collection of this.model.collections) {
-      // Don't include collections that are meant to be suppressed
-      if (!suppressedCollections[collection]) {
+      // Don't include favorites or collections that are meant to be suppressed
+      if (
+        !suppressedCollections[collection] &&
+        !collection.startsWith('fav-')
+      ) {
         promises.push(
           this.collectionNameCache?.collectionNameFor(collection).then(name => {
             newCollectionLinks.push(

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -71,6 +71,26 @@ describe('List Tile', () => {
     );
   });
 
+  it('should not render fav- collections', async () => {
+    const collectionNameCache = new MockCollectionNameCache();
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${{ collections: ['fav-foo', 'bar'] }}
+        .collectionNameCache=${collectionNameCache}
+      >
+      </tile-list>
+    `);
+
+    const collectionsRow = el.shadowRoot?.getElementById('collections');
+    expect(collectionsRow).to.exist;
+
+    const collectionLinks = collectionsRow?.querySelectorAll('a[href]');
+    expect(collectionLinks?.length).to.equal(1);
+    expect(collectionLinks?.item(0).getAttribute('href')).to.equal(
+      '/details/bar'
+    );
+  });
+
   it('should render weekly views when sorting by week', async () => {
     const el = await fixture<TileList>(html`
       <tile-list


### PR DESCRIPTION
The list of collection links on tiles in extended list view should not include "user favorites" collections (`fav-<username>`). This PR ensures those collections are not rendered.