### PR TITLE
WEBDEV-5690 Adjust grid tile layout

### DIFF
--- a/src/styles/item-image-styles.ts
+++ b/src/styles/item-image-styles.ts
@@ -16,6 +16,10 @@ export const baseItemImageStyles = css`
     position: relative;
   }
 
+  .list-box img {
+    border-radius: 0;
+  }
+
   .contain {
     object-fit: contain;
     object-position: center;
@@ -40,7 +44,7 @@ export const baseItemImageStyles = css`
     height: 160px;
   }
 
-  .collection-image {
+  :not(.list-box) > .collection-image {
     object-fit: cover;
     border-radius: 8px;
     width: 100%;

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -83,7 +83,6 @@ export class ItemTile extends LitElement {
   private get imageBlockTemplate(): TemplateResult {
     return html`
       <image-block
-        class=${this.hasSnippets ? 'has-snippets' : nothing}
         .model=${this.model}
         .baseImageUrl=${this.baseImageUrl}
         .loggedIn=${this.loggedIn}
@@ -174,7 +173,7 @@ export class ItemTile extends LitElement {
 
         text-snippet-block {
           --containerLeftMargin: 5px;
-          --containerTopMargin: 10px;
+          --containerTopMargin: 5px;
         }
       `,
     ];

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -21,7 +21,6 @@ export const baseTileStyles = css`
 
   image-block {
     display: block;
-    margin-bottom: 5px;
     position: relative;
     text-align: center;
   }
@@ -30,19 +29,19 @@ export const baseTileStyles = css`
     display: flex;
     flex-direction: column;
     height: 100%;
-    row-gap: 5px;
+    row-gap: 10px;
     font-family: 'Helvetica Neue', ui-sans-serif, system-ui, sans-serif;
   }
 
   .item-info {
+    display: flex;
+    flex-direction: column;
+    row-gap: 5px;
     flex-grow: 1;
   }
 
   #title {
-    flex-shrink: 0;
-    padding-left: 5px;
-    padding-right: 5px;
-    margin-bottom: 5px;
+    padding: 0 5px;
   }
 
   .created-by,
@@ -52,7 +51,7 @@ export const baseTileStyles = css`
     display: flex;
     justify-content: left;
     align-items: flex-end; /* Important to start text from bottom */
-    padding: 0 5px 5px 5px;
+    padding: 0 5px;
   }
 
   .truncated {

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -30,7 +30,7 @@ export const baseTileStyles = css`
     display: flex;
     flex-direction: column;
     height: 100%;
-    row-gap: 10px;
+    row-gap: 5px;
     font-family: 'Helvetica Neue', ui-sans-serif, system-ui, sans-serif;
   }
 
