### PR TITLE
WEBDEV-5648 Adjust tile typography for Windows and avoid clipping descenders

### DIFF
--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -31,6 +31,7 @@ export const baseTileStyles = css`
     flex-direction: column;
     height: 100%;
     row-gap: 10px;
+    font-family: 'Helvetica Neue', ui-sans-serif, system-ui, sans-serif;
   }
 
   .item-info {
@@ -73,6 +74,7 @@ export const baseTileStyles = css`
     line-height: 15px;
     font-size: 14px;
     font-weight: 500;
+    padding-bottom: 1px;
   }
 
   span {
@@ -83,6 +85,7 @@ export const baseTileStyles = css`
     word-wrap: break-word;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
+    padding-bottom: 1px;
   }
 
   .container:hover > .tile-details > .item-info > #title > .truncated {

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -103,6 +103,7 @@ export class TileStats extends LitElement {
         height: 35px;
         padding-left: 5px;
         padding-right: 5px;
+        font-family: 'Helvetica Neue', ui-sans-serif, system-ui, sans-serif;
       }
 
       #stats-row {


### PR DESCRIPTION
On Windows machines, the font that matches Helvetica by default does not allow more granular font weights than normal and bold. Since our new tile designs use a medium font weight between these two, Windows users would see the same font weight for item titles and creators, which gave a poor sense of visual hierarchy. Also, with the current line heights, descenders on some text lines are being cut off.

This PR fixes both of these problems by updating the font fallback stack to one that looks better on Windows, and adding a small bottom padding to certain lines of tile text to accommodate descenders.