### PR TITLE
WEBDEV-5605 Integrate search service filter map

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.2",
+    "@internetarchive/collection-name-cache": "^0.2.3-alpha.1",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.2",
+    "@internetarchive/search-service": "^0.4.3-alpha.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.3-alpha.1",
+    "@internetarchive/collection-name-cache": "^0.2.3",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.7",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.3-alpha.1",
+    "@internetarchive/search-service": "^0.4.3",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -428,7 +428,6 @@ export class AppRoot extends LitElement {
     if (!this.collectionBrowser.showHistogramDatePicker) {
       this.collectionBrowser.minSelectedDate = undefined;
       this.collectionBrowser.maxSelectedDate = undefined;
-      this.collectionBrowser.dateRangeQueryClause = undefined;
     }
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -918,7 +918,10 @@ export class CollectionBrowser
       for (const [facetName, facetValues] of Object.entries(
         this.selectedFacets
       )) {
-        const { name, values } = this.prepareFacet(facetName, facetValues);
+        const { name, values } = this.prepareFacetForFetch(
+          facetName,
+          facetValues
+        );
         for (const [value, bucket] of Object.entries(values)) {
           let constraint;
           if (bucket.state === 'selected') {
@@ -1082,10 +1085,10 @@ export class CollectionBrowser
    * @param facetName The name of the facet type (e.g., 'language')
    * @param facetValues An array of values for that facet type
    */
-  private prepareFacet(
+  private prepareFacetForFetch(
     facetName: string,
     facetValues: Record<string, FacetBucket>
-  ) {
+  ): { name: string; values: Record<string, FacetBucket> } {
     let [normalizedName, normalizedValues] = [facetName, facetValues];
 
     // The full "search engine" name of the lending field is "lending___status"
@@ -1093,7 +1096,7 @@ export class CollectionBrowser
       normalizedName = 'lending___status';
     }
 
-    // Language codes like "en-US|en-GB|en" need to be broken apart into
+    // Language codes like "en-US|en-GB|en" need to be broken apart into individual values
     if (facetName === 'language') {
       normalizedValues = {};
       for (const [facetValue, facetData] of Object.entries(facetValues)) {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -940,7 +940,7 @@ export class CollectionBrowser
 
     const filterMap = builder.build();
 
-    // TEMP: At present, the search engine incorrectly returns 0 results if
+    // TEMP: At present, the backend search engine incorrectly returns 0 results if
     // the _first_ language filter contains a space, so let's try to avoid that if possible.
     if (filterMap.language) {
       for (const [value, constraint] of Object.entries(filterMap.language)) {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1073,25 +1073,17 @@ export class CollectionBrowser
     facetName: string,
     facetValues: Record<string, FacetBucket>
   ): string {
-    const facetEntries = Object.entries(facetValues);
+    const { name: facetQueryName, values } = this.prepareFacetForFetch(
+      facetName,
+      facetValues
+    );
+    const facetEntries = Object.entries(values);
     if (facetEntries.length === 0) return '';
 
-    const facetQueryName =
-      facetName === 'lending' ? 'lending___status' : facetName;
     const facetValuesArray: string[] = [];
-
     for (const [key, facetData] of facetEntries) {
       const plusMinusPrefix = facetData.state === 'hidden' ? '-' : '';
-
-      if (facetName === 'language') {
-        const languages =
-          this.languageCodeHandler.getCodeArrayFromCodeString(key);
-        for (const language of languages) {
-          facetValuesArray.push(`${plusMinusPrefix}"${language}"`);
-        }
-      } else {
-        facetValuesArray.push(`${plusMinusPrefix}"${key}"`);
-      }
+      facetValuesArray.push(`${plusMinusPrefix}"${key}"`);
     }
 
     const valueQuery = facetValuesArray.join(` OR `);

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -558,7 +558,8 @@ export class CollectionBrowser
         .collectionNameCache=${this.collectionNameCache}
         .languageCodeHandler=${this.languageCodeHandler}
         .showHistogramDatePicker=${this.showHistogramDatePicker}
-        .fullQuery=${this.fullQuery}
+        .query=${this.filteredQuery}
+        .filterMap=${this.filterMap}
         .modalManager=${this.modalManager}
         ?collapsableFacets=${this.mobileView}
         ?facetsLoading=${this.facetDataLoading}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -937,7 +937,26 @@ export class CollectionBrowser
       }
     }
 
-    return builder.build();
+    const filterMap = builder.build();
+
+    // TEMP: At present, the search engine incorrectly returns 0 results if
+    // the _first_ language filter contains a space, so let's try to avoid that if possible.
+    if (filterMap.language) {
+      for (const [value, constraint] of Object.entries(filterMap.language)) {
+        if (value.includes(' ')) {
+          // Delete and re-add this filter to make it the last one on the parent object
+          // (Technically this isn't in the standard, but most browser impls output
+          // object keys in the order they were added.)
+          delete filterMap.language[value];
+          filterMap.language[value] = constraint;
+        } else {
+          // As soon as we reach one without a space, we're done
+          break;
+        }
+      }
+    }
+
+    return filterMap;
   }
 
   /** The base query joined with any title/creator letter filters */

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -12,6 +12,7 @@ import { map } from 'lit/directives/map.js';
 import type {
   Aggregation,
   Bucket,
+  FilterMap,
   SearchServiceInterface,
   SearchType,
 } from '@internetarchive/search-service';
@@ -72,7 +73,9 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Boolean }) showHistogramDatePicker = false;
 
-  @property({ type: String }) fullQuery?: string;
+  @property({ type: String }) query?: string;
+
+  @property({ type: Object }) filterMap?: FilterMap;
 
   @property({ type: Object, attribute: false })
   modalManager?: ModalManagerInterface;
@@ -491,7 +494,8 @@ export class CollectionFacets extends LitElement {
         .analyticsHandler=${this.analyticsHandler}
         .facetKey=${facetGroup.key}
         .facetAggregationKey=${facetAggrKey}
-        .fullQuery=${this.fullQuery}
+        .query=${this.query}
+        .filterMap=${this.filterMap}
         .modalManager=${this.modalManager}
         .searchService=${this.searchService}
         .searchType=${this.searchType}

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -17,6 +17,7 @@ import {
   SearchParams,
   SearchType,
   AggregationSortType,
+  FilterMap,
 } from '@internetarchive/search-service';
 import type { CollectionNameCacheInterface } from '@internetarchive/collection-name-cache';
 import type { ModalManagerInterface } from '@internetarchive/modal-manager';
@@ -44,7 +45,9 @@ export class MoreFacetsContent extends LitElement {
 
   @property({ type: String }) facetAggregationKey?: FacetOption;
 
-  @property({ type: String }) fullQuery?: string;
+  @property({ type: String }) query?: string;
+
+  @property({ type: Object }) filterMap?: FilterMap;
 
   @property({ type: Object }) modalManager?: ModalManagerInterface;
 
@@ -127,7 +130,8 @@ export class MoreFacetsContent extends LitElement {
     const aggregationsSize = 65535; // todo - do we want to have all the records at once?
 
     const params: SearchParams = {
-      query: this.fullQuery as string,
+      query: this.query as string,
+      filters: this.filterMap,
       aggregations,
       aggregationsSize,
       rows: 0, // todo - do we want server-side pagination with offset/page/limit flag?

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -25,7 +25,6 @@ export interface RestorationState {
   selectedFacets: SelectedFacets;
   baseQuery?: string;
   currentPage?: number;
-  dateRangeQueryClause?: string;
   titleQuery?: string;
   creatorQuery?: string;
   minSelectedDate?: string;
@@ -142,8 +141,11 @@ export class RestorationStateHandler
       }
     }
 
-    if (state.dateRangeQueryClause) {
-      searchParams.append('and[]', state.dateRangeQueryClause);
+    if (state.minSelectedDate && state.maxSelectedDate) {
+      searchParams.append(
+        'and[]',
+        `year:[${state.minSelectedDate} TO ${state.maxSelectedDate}]`
+      );
     }
     if (state.titleQuery) {
       searchParams.append('and[]', state.titleQuery);
@@ -159,7 +161,8 @@ export class RestorationStateHandler
         page: state.currentPage,
         and: state.selectedFacets,
         not: state.selectedFacets,
-        dateRange: state.dateRangeQueryClause,
+        minDate: state.minSelectedDate,
+        maxDate: state.maxSelectedDate,
       },
       '',
       url
@@ -244,7 +247,6 @@ export class RestorationStateHandler
                 0,
                 maxDate.length - 1
               );
-              restorationState.dateRangeQueryClause = `year:${value}`;
             } else {
               this.setSelectedFacetState(
                 restorationState.selectedFacets,

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -761,6 +761,8 @@ describe('Collection Browser', () => {
     el.baseQuery = 'first-creator';
     el.selectedSort = 'creator' as SortField;
     el.selectedFacets = selectedFacets;
+    el.minSelectedDate = '1950';
+    el.maxSelectedDate = '1970';
     el.dateRangeQueryClause = 'year:[1950 TO 1970]';
     el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'X';
@@ -772,8 +774,17 @@ describe('Collection Browser', () => {
     });
 
     expect(searchService.searchParams?.query).to.equal(
-      'first-creator AND (collection:("foo")) AND year:[1950 TO 1970] AND firstCreator:X'
+      'first-creator AND firstCreator:X'
     );
+    expect(searchService.searchParams?.filters).to.deep.equal({
+      collection: {
+        foo: 'inc',
+      },
+      year: {
+        '1950': 'gte',
+        '1970': 'lte',
+      },
+    });
   });
 
   it('sets date range query when date picker selection changed', async () => {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -364,7 +364,8 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     el.showHistogramDatePicker = true;
-    el.dateRangeQueryClause = 'year:[1995 TO 2005]';
+    el.minSelectedDate = '1995';
+    el.maxSelectedDate = '2005';
     await el.updateComplete;
 
     expect(
@@ -402,7 +403,8 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     el.showHistogramDatePicker = false;
-    el.dateRangeQueryClause = 'year:[1995 TO 2005]';
+    el.minSelectedDate = '1995';
+    el.maxSelectedDate = '2005';
     await el.updateComplete;
 
     expect(searchService.searchParams?.aggregations?.simpleParams).to.satisfy(
@@ -763,7 +765,6 @@ describe('Collection Browser', () => {
     el.selectedFacets = selectedFacets;
     el.minSelectedDate = '1950';
     el.maxSelectedDate = '1970';
-    el.dateRangeQueryClause = 'year:[1950 TO 1970]';
     el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
@@ -833,7 +834,8 @@ describe('Collection Browser', () => {
     // Ensure that the histogram change propagated to the collection browser's
     // date query correctly.
     await el.updateComplete;
-    expect(el.dateRangeQueryClause).to.equal('year:[1960 TO 2000]');
+    expect(el.minSelectedDate).to.equal('1960');
+    expect(el.maxSelectedDate).to.equal('2000');
   });
 
   it('scrolls to page', async () => {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -306,9 +306,16 @@ describe('Collection Browser', () => {
     el.selectedFacets = selectedFacets;
     await el.updateComplete;
 
-    expect(searchService.searchParams?.query).to.equal(
-      'collection:foo AND (subject:("foo" OR -"bar") AND language:("en"))'
-    );
+    expect(searchService.searchParams?.query).to.equal('collection:foo');
+    expect(searchService.searchParams?.filters).to.deep.equal({
+      subject: {
+        foo: 'inc',
+        bar: 'exc',
+      },
+      language: {
+        en: 'inc',
+      },
+    });
   });
 
   it('fires a separate date histogram query when year facets are applied', async () => {

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -80,7 +80,7 @@ describe('More facets content', () => {
     );
 
     el.facetKey = 'collection';
-    el.fullQuery = 'title:hello';
+    el.query = 'title:hello';
     await el.updateComplete;
 
     expect(searchService.searchParams?.query).to.equal('title:hello');
@@ -97,7 +97,7 @@ describe('More facets content', () => {
     );
 
     el.facetKey = 'collection';
-    el.fullQuery = 'title:hello';
+    el.query = 'title:hello';
     await el.updateComplete;
 
     expect(searchService.searchParams?.query).to.equal('title:hello');

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -59,9 +59,6 @@ describe('Restoration state handler', () => {
     const restorationState = handler.getRestorationState();
     expect(restorationState.minSelectedDate).to.equal('2018');
     expect(restorationState.maxSelectedDate).to.equal('2021');
-    expect(restorationState.dateRangeQueryClause).to.equal(
-      'year:"2018 TO 2021"'
-    );
   });
 
   it('should restore creator filter from URL', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.3-alpha.1":
-  version "0.2.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.3-alpha.1.tgz#0665f2f8a26faba9fb64ec0a1c37ac5c132e565c"
-  integrity sha512-3PA/dCVCEBaPbYzEhq4nqBBku197YCESYrSwaPGyj51DmlctzJ3IMrwW6EOCI4VYmsj/uQ6SFubEtVRytgVklg==
+"@internetarchive/collection-name-cache@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.3.tgz#020337e6c5840691d3bf82323060282bc4464195"
+  integrity sha512-CDfMqz4oh3f2BrvnyqD2Y9Y4sOs3fY3F5jI4xMyrdg/z3U0CRYpIQ8NSJFxbJ4EtNvaemlCbrRu5QLHdDYWZLg==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.3-alpha.1"
+    "@internetarchive/search-service" "^0.4.3"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.3-alpha.1":
-  version "0.4.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.3-alpha.1.tgz#258b2c1022eff677710effc95b7d4f14a9f39a70"
-  integrity sha512-a3uVraAO0NYE+uqnF1u4UDmUr1QOB3sTKXgUaAUhicxu9J8NcjMYKu7/lIT/tL5fc7KoBymDx0aisBFwTjL9Ig==
+"@internetarchive/search-service@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.3.tgz#0cc8752db5bd76a0a316addac160c6605d76a7e0"
+  integrity sha512-ANL8MdiZtw+0+tFvlHK96cRRceswH8aPZGdDNBVhlT3sYZsmF7tz41nkBBSxj4pzd/vAA05AQsgMWODCwSnUAQ==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.2.tgz#31e342d2d271b1c737122ca2de22adb3ac67c45c"
-  integrity sha512-v32uBVH69Nod9M+MjQGDsQ5UPmIN+ds4EB9guN2WfwXbVNyZ8B7BKtZLitIq71KMeNik2vvt+eqeg6SNqJC5cg==
+"@internetarchive/collection-name-cache@^0.2.3-alpha.1":
+  version "0.2.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.3-alpha.1.tgz#0665f2f8a26faba9fb64ec0a1c37ac5c132e565c"
+  integrity sha512-3PA/dCVCEBaPbYzEhq4nqBBku197YCESYrSwaPGyj51DmlctzJ3IMrwW6EOCI4VYmsj/uQ6SFubEtVRytgVklg==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.2"
+    "@internetarchive/search-service" "^0.4.3-alpha.1"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.2.tgz#caf9fdd05b6cc540993baa41981434f259699f78"
-  integrity sha512-/ybeQuXRLbhRRgB1U4VIzUBUEKRvWYCcwxSNWrlVF2tuxlcllH3Z+AAaCfWcKma2GL1Lvlq9/2JV8Us1w8PoAw==
+"@internetarchive/search-service@^0.4.3-alpha.1":
+  version "0.4.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.3-alpha.1.tgz#258b2c1022eff677710effc95b7d4f14a9f39a70"
+  integrity sha512-a3uVraAO0NYE+uqnF1u4UDmUr1QOB3sTKXgUaAUhicxu9J8NcjMYKu7/lIT/tL5fc7KoBymDx0aisBFwTjL9Ig==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
The PPS has a `filter_map` param for accepting facets and date picker ranges in a more structured way than jamming them all into the query string (which is what is currently done). The search service has recently been updated to handle this parameter.

This is an important prerequisite for having “correct” facet handling at the PPS level (i.e., omitting each facet group’s filters from its own facet queries).

This PR updates collection-browser's handling of facets and date ranges to rely on filter maps rather than joining all the query clauses itself.