### PR TITLE
WEBDEV-5694 Make mediatype icons in list view link to their collection

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -120,7 +120,7 @@ export class TileList extends LitElement {
   // Data templates
   private get iconRightTemplate() {
     return html`
-      <a id="icon-right" href=${this.mediatypeURL}>
+      <a id="icon-right" href=${this.mediatypeURL} target="_blank">
         <mediatype-icon
           .mediatype=${this.model?.mediatype}
           .collections=${this.model?.collections}
@@ -333,9 +333,19 @@ export class TileList extends LitElement {
 
   /** The URL of this item's mediatype collection, if defined. */
   private get mediatypeURL(): string | typeof nothing {
-    return this.baseNavigationUrl && this.model?.mediatype
-      ? `${this.baseNavigationUrl}/details/${encodeURI(this.model.mediatype)}`
-      : nothing;
+    if (!this.baseNavigationUrl || !this.model?.mediatype) return nothing;
+
+    // Need special handling for certain mediatypes that don't have a top-level collection page
+    switch (this.model.mediatype) {
+      case 'collection':
+        return `${this.baseNavigationUrl}/search?query=mediatype:collection&sort=-downloads`;
+      case 'account':
+        return nothing;
+      default:
+        return `${this.baseNavigationUrl}/details/${encodeURI(
+          this.model.mediatype
+        )}`;
+    }
   }
 
   protected updated(changed: PropertyValues): void {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -120,13 +120,13 @@ export class TileList extends LitElement {
   // Data templates
   private get iconRightTemplate() {
     return html`
-      <div id="icon-right">
+      <a id="icon-right" href=${this.mediatypeURL}>
         <mediatype-icon
           .mediatype=${this.model?.mediatype}
           .collections=${this.model?.collections}
         >
         </mediatype-icon>
-      </div>
+      </a>
     `;
   }
 
@@ -329,6 +329,13 @@ export class TileList extends LitElement {
       href="${this.baseNavigationUrl}/details/${encodeURI(identifier)}"
       >${DOMPurify.sanitize(linkText)}</a
     >`;
+  }
+
+  /** The URL of this item's mediatype collection, if defined. */
+  private get mediatypeURL(): string | typeof nothing {
+    return this.baseNavigationUrl && this.model?.mediatype
+      ? `${this.baseNavigationUrl}/details/${encodeURI(this.model.mediatype)}`
+      : nothing;
   }
 
   protected updated(changed: PropertyValues): void {

--- a/test/tiles/grid/account-tile.test.ts
+++ b/test/tiles/grid/account-tile.test.ts
@@ -45,7 +45,7 @@ describe('Account Tile', () => {
     const el = await fixture<AccountTile>(html`
       <account-tile
         .model=${{
-          dateAdded: new Date('2022-01-01'),
+          dateAdded: new Date('2022-02-02'),
         }}
       >
       </account-tile>

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -181,6 +181,61 @@ describe('List Tile', () => {
     expect(descriptionBlock?.textContent?.trim()).to.equal('line1 line2'); // line break replaced by space
   });
 
+  it('should render mediatype icon as link to corresponding mediatype collection details', async () => {
+    const model: Partial<TileModel> = {
+      mediatype: 'texts',
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .baseNavigationUrl=${'https://archive.org'}
+        .model=${model}
+      ></tile-list>
+    `);
+
+    const mediatypeLink = el.shadowRoot?.querySelector('a#icon-right');
+    expect(mediatypeLink).to.exist;
+    expect(mediatypeLink?.getAttribute('href')).to.equal(
+      `https://archive.org/details/texts`
+    );
+  });
+
+  it('should render collection mediatype icon as link to search page', async () => {
+    const model: Partial<TileModel> = {
+      mediatype: 'collection',
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .baseNavigationUrl=${'https://archive.org'}
+        .model=${model}
+      ></tile-list>
+    `);
+
+    const mediatypeLink = el.shadowRoot?.querySelector('a#icon-right');
+    expect(mediatypeLink).to.exist;
+    expect(mediatypeLink?.getAttribute('href')).to.equal(
+      `https://archive.org/search?query=mediatype:collection&sort=-downloads`
+    );
+  });
+
+  it('should not render account mediatype icon as link', async () => {
+    const model: Partial<TileModel> = {
+      mediatype: 'account',
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .baseNavigationUrl=${'https://archive.org'}
+        .model=${model}
+      ></tile-list>
+    `);
+
+    const mediatypeLink = el.shadowRoot?.querySelector('a#icon-right');
+    expect(mediatypeLink).to.exist;
+    expect(mediatypeLink?.getAttribute('href')).not.to.exist;
+  });
+
   it('should render date added for accounts', async () => {
     const el = await fixture<TileList>(html`
       <tile-list


### PR DESCRIPTION
Converts extended list view mediatype icons into links targeting their mediatype's collection details page.