### PR TITLE
WEBDEV-5686 Ensure grid tiles are not overly wide, fit 2 cols in mobile view

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1700,11 +1700,20 @@ export class CollectionBrowser
     infinite-scroller.grid {
       --infiniteScrollerCellMinWidth: var(
         --collectionBrowserCellMinWidth,
-        18rem
+        17rem
       );
       --infiniteScrollerCellMaxWidth: var(--collectionBrowserCellMaxWidth, 1fr);
     }
 
+    /* Allow tiles to shrink a bit further at smaller viewport widths */
+    @media screen and (max-width: 880px) {
+      infinite-scroller.grid {
+        --infiniteScrollerCellMinWidth: var(
+          --collectionBrowserCellMinWidth,
+          15rem
+        );
+      }
+    }
     /* At very small widths, maintain a 2-tile layout as far as it can reasonably go */
     @media screen and (max-width: 360px) {
       infinite-scroller.grid {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1705,6 +1705,16 @@ export class CollectionBrowser
       --infiniteScrollerCellMaxWidth: var(--collectionBrowserCellMaxWidth, 1fr);
     }
 
+    /* At very small widths, maintain a 2-tile layout as far as it can reasonably go */
+    @media screen and (max-width: 360px) {
+      infinite-scroller.grid {
+        --infiniteScrollerCellMinWidth: var(
+          --collectionBrowserCellMinWidth,
+          12rem
+        );
+      }
+    }
+
     infinite-scroller.hidden {
       display: none;
     }

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -135,6 +135,7 @@ export class TileStats extends LitElement {
 
       .col {
         min-width: 15px;
+        max-width: 25%;
         height: 25px;
       }
 


### PR DESCRIPTION
Currently, at mobile device portrait view widths, often there is only one column of grid tiles shown, and the tiles appear overly wide.

This PR reduces the minimum widths of tiles at different breakpoints to ensure that they can continue to fit 2 columns even down to very narrow device widths. These smaller min widths also allow the tile columns to shrink further before a column is removed, which has the side effect of reducing the maximum tile width possible.