### PR TITLE
WEBDEV-5620 Fix page fetch race condition that sometimes causes tiles not to load

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1211,10 +1211,19 @@ export class CollectionBrowser
       this.preloadCollectionNames(results);
       this.updateDataSource(pageNumber, results);
     }
-    if (results.length < this.pageSize) {
+
+    // When we reach the end of the data, we can't always immediately cap off the
+    // tile count, because there may be previous pages that haven't finished loading
+    // yet. So we flag the end of the data, but let the final page load set the count.
+    // This avoids race conditions dependent on the order pages arrive in.
+    if (results.length < this.pageSize || this.endOfDataReached) {
       this.endOfDataReached = true;
-      // this updates the infinite scroller to show the actual size
-      if (this.infiniteScroller) {
+      // This updates the infinite scroller to show the actual size
+      // (provided there are no other pages still being fetched)
+      if (
+        this.infiniteScroller &&
+        Object.keys(this.pageFetchesInProgress).length === 1 // This must be the last page fetch
+      ) {
         this.infiniteScroller.itemCount = this.actualTileCount;
       }
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1212,20 +1212,12 @@ export class CollectionBrowser
       this.updateDataSource(pageNumber, results);
     }
 
-    // When we reach the end of the data, we can't always immediately cap off the
-    // tile count, because there may be previous pages that haven't finished loading
-    // yet. So we flag the end of the data, but let the final page load set the count.
-    // This avoids race conditions dependent on the order pages arrive in.
-    if (results.length < this.pageSize || this.endOfDataReached) {
+    // When we reach the end of the data, we can set the infinite scroller's
+    // item count to the real total number of results (rather than the
+    // temporary estimates based on pages rendered so far).
+    if (results.length < this.pageSize) {
       this.endOfDataReached = true;
-      // This updates the infinite scroller to show the actual size
-      // (provided there are no other pages still being fetched)
-      if (
-        this.infiniteScroller &&
-        Object.keys(this.pageFetchesInProgress).length === 1 // This must be the last page fetch
-      ) {
-        this.infiniteScroller.itemCount = this.actualTileCount;
-      }
+      this.infiniteScroller.itemCount = this.totalResults;
     }
     this.pageFetchesInProgress[pageFetchQueryKey]?.delete(pageNumber);
     this.searchResultsLoading = false;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1394,8 +1394,10 @@ export class CollectionBrowser
    * increase the number of pages to render and start fetching data for the new page
    */
   private scrollThresholdReached() {
-    this.pagesToRender += 1;
-    this.fetchPage(this.pagesToRender);
+    if (!this.endOfDataReached) {
+      this.pagesToRender += 1;
+      this.fetchPage(this.pagesToRender);
+    }
   }
 
   static styles = css`


### PR DESCRIPTION
The page fetch logic currently assumes that when the last page of results loads in, it must represent the final page fetch. So it caps off the infinite scroller’s tile count with whatever count it currently has.

However, if the last couple of pages load out-of-order (e.g., page N arrives before page N-1), then this prematurely limits the number of items shown (page N-1 never shows up in the UI).

This is particularly problematic on [searches that have just over 50 items](https://internetarchive.github.io/iaux-collection-browser/main/?query=pro+archia+poeta) – if the second page of items arrives before the first, then only a few items will ever be shown, completely ignoring the first 50.

This PR addresses the issue by ensuring that the infinite scroller's item count is not capped off until all pending page fetches resolve.