### PR TITLE
WEBDEV-5654 Ensure uses of infiniteScroller are properly null-guarded

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -262,7 +262,7 @@ export class CollectionBrowser
   private dataSource: Record<string, TileModel[]> = {};
 
   @query('infinite-scroller')
-  private infiniteScroller!: InfiniteScroller;
+  private infiniteScroller?: InfiniteScroller;
 
   /**
    * Go to the given page of results
@@ -1142,14 +1142,14 @@ export class CollectionBrowser
     // then scrolls to the cell
     setTimeout(() => {
       this.isScrollingToCell = true;
-      this.infiniteScroller.scrollToCell(cellIndexToScrollTo, true);
+      this.infiniteScroller?.scrollToCell(cellIndexToScrollTo, true);
       // This timeout is to give the scroll animation time to finish
       // then updating the infinite scroller once we're done scrolling
       // There's no scroll animation completion callback so we're
       // giving it 0.5s to finish.
       setTimeout(() => {
         this.isScrollingToCell = false;
-        this.infiniteScroller.reload();
+        this.infiniteScroller?.reload();
       }, 500);
     }, 0);
   }
@@ -1248,7 +1248,9 @@ export class CollectionBrowser
     // temporary estimates based on pages rendered so far).
     if (results.length < this.pageSize) {
       this.endOfDataReached = true;
-      this.infiniteScroller.itemCount = this.totalResults;
+      if (this.infiniteScroller) {
+        this.infiniteScroller.itemCount = this.totalResults;
+      }
     }
     this.pageFetchesInProgress[pageFetchQueryKey]?.delete(pageNumber);
     this.searchResultsLoading = false;
@@ -1350,7 +1352,7 @@ export class CollectionBrowser
     const visiblePages = this.currentVisiblePageNumbers;
     const needsReload = visiblePages.includes(pageNumber);
     if (needsReload) {
-      this.infiniteScroller.reload();
+      this.infiniteScroller?.reload();
     }
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -8,7 +8,7 @@ import {
   nothing,
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
 import type {
@@ -262,7 +262,7 @@ export class CollectionBrowser
   private dataSource: Record<string, TileModel[]> = {};
 
   @query('infinite-scroller')
-  private infiniteScroller?: InfiniteScroller;
+  private infiniteScroller!: InfiniteScroller;
 
   /**
    * Go to the given page of results
@@ -328,6 +328,7 @@ export class CollectionBrowser
         .placeholderType=${this.placeholderType}
         ?isMobileView=${this.mobileView}
       ></empty-placeholder>
+      ${this.infiniteScrollerTemplate}
     `;
   }
 
@@ -371,12 +372,20 @@ export class CollectionBrowser
 
   private get infiniteScrollerTemplate() {
     return html`<infinite-scroller
-      class="${ifDefined(this.displayMode)}"
+      class=${this.infiniteScrollerClasses}
+      itemCount=${this.placeholderType ? 0 : nothing}
       .cellProvider=${this}
       .placeholderCellTemplate=${this.placeholderCellTemplate}
       @scrollThresholdReached=${this.scrollThresholdReached}
       @visibleCellsChanged=${this.visibleCellsChanged}
     ></infinite-scroller>`;
+  }
+
+  private get infiniteScrollerClasses() {
+    return classMap({
+      [this.displayMode ?? '']: !!this.displayMode,
+      hidden: !!this.placeholderType,
+    });
   }
 
   private get sortFilterBarTemplate() {
@@ -1693,6 +1702,10 @@ export class CollectionBrowser
         18rem
       );
       --infiniteScrollerCellMaxWidth: var(--collectionBrowserCellMaxWidth, 1fr);
+    }
+
+    infinite-scroller.hidden {
+      display: none;
     }
   `;
 }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -272,7 +272,7 @@ export class CollectionBrowser
   goToPage(pageNumber: number) {
     this.initialPageNumber = pageNumber;
     this.pagesToRender = pageNumber;
-    this.scrollToPage(pageNumber);
+    return this.scrollToPage(pageNumber);
   }
 
   clearFilters() {
@@ -1136,22 +1136,25 @@ export class CollectionBrowser
       results?.success?.response?.aggregations?.['year-histogram']; // Temp fix until PPS FTS key is fixed to use underscore
   }
 
-  private scrollToPage(pageNumber: number) {
-    const cellIndexToScrollTo = this.pageSize * (pageNumber - 1);
-    // without this setTimeout, Safari just pauses until the `fetchPage` is complete
-    // then scrolls to the cell
-    setTimeout(() => {
-      this.isScrollingToCell = true;
-      this.infiniteScroller?.scrollToCell(cellIndexToScrollTo, true);
-      // This timeout is to give the scroll animation time to finish
-      // then updating the infinite scroller once we're done scrolling
-      // There's no scroll animation completion callback so we're
-      // giving it 0.5s to finish.
+  private scrollToPage(pageNumber: number): Promise<void> {
+    return new Promise(resolve => {
+      const cellIndexToScrollTo = this.pageSize * (pageNumber - 1);
+      // without this setTimeout, Safari just pauses until the `fetchPage` is complete
+      // then scrolls to the cell
       setTimeout(() => {
-        this.isScrollingToCell = false;
-        this.infiniteScroller?.reload();
-      }, 500);
-    }, 0);
+        this.isScrollingToCell = true;
+        this.infiniteScroller?.scrollToCell(cellIndexToScrollTo, true);
+        // This timeout is to give the scroll animation time to finish
+        // then updating the infinite scroller once we're done scrolling
+        // There's no scroll animation completion callback so we're
+        // giving it 0.5s to finish.
+        setTimeout(() => {
+          this.isScrollingToCell = false;
+          this.infiniteScroller?.reload();
+          resolve();
+        }, 500);
+      }, 0);
+    });
   }
 
   /**

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -751,7 +751,12 @@ describe('Collection Browser', () => {
       </collection-browser>`
     );
 
-    // Infinite scroller won't exist unless there's a base query
+    // Infinite scroller won't exist unless there's a base query.
+    // First ensure that we don't throw errors when it doesn't exist.
+    await el.goToPage(1);
+
+    // And make sure it correctly calls scrollToCell when the
+    // infinite scroller does exist.
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
 
@@ -764,12 +769,7 @@ describe('Collection Browser', () => {
     const spy = sinon.spy();
     infiniteScroller.scrollToCell = spy;
 
-    el.goToPage(1);
-
-    // Give it a second to scroll
-    await new Promise(res => {
-      setTimeout(res, 1000);
-    });
+    await el.goToPage(1);
 
     expect(spy.callCount).to.equal(1);
 


### PR DESCRIPTION
The `infiniteScroller` member of collection browser is incorrectly asserted to be non-null. This assertion is invalid in cases where the infinite scroller is not rendered, such as when showing a “0 results” or “no query” placeholder. As a result of the non-null assertion, there are several places in collection-browser.ts that assume `this.infiniteScroller` exists without tsc complaining, producing errors at runtime when that assumption fails (like in the case above).

This PR removes that non-null assertion and ensures uses of `this.infiniteScroller` are optional-chained or null-guarded as appropriate.