### PR TITLE
WEBDEV-5586 Add rel=nofollow links to search tile links and collection facets

### DIFF
--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -115,7 +115,7 @@ export class FacetsTemplate extends LitElement {
             const bucketTextDisplay =
               facetGroup.key !== 'collection'
                 ? html`${bucket.displayText ?? bucket.key}`
-                : html`<a href="/details/${bucket.key}">
+                : html`<a href="/details/${bucket.key}" rel="nofollow">
                     <async-collection-name
                       .collectionNameCache=${this.collectionNameCache}
                       .identifier=${bucket.key}

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -115,7 +115,7 @@ export class FacetsTemplate extends LitElement {
             const bucketTextDisplay =
               facetGroup.key !== 'collection'
                 ? html`${bucket.displayText ?? bucket.key}`
-                : html`<a href="/details/${bucket.key}" rel="nofollow">
+                : html`<a href="/details/${bucket.key}">
                     <async-collection-name
                       .collectionNameCache=${this.collectionNameCache}
                       .identifier=${bucket.key}

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -346,13 +346,14 @@ export class TileList extends LitElement {
     // No whitespace after closing tag
     // Note: single ' for href='' to wrap " in query var gets changed back by yarn format
 
-    // eslint-disable-next-line lit/no-invalid-html
+    /* eslint-disable lit/no-invalid-html */
     return html`<a
       href="${this.baseNavigationUrl}/search?query=${query}"
       rel="nofollow"
     >
       ${DOMPurify.sanitize(searchTerm)}</a
     >`;
+    /* eslint-enable lit/no-invalid-html */
   }
 
   private detailsLink(identifier: string, text?: string): TemplateResult {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -203,7 +203,7 @@ export class TileList extends LitElement {
   }
 
   private get creatorTemplate() {
-    // "Achivist since" if account
+    // "Archivist since" if account
     if (this.model?.mediatype === 'account') {
       return html`
         <div id="creator" class="metadata">

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -347,7 +347,10 @@ export class TileList extends LitElement {
     // Note: single ' for href='' to wrap " in query var gets changed back by yarn format
 
     // eslint-disable-next-line lit/no-invalid-html
-    return html`<a href="${this.baseNavigationUrl}/search?query=${query}">
+    return html`<a
+      href="${this.baseNavigationUrl}/search?query=${query}"
+      rel="nofollow"
+    >
       ${DOMPurify.sanitize(searchTerm)}</a
     >`;
   }

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -20,6 +20,21 @@ describe('List Tile', () => {
     expect(imageBlock).to.exist;
   });
 
+  it('should render the mobile template if below mobile breakpoint', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list .mobileBreakpoint=${500} .currentWidth=${400}> </tile-list>
+    `);
+
+    const listContainer = el.shadowRoot?.getElementById('list-line');
+    const topLine = el.shadowRoot?.getElementById('list-line-top');
+    const bottomLine = el.shadowRoot?.getElementById('list-line-bottom');
+
+    expect(listContainer).to.exist;
+    expect(listContainer?.classList.contains('mobile')).to.be.true;
+    expect(topLine).to.exist;
+    expect(bottomLine).to.exist;
+  });
+
   it('should render with creator element but not dates', async () => {
     const el = await fixture<TileList>(html`
       <tile-list .model=${{ creators: ['someone'] }}></tile-list>
@@ -164,5 +179,21 @@ describe('List Tile', () => {
     const descriptionBlock = el.shadowRoot?.getElementById('description');
     expect(descriptionBlock).to.exist;
     expect(descriptionBlock?.textContent?.trim()).to.equal('line1 line2'); // line break replaced by space
+  });
+
+  it('should render date added for accounts', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${{
+          mediatype: 'account',
+          dateAdded: new Date('2015-05-05T00:00:00'),
+        }}
+      >
+      </tile-list>
+    `);
+
+    const creatorBlock = el.shadowRoot?.getElementById('creator');
+    expect(creatorBlock).to.exist;
+    expect(creatorBlock?.textContent?.trim()).to.equal('Archivist since 2015');
   });
 });


### PR DESCRIPTION
Certain links on search tiles in extended list view point to new `/search` queries without `rel=nofollow`, causing crawlers to hit potentially many more search pages than desired.

Our links to collection details pages on collection facets are also not using `rel=nofollow`, which may have similar effects on crawlers.

This PR adds `rel=nofollow` to both of those types of links.