@@ -42,7 +42,7 @@ export const baseTileStyles = css`
     flex-shrink: 0;
     padding-left: 5px;
     padding-right: 5px;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
   }
 
   .created-by,

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -43,7 +43,7 @@ export class TileStats extends LitElement {
             <p class="sr-only">Mediatype:</p>
             <mediatype-icon .mediatype=${this.mediatype}></mediatype-icon>
           </li>
-          <li class="col" title="${uploadsOrViewsTitle}">
+          <li class="col views" title="${uploadsOrViewsTitle}">
             ${this.mediatype === 'account' ? uploadIcon : viewsIcon}
             <p class="status-text">
               <span class="sr-only">
@@ -56,14 +56,14 @@ export class TileStats extends LitElement {
               )}
             </p>
           </li>
-          <li class="col" title="${formattedFavCount} favorites">
+          <li class="col favorites" title="${formattedFavCount} favorites">
             ${favoriteFilledIcon}
             <p class="status-text">
               <span class="sr-only">Favorites:</span>
               ${formattedFavCount}
             </p>
           </li>
-          <li class="col" title="${formattedReviewCount} reviews">
+          <li class="col reviews" title="${formattedReviewCount} reviews">
             ${reviewsIcon}
             <p class="status-text">
               <span class="sr-only">Reviews:</span>
@@ -97,6 +97,13 @@ export class TileStats extends LitElement {
         display: block;
         margin: auto;
         pointer-events: none;
+      }
+
+      /* Make the reviews icon slightly smaller/lower, for even visual weight */
+      .reviews svg {
+        height: 9px;
+        width: 9px;
+        margin-top: 1px;
       }
 
       .item-stats {

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -43,7 +43,7 @@ export class TileStats extends LitElement {
             <p class="sr-only">Mediatype:</p>
             <mediatype-icon .mediatype=${this.mediatype}></mediatype-icon>
           </li>
-          <li class="col views" title="${uploadsOrViewsTitle}">
+          <li class="col" title="${uploadsOrViewsTitle}">
             ${this.mediatype === 'account' ? uploadIcon : viewsIcon}
             <p class="status-text">
               <span class="sr-only">
@@ -56,7 +56,7 @@ export class TileStats extends LitElement {
               )}
             </p>
           </li>
-          <li class="col favorites" title="${formattedFavCount} favorites">
+          <li class="col" title="${formattedFavCount} favorites">
             ${favoriteFilledIcon}
             <p class="status-text">
               <span class="sr-only">Favorites:</span>

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -92,8 +92,8 @@ export class TileStats extends LitElement {
       }
 
       svg {
-        height: 10px;
-        width: 10px;
+        height: 13px;
+        width: 13px;
         display: block;
         margin: auto;
         pointer-events: none;
@@ -101,9 +101,9 @@ export class TileStats extends LitElement {
 
       /* Make the reviews icon slightly smaller/lower, for even visual weight */
       .reviews svg {
-        height: 9px;
-        width: 9px;
-        margin-top: 1px;
+        height: 11px;
+        width: 11px;
+        margin-top: 2px;
       }
 
       .item-stats {
@@ -141,7 +141,7 @@ export class TileStats extends LitElement {
         font-size: 14px;
         height: 15px;
         color: #2c2c2c;
-        line-height: 20px;
+        line-height: 17px;
         margin: auto;
         display: block;
         text-align: center;

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -100,7 +100,7 @@ export class TileStats extends LitElement {
       }
 
       .item-stats {
-        height: 35px;
+        height: 30px;
         padding-left: 5px;
         padding-right: 5px;
         font-family: 'Helvetica Neue', ui-sans-serif, system-ui, sans-serif;
@@ -108,9 +108,9 @@ export class TileStats extends LitElement {
 
       #stats-row {
         display: flex;
+        justify-content: space-between;
         flex-wrap: wrap;
         width: 100%;
-        padding-top: 5px;
         padding-bottom: 5px;
       }
 
@@ -126,7 +126,7 @@ export class TileStats extends LitElement {
       }
 
       .col {
-        width: 25%;
+        min-width: 15px;
         height: 25px;
       }
 

--- a/src/tiles/image-block.ts
+++ b/src/tiles/image-block.ts
@@ -90,6 +90,7 @@ export class ImageBlock extends LitElement {
         justify-content: center;
         position: relative;
         background-color: ${imageBlockBackgroundColor};
+        border-radius: 4px;
       }
 
       .grid {
@@ -97,6 +98,7 @@ export class ImageBlock extends LitElement {
         flex: 1;
         position: initial;
         padding: 5px;
+        border-radius: 4px 4px 0 0;
       }
 
       .collection.grid {
@@ -106,6 +108,7 @@ export class ImageBlock extends LitElement {
       /** tile-list view */
       .list.desktop {
         width: 100px;
+        max-width: 100%;
         height: 100px;
         display: inline-block;
         position: relative;

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -85,11 +85,12 @@ export class TextSnippetBlock extends LitElement {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-        width: 100%;
+        width: calc(100% - 10px);
         border-left: 5px solid #194880;
         margin-top: var(--containerTopMargin, 10px);
         margin-left: var(--containerLeftMargin, 0px);
         border-radius: 3px;
+        box-sizing: border-box;
       }
 
       .snippet-view {
@@ -101,17 +102,16 @@ export class TextSnippetBlock extends LitElement {
         -webkit-line-clamp: var(--maxLines, 3);
         -webkit-box-orient: vertical;
         margin-left: 5px;
-        margin-right: 10px;
       }
 
       .grid {
-        margin: 0px 15px 0px 5px;
         font-size: 1.2rem;
         line-height: 1.5rem;
       }
 
       .list {
-        padding-left: 20px;
+        margin: 0;
+        padding-left: 15px;
         font-size: 1.4rem;
         line-height: 2rem;
       }


### PR DESCRIPTION
Removes some of the whitespace between lines on grid tiles, and ensures the stats row at the bottom is aligned consistently.