### PR TITLE
WEBDEV-5680 Ensure title/creator letter filters clear when mobile sort field changes

### DIFF
--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -385,12 +385,10 @@ export class SortFilterBar
 
     this.alphaSelectorVisible = null;
     if (sortField !== 'title' && this.selectedTitleFilter) {
-      this.alphaSelectorVisible = 'title';
       this.selectedTitleFilter = null;
       this.emitTitleLetterChangedEvent();
     }
     if (sortField !== 'creator' && this.selectedCreatorFilter) {
-      this.alphaSelectorVisible = 'creator';
       this.selectedCreatorFilter = null;
       this.emitCreatorLetterChangedEvent();
     }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -383,11 +383,14 @@ export class SortFilterBar
     const sortField = target.value as SortField;
     this.setSelectedSort(sortField);
 
+    this.alphaSelectorVisible = null;
     if (sortField !== 'title' && this.selectedTitleFilter) {
+      this.alphaSelectorVisible = 'title';
       this.selectedTitleFilter = null;
       this.emitTitleLetterChangedEvent();
     }
     if (sortField !== 'creator' && this.selectedCreatorFilter) {
+      this.alphaSelectorVisible = 'creator';
       this.selectedCreatorFilter = null;
       this.emitCreatorLetterChangedEvent();
     }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -380,7 +380,17 @@ export class SortFilterBar
 
   private mobileSortChanged(e: Event) {
     const target = e.target as HTMLSelectElement;
-    this.setSelectedSort(target.value as SortField);
+    const sortField = target.value as SortField;
+    this.setSelectedSort(sortField);
+
+    if (sortField !== 'title' && this.selectedTitleFilter) {
+      this.selectedTitleFilter = null;
+      this.emitTitleLetterChangedEvent();
+    }
+    if (sortField !== 'creator' && this.selectedCreatorFilter) {
+      this.selectedCreatorFilter = null;
+      this.emitCreatorLetterChangedEvent();
+    }
   }
 
   private get displayOptionTemplate() {

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -229,3 +229,92 @@ describe('Sort/filter bar letter behavior', () => {
     expect(el.selectedCreatorFilter).to.equal('C');
   });
 });
+
+describe('Sort/filter bar mobile view', () => {
+  let origWindowSize: { width: number; height: number };
+  before(() => {
+    origWindowSize = { width: window.innerWidth, height: window.innerHeight };
+    window.resizeTo(500, 600);
+  });
+
+  after(() => {
+    window.resizeTo(origWindowSize.width, origWindowSize.height);
+  });
+
+  it('renders in mobile view', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    const mobileSortSelector = el.shadowRoot?.querySelector(
+      '#mobile-sort-selector'
+    );
+    const desktopSortSelector = el.shadowRoot?.querySelector(
+      '#desktop-sort-selector'
+    );
+
+    expect(mobileSortSelector?.classList?.contains('visible')).to.be.true;
+    expect(desktopSortSelector?.classList?.contains('hidden')).to.be.true;
+  });
+
+  it('changes selected sort in mobile view', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    const mobileSortSelector = el.shadowRoot?.querySelector(
+      '#mobile-sort-selector'
+    ) as HTMLSelectElement;
+    expect(mobileSortSelector).to.exist;
+
+    mobileSortSelector.value = 'title';
+    mobileSortSelector.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+
+    expect(el.selectedSort).to.equal('title');
+  });
+
+  it('clears title filter when sort changed from title in mobile view', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    el.selectedSort = 'title' as SortField;
+    el.selectedTitleFilter = 'A';
+    await el.updateComplete;
+
+    const mobileSortSelector = el.shadowRoot?.querySelector(
+      '#mobile-sort-selector'
+    ) as HTMLSelectElement;
+    expect(mobileSortSelector).to.exist;
+
+    mobileSortSelector.value = 'relevance';
+    mobileSortSelector.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+
+    expect(el.selectedSort).to.equal('relevance');
+    expect(el.selectedTitleFilter).to.be.null;
+  });
+
+  it('clears creator filter when sort changed from creator in mobile view', async () => {
+    const el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+
+    el.selectedSort = 'creator' as SortField;
+    el.selectedCreatorFilter = 'A';
+    await el.updateComplete;
+
+    const mobileSortSelector = el.shadowRoot?.querySelector(
+      '#mobile-sort-selector'
+    ) as HTMLSelectElement;
+    expect(mobileSortSelector).to.exist;
+
+    mobileSortSelector.value = 'relevance';
+    mobileSortSelector.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+
+    expect(el.selectedSort).to.equal('relevance');
+    expect(el.selectedCreatorFilter).to.be.null;
+  });
+});


### PR DESCRIPTION
Resolves a bug in mobile view, where selecting a different sort option would still leave any existing title/creator letter filter active.