### PR TITLE
WEBDEV-5561 Disable/gray-out letters with 0 results in alphabet filter bar

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -319,6 +319,7 @@ export class AppRoot extends LitElement {
 
   private baseQueryChanged(e: CustomEvent<{ baseQuery?: string }>): void {
     this.searchQuery = e.detail.baseQuery;
+    this.collectionBrowser.clearFilters();
   }
 
   /** Handler for search type changes coming from collection browser */

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -664,7 +664,7 @@ export class CollectionBrowser
       changed.has('dateRangeQueryClause') ||
       changed.has('selectedFacets')
     ) {
-      this.clearLetterCounts();
+      this.refreshLetterCounts();
     }
     if (changed.has('selectedSort') || changed.has('sortDirection')) {
       const prevSortDirection = changed.get('sortDirection') as SortDirection;
@@ -1402,12 +1402,21 @@ export class CollectionBrowser
   }
 
   /**
-   * Sets both the title and creator letter counts to undefined.
-   * Call this whenever they are invalidated (e.g., the query changed).
+   * Clears the cached letter counts for both title and creator, and
+   * fetches a new set of counts for whichever of them is the currently
+   * selected sort option (which may be neither).
+   *
+   * Call this whenever the counts are invalidated (e.g., by a query change).
    */
-  private clearLetterCounts(): void {
+  private refreshLetterCounts(): void {
     this.titleLetterCounts = undefined;
     this.creatorLetterCounts = undefined;
+
+    if (this.selectedSort === 'title') {
+      this.fetchTitleLetterCounts();
+    } else if (this.selectedSort === 'creator') {
+      this.fetchCreatorLetterCounts();
+    }
   }
 
   /*

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -181,10 +181,9 @@ export class CollectionBrowser
 
   @state() private placeholderType: PlaceholderType = null;
 
-  @state() private prefixFilterCountMap: Record<
-    PrefixFilterType,
-    PrefixFilterCounts
-  > = { title: {}, creator: {} };
+  @state() private prefixFilterCountMap: Partial<
+    Record<PrefixFilterType, PrefixFilterCounts>
+  > = {};
 
   @query('#content-container') private contentContainer!: HTMLDivElement;
 
@@ -1419,7 +1418,7 @@ export class CollectionBrowser
    * Call this whenever the counts are invalidated (e.g., by a query change).
    */
   private refreshLetterCounts(): void {
-    this.prefixFilterCountMap = { title: {}, creator: {} };
+    this.prefixFilterCountMap = {};
     this.updatePrefixFiltersForCurrentSort();
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -907,6 +907,22 @@ export class CollectionBrowser
     return fullQuery;
   }
 
+  /** The full query without any title/creator letter filters */
+  private get fullQueryWithoutAlphaFilters(): string | undefined {
+    if (!this.baseQuery) return undefined;
+    let fullQuery = this.baseQuery;
+
+    const { facetQuery, dateRangeQueryClause } = this;
+
+    if (facetQuery) {
+      fullQuery += ` AND ${facetQuery}`;
+    }
+    if (dateRangeQueryClause) {
+      fullQuery += ` AND ${dateRangeQueryClause}`;
+    }
+    return fullQuery;
+  }
+
   /** The full query without any year facets or date range clauses */
   private get fullQueryWithoutDates(): string | undefined {
     if (!this.baseQuery) return undefined;
@@ -1344,10 +1360,10 @@ export class CollectionBrowser
   private async fetchLetterBuckets(
     type: 'firstTitle' | 'firstCreator'
   ): Promise<Bucket[]> {
-    if (!this.fullQuery) return [];
+    if (!this.fullQueryWithoutAlphaFilters) return [];
 
     const params: SearchParams = {
-      query: this.fullQuery,
+      query: this.fullQueryWithoutAlphaFilters,
       rows: 0,
       // Only fetch the firstTitle or firstCreator aggregation
       aggregations: { simpleParams: [type] },

--- a/src/models.ts
+++ b/src/models.ts
@@ -123,7 +123,7 @@ export const MetadataFieldToSortField: {
 export type PrefixFilterType = 'title' | 'creator';
 
 /** A map from prefixes (e.g., initial letters) to the number of items matching that prefix */
-export type PrefixFilterCountMap = Record<string, number>;
+export type PrefixFilterCounts = Record<string, number>;
 
 /**
  * A map from prefix filter types to the corresponding aggregation keys

--- a/src/models.ts
+++ b/src/models.ts
@@ -119,6 +119,21 @@ export const MetadataFieldToSortField: {
   creatorSorter: SortField.creator,
 };
 
+/** A union of the fields that permit prefix filtering (e.g., alphabetical filtering) */
+export type PrefixFilterType = 'title' | 'creator';
+
+/** A map from prefixes (e.g., initial letters) to the number of items matching that prefix */
+export type PrefixFilterCountMap = Record<string, number>;
+
+/**
+ * A map from prefix filter types to the corresponding aggregation keys
+ * that are needed to fetch the filter counts from the backend.
+ */
+export const prefixFilterAggregationKeys: Record<PrefixFilterType, string> = {
+  title: 'firstTitle',
+  creator: 'firstCreator',
+};
+
 export type FacetOption =
   | 'subject'
   | 'lending'

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -1,11 +1,12 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import type { PrefixFilterCounts } from '../models';
 
 @customElement('alpha-bar')
 export class AlphaBar extends LitElement {
   @property({ type: String }) selectedLetter: string | null = null;
 
-  @property({ type: Object }) letterCounts?: Record<string, number>;
+  @property({ type: Object }) letterCounts?: PrefixFilterCounts;
 
   private get selectedUppercaseLetter(): string | undefined {
     return this.selectedLetter?.toUpperCase();

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -5,6 +5,8 @@ import { customElement, property } from 'lit/decorators.js';
 export class AlphaBar extends LitElement {
   @property({ type: String }) selectedLetter: string | null = null;
 
+  @property({ type: Object }) letterCounts?: Record<string, number>;
+
   private get selectedUppercaseLetter(): string | undefined {
     return this.selectedLetter?.toUpperCase();
   }
@@ -21,20 +23,28 @@ export class AlphaBar extends LitElement {
                     ? 'selected'
                     : ''}
                 >
-                  <a
-                    href="#"
-                    @click=${(e: Event) => {
-                      e.preventDefault();
-                      this.letterClicked(letter);
-                    }}
-                  >
-                    ${letter}
-                  </a>
+                  ${this.letterCounts?.[letter]
+                    ? this.letterLinkTemplate(letter)
+                    : html`<span>${letter}</span>`}
                 </li>
               `
           )}
         </ul>
       </div>
+    `;
+  }
+
+  private letterLinkTemplate(letter: string) {
+    return html`
+      <a
+        href="#"
+        @click=${(e: Event) => {
+          e.preventDefault();
+          this.letterClicked(letter);
+        }}
+      >
+        ${letter}
+      </a>
     `;
   }
 
@@ -81,6 +91,12 @@ export class AlphaBar extends LitElement {
     a {
       color: #333;
       text-decoration: none;
+      padding: 0.5rem 0;
+      display: block;
+    }
+
+    span {
+      color: #aaa;
       padding: 0.5rem 0;
       display: block;
     }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -13,6 +13,8 @@ import type {
 } from '@internetarchive/shared-resize-observer';
 import {
   CollectionDisplayMode,
+  PrefixFilterCounts,
+  PrefixFilterType,
   SortField,
   SortFieldDisplayName,
 } from '../models';
@@ -42,9 +44,10 @@ export class SortFilterBar
 
   @property({ type: Boolean }) showRelevance: boolean = true;
 
-  @property({ type: Object }) titleLetterCounts?: Record<string, number>;
-
-  @property({ type: Object }) creatorLetterCounts?: Record<string, number>;
+  @property({ type: Object }) prefixFilterCountMap?: Record<
+    PrefixFilterType,
+    PrefixFilterCounts
+  >;
 
   @property({ type: Object }) resizeObserver?: SharedResizeObserverInterface;
 
@@ -567,7 +570,7 @@ export class SortFilterBar
   private get titleSelectorBar() {
     return html` <alpha-bar
       .selectedLetter=${this.selectedTitleFilter}
-      .letterCounts=${this.titleLetterCounts}
+      .letterCounts=${this.prefixFilterCountMap?.title}
       @letterChanged=${this.titleLetterChanged}
     ></alpha-bar>`;
   }
@@ -575,7 +578,7 @@ export class SortFilterBar
   private get creatorSelectorBar() {
     return html` <alpha-bar
       .selectedLetter=${this.selectedCreatorFilter}
-      .letterCounts=${this.creatorLetterCounts}
+      .letterCounts=${this.prefixFilterCountMap?.creator}
       @letterChanged=${this.creatorLetterChanged}
     ></alpha-bar>`;
   }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -42,6 +42,10 @@ export class SortFilterBar
 
   @property({ type: Boolean }) showRelevance: boolean = true;
 
+  @property({ type: Object }) titleLetterCounts?: Record<string, number>;
+
+  @property({ type: Object }) creatorLetterCounts?: Record<string, number>;
+
   @property({ type: Object }) resizeObserver?: SharedResizeObserverInterface;
 
   @state() alphaSelectorVisible: AlphaSelector | null = null;
@@ -563,6 +567,7 @@ export class SortFilterBar
   private get titleSelectorBar() {
     return html` <alpha-bar
       .selectedLetter=${this.selectedTitleFilter}
+      .letterCounts=${this.titleLetterCounts}
       @letterChanged=${this.titleLetterChanged}
     ></alpha-bar>`;
   }
@@ -570,6 +575,7 @@ export class SortFilterBar
   private get creatorSelectorBar() {
     return html` <alpha-bar
       .selectedLetter=${this.selectedCreatorFilter}
+      .letterCounts=${this.creatorLetterCounts}
       @letterChanged=${this.creatorLetterChanged}
     ></alpha-bar>`;
   }

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -61,6 +61,8 @@ describe('Collection Browser', () => {
     );
 
     el.searchContext = 'betaSearchService';
+    el.selectedSort = 'creator' as SortField;
+    el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'A';
     await el.updateComplete;
 
@@ -86,6 +88,7 @@ describe('Collection Browser', () => {
 
     el.searchContext = 'beta-search-service';
     el.selectedSort = 'title' as SortField;
+    el.sortDirection = 'asc';
     el.selectedTitleFilter = 'A';
     await el.updateComplete;
 
@@ -675,7 +678,9 @@ describe('Collection Browser', () => {
       </collection-browser>`
     );
 
-    el.baseQuery = 'collection:foo';
+    el.baseQuery = 'first-title';
+    el.selectedSort = 'title' as SortField;
+    el.sortDirection = 'asc';
     el.selectedTitleFilter = 'X';
     await el.updateComplete;
 
@@ -685,7 +690,7 @@ describe('Collection Browser', () => {
     });
 
     expect(searchService.searchParams?.query).to.equal(
-      'collection:foo AND firstTitle:X'
+      'first-title AND firstTitle:X'
     );
   });
 
@@ -696,7 +701,9 @@ describe('Collection Browser', () => {
       </collection-browser>`
     );
 
-    el.baseQuery = 'collection:foo';
+    el.baseQuery = 'first-creator';
+    el.selectedSort = 'creator' as SortField;
+    el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
 
@@ -706,7 +713,7 @@ describe('Collection Browser', () => {
     });
 
     expect(searchService.searchParams?.query).to.equal(
-      'collection:foo AND firstCreator:X'
+      'first-creator AND firstCreator:X'
     );
   });
 

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -717,6 +717,41 @@ describe('Collection Browser', () => {
     );
   });
 
+  it('sets sort filter properties simultaneous with facets and date range', async () => {
+    const searchService = new MockSearchService();
+    const selectedFacets: SelectedFacets = {
+      collection: { foo: { key: 'foo', state: 'selected', count: 1 } },
+      creator: {},
+      language: {},
+      lending: {},
+      mediatype: {},
+      subject: {},
+      year: {},
+    };
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'first-creator';
+    el.selectedSort = 'creator' as SortField;
+    el.selectedFacets = selectedFacets;
+    el.dateRangeQueryClause = 'year:[1950 TO 1970]';
+    el.sortDirection = 'asc';
+    el.selectedCreatorFilter = 'X';
+    await el.updateComplete;
+
+    // Wait an extra tick
+    await new Promise(res => {
+      setTimeout(res, 0);
+    });
+
+    expect(searchService.searchParams?.query).to.equal(
+      'first-creator AND (collection:("foo")) AND year:[1950 TO 1970] AND firstCreator:X'
+    );
+  });
+
   it('sets date range query when date picker selection changed', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -193,6 +193,84 @@ export const mockSuccessLoggedInAndNoPreviewResult: Result<
   },
 };
 
+export const mockSuccessFirstTitleResult: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'first-title',
+        sort: ['title', 'asc'],
+      },
+      finalizedParameters: {
+        user_query: 'first-title',
+        sort: ['title', 'asc'],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      aggregations: {
+        firstTitle: new Aggregation({
+          buckets: [{ key: 'X', doc_count: 1 }],
+        }),
+      },
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
+export const mockSuccessFirstCreatorResult: Result<
+  SearchResponse,
+  SearchServiceError
+> = {
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'first-creator',
+        sort: ['creator', 'asc'],
+      },
+      finalizedParameters: {
+        user_query: 'first-creator',
+        sort: ['creator', 'asc'],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      aggregations: {
+        firstCreator: new Aggregation({
+          buckets: [{ key: 'X', doc_count: 1 }],
+        }),
+      },
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+};
+
 export const getMockSuccessSingleResultWithSort: (
   resultsSpy: Function
 ) => Result<SearchResponse, SearchServiceError> = (resultsSpy: Function) => ({

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -15,6 +15,8 @@ import {
   mockSuccessLoggedInAndNoPreviewResult,
   mockSuccessWithYearHistogramAggs,
   mockSuccessMultiLineDescription,
+  mockSuccessFirstTitleResult,
+  mockSuccessFirstCreatorResult,
 } from './mock-search-responses';
 
 export class MockSearchService implements SearchServiceInterface {
@@ -58,6 +60,10 @@ export class MockSearchService implements SearchServiceInterface {
         return mockSuccessNoPreviewResult;
       case 'loggedin-no-preview':
         return mockSuccessLoggedInAndNoPreviewResult;
+      case 'first-title':
+        return mockSuccessFirstTitleResult;
+      case 'first-creator':
+        return mockSuccessFirstCreatorResult;
       case 'with-sort':
         return getMockSuccessSingleResultWithSort(this.resultsSpy);
       default:

--- a/test/sort-filter-bar/alpha-bar.test.ts
+++ b/test/sort-filter-bar/alpha-bar.test.ts
@@ -1,0 +1,52 @@
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { AlphaBar } from '../../src/sort-filter-bar/alpha-bar';
+
+import '../../src/sort-filter-bar/alpha-bar';
+
+describe('Alphabetical Filter Bar', () => {
+  it('renders component', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+
+    // Should have all the letters
+    const letters = el.shadowRoot?.querySelectorAll('li');
+    expect(letters?.length).to.equal(26);
+  });
+
+  it('renders letters with items as links', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+
+    el.letterCounts = { U: 10, X: 10 };
+    await el.updateComplete;
+
+    // Should have exactly two letter links
+    const letterLinks = el.shadowRoot?.querySelectorAll('li > a[href]');
+    expect(letterLinks?.length).to.equal(2);
+    expect(letterLinks?.item(0).textContent?.trim()).to.equal('U');
+    expect(letterLinks?.item(1).textContent?.trim()).to.equal('X');
+  });
+
+  it('renders letters without items as uninteractive text', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+
+    el.letterCounts = { U: 10, X: 10 };
+    await el.updateComplete;
+
+    // All but the two letters above should just be inert spans, not links
+    const letterNonLinks = el.shadowRoot?.querySelectorAll('li > span');
+    expect(letterNonLinks?.length).to.equal(24);
+    expect(letterNonLinks?.item(0).textContent?.trim()).to.equal('A');
+    expect(letterNonLinks?.item(23).textContent?.trim()).to.equal('Z');
+  });
+
+  it('renders the selected letter with the "selected" class', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+
+    el.selectedLetter = 'B';
+    await el.updateComplete;
+
+    const selectedLetter = el.shadowRoot?.querySelector('li.selected');
+    expect(selectedLetter).to.exist;
+    expect(selectedLetter?.textContent?.trim()).to.equal('B');
+  });
+});

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -193,7 +193,7 @@ describe('Sort/filter bar letter behavior', () => {
     `);
 
     el.selectedSort = 'title' as SortField;
-    el.titleLetterCounts = { T: 1 };
+    el.prefixFilterCountMap = { title: { T: 1 }, creator: {} };
     await el.updateComplete;
 
     const alphaBar = el.shadowRoot?.querySelector('alpha-bar');
@@ -214,7 +214,7 @@ describe('Sort/filter bar letter behavior', () => {
     `);
 
     el.selectedSort = 'creator' as SortField;
-    el.creatorLetterCounts = { C: 1 };
+    el.prefixFilterCountMap = { title: {}, creator: { C: 1 } };
     await el.updateComplete;
 
     const alphaBar = el.shadowRoot?.querySelector('alpha-bar');

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -185,3 +185,47 @@ describe('Display mode/style buttons', () => {
     expect(displayModeTitle).to.equal('Tile view');
   });
 });
+
+describe('Sort/filter bar letter behavior', () => {
+  it('sets the selected title letter when clicked', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    el.selectedSort = 'title' as SortField;
+    el.titleLetterCounts = { T: 1 };
+    await el.updateComplete;
+
+    const alphaBar = el.shadowRoot?.querySelector('alpha-bar');
+    const letterLink = alphaBar?.shadowRoot?.querySelector(
+      'li > a[href]'
+    ) as HTMLAnchorElement;
+    expect(letterLink?.textContent?.trim()).to.equal('T');
+
+    letterLink?.click();
+    await el.updateComplete;
+
+    expect(el.selectedTitleFilter).to.equal('T');
+  });
+
+  it('sets the selected creator letter when clicked', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    el.selectedSort = 'creator' as SortField;
+    el.creatorLetterCounts = { C: 1 };
+    await el.updateComplete;
+
+    const alphaBar = el.shadowRoot?.querySelector('alpha-bar');
+    const letterLink = alphaBar?.shadowRoot?.querySelector(
+      'li > a[href]'
+    ) as HTMLAnchorElement;
+    expect(letterLink?.textContent?.trim()).to.equal('C');
+
+    letterLink?.click();
+    await el.updateComplete;
+
+    expect(el.selectedCreatorFilter).to.equal('C');
+  });
+});


### PR DESCRIPTION
On the legacy search page, when the alphabet filter bar is shown, letters which correspond to 0 items are grayed out and unclickable. This PR adds that functionality to the collection browser.