### PR TITLE
WEBDEV-5695 Correct compact list view headers & date column defaults

### DIFF
--- a/src/tiles/list/date-label.ts
+++ b/src/tiles/list/date-label.ts
@@ -1,12 +1,12 @@
 export function dateLabel(sortField: string | undefined): string {
   switch (sortField) {
-    case 'date':
-      return 'Published';
+    case 'publicdate':
+      return 'Archived';
     case 'reviewdate':
       return 'Reviewed';
     case 'addeddate':
       return 'Added';
     default:
-      return 'Archived';
+      return 'Published';
   }
 }

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -67,11 +67,11 @@ export class TileListCompactHeader extends LitElement {
       }
 
       #list-line-header.mobile {
-        grid-template-columns: 36px 3fr 2fr 91px;
+        grid-template-columns: 36px 3fr 2fr 68px 35px;
       }
 
       #list-line-header.desktop {
-        grid-template-columns: 51px 3fr 2fr 100px 20px 60px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 60px;
       }
     `;
   }

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -56,6 +56,7 @@ export class TileListCompactHeader extends LitElement {
 
       #views {
         text-align: right;
+        padding-right: 8px;
       }
 
       #list-line-header {

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -21,7 +21,7 @@ export class TileListCompactHeader extends LitElement {
         <div id="title">Title</div>
         <div id="creator">Creator</div>
         <div id="date">${dateLabel(this.sortParam?.field)}</div>
-        <div id="icon"></div>
+        <div id="icon">Type</div>
         <div id="views">Views</div>
       </div>
     `;

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -66,6 +66,12 @@ export class TileListCompact extends LitElement {
    * @see src/models.ts
    */
   private get date(): Date | undefined {
+    // Note on 'publicdate' vs. 'date':
+    // The search engine metadata uses 'publicdate' as the key for the date the item
+    // was created on archive.org, which in the UI is referred to as "Date Archived".
+    // In contrast, the search engine metadata uses 'date' to refer to the actual
+    // publication date of the underlying media ("Date Published" in the UI).
+    // Refer to the full metadata schema for more info.
     switch (this.sortParam?.field) {
       case 'publicdate':
         return this.model?.dateArchived;
@@ -74,7 +80,7 @@ export class TileListCompact extends LitElement {
       case 'addeddate':
         return this.model?.dateAdded;
       default:
-        return this.model?.datePublished; // 'date'
+        return this.model?.datePublished;
     }
   }
 

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -67,14 +67,14 @@ export class TileListCompact extends LitElement {
    */
   private get date(): Date | undefined {
     switch (this.sortParam?.field) {
-      case 'date':
-        return this.model?.datePublished;
+      case 'publicdate':
+        return this.model?.dateArchived;
       case 'reviewdate':
         return this.model?.dateReviewed;
       case 'addeddate':
         return this.model?.dateAdded;
       default:
-        return this.model?.dateArchived; // publicdate
+        return this.model?.datePublished; // 'date'
     }
   }
 

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -127,11 +127,11 @@ export class TileListCompact extends LitElement {
       }
 
       #list-line.mobile {
-        grid-template-columns: 36px 3fr 2fr 62px 19px;
+        grid-template-columns: 36px 3fr 2fr 68px 35px;
       }
 
       #list-line.desktop {
-        grid-template-columns: 51px 3fr 2fr 100px 20px 60px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 60px;
       }
 
       #list-line:hover #title {
@@ -148,6 +148,10 @@ export class TileListCompact extends LitElement {
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
+      }
+
+      #icon {
+        margin-left: 2px;
       }
 
       #views {


### PR DESCRIPTION
In the compact list view:
- Adds a "Type" column header to the column with the mediatype icons (since it looks strange without any header)
- Defaults the date column to show date published, not date archived (unless there is a date sort active, which takes precedence).