### PR TITLE
WEBDEV-5693 Adjust extended list view thumbnail styles for better visibility/alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     }
 
     body {
-      background: #fff;
+      background: #F5F5F7;
       color: #2C2C2C;
     }
   </style>

--- a/src/tiles/image-block.ts
+++ b/src/tiles/image-block.ts
@@ -106,6 +106,12 @@ export class ImageBlock extends LitElement {
       }
 
       /** tile-list view */
+      .list {
+        border-radius: 0;
+        background-color: var(--imageBlockListBackgroundColor, #ebebee);
+        box-shadow: 1px 1px 2px rgb(0, 0, 0, 0.2);
+      }
+
       .list.desktop {
         width: 100px;
         max-width: 100%;


### PR DESCRIPTION
The container box around extended list view thumbnails blends in very closely with the background on archive.org, making it look like the aspect-fit thumbnails are misaligned when they are wider than they are tall. This PR adjusts the styles for the container box to make the box more visibly aligned with the title row.

Also gives the demo app the same color background as archive.org, to serve as a better point of comparison.