### PR TITLE
WEBDEV-5599 Prevent item images from having undefined URLs

### DIFF
--- a/src/tiles/item-image.ts
+++ b/src/tiles/item-image.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement } from 'lit';
+import { css, CSSResultGroup, html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 
@@ -42,7 +42,10 @@ export class ItemImage extends LitElement {
    * Helpers
    */
   private get imageSrc() {
-    return `${this.baseImageUrl}/services/img/${this.model?.identifier}`;
+    // Don't try to load invalid image URLs
+    return this.baseImageUrl && this.model?.identifier
+      ? `${this.baseImageUrl}/services/img/${this.model.identifier}`
+      : nothing;
   }
 
   private get hashBasedGradient() {

--- a/test/item-image.test.ts
+++ b/test/item-image.test.ts
@@ -106,7 +106,7 @@ describe('ItemImage component', () => {
       </item-image>
     `);
 
-    // Doesn't set the image src if base url is undefined
+    // Doesn't set the image src if model is not present
     const img = el.shadowRoot?.querySelector('img');
     expect(img).to.exist;
     expect(img?.getAttribute('src')).not.to.exist;
@@ -123,7 +123,7 @@ describe('ItemImage component', () => {
       </item-image>
     `);
 
-    // Doesn't set the image src if base url is undefined
+    // Doesn't set the image src if identifier is not present
     const img = el.shadowRoot?.querySelector('img');
     expect(img).to.exist;
     expect(img?.getAttribute('src')).not.to.exist;

--- a/test/item-image.test.ts
+++ b/test/item-image.test.ts
@@ -79,4 +79,53 @@ describe('ItemImage component', () => {
       expect(imgClassName).to.eql(' waveform ');
     }, 1000);
   });
+
+  it('should not fetch image with undefined base url', async () => {
+    const el = await fixture<ItemImage>(html`
+      <item-image
+        .isListTile=${false}
+        .isCompactTile=${false}
+        .model=${testBookModel}
+      >
+      </item-image>
+    `);
+
+    // Doesn't set the image src if base url is undefined
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img).to.exist;
+    expect(img?.getAttribute('src')).not.to.exist;
+  });
+
+  it('should not fetch image with undefined model', async () => {
+    const el = await fixture<ItemImage>(html`
+      <item-image
+        .isListTile=${false}
+        .isCompactTile=${false}
+        .baseImageUrl=${baseImageUrl}
+      >
+      </item-image>
+    `);
+
+    // Doesn't set the image src if base url is undefined
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img).to.exist;
+    expect(img?.getAttribute('src')).not.to.exist;
+  });
+
+  it('should not fetch image with undefined identifier', async () => {
+    const el = await fixture<ItemImage>(html`
+      <item-image
+        .isListTile=${false}
+        .isCompactTile=${false}
+        .model=${{}}
+        .baseImageUrl=${baseImageUrl}
+      >
+      </item-image>
+    `);
+
+    // Doesn't set the image src if base url is undefined
+    const img = el.shadowRoot?.querySelector('img');
+    expect(img).to.exist;
+    expect(img?.getAttribute('src')).not.to.exist;
+  });
 });


### PR DESCRIPTION
Currently, if search result tiles are rendered before the page config has fully loaded, they may have an invalid `baseImageUrl` which they use to fetch their item image, resulting in many 404s for URLs containing `undefined`.

This PR adds a guard clause preventing these bad image requests from firing before the config (with correct `baseImageUrl`) has properly loaded.