### PR TITLE
WEBDEV-5671 Remove facet sort toggles from sidebar, and convert to links in More dialog

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -399,9 +399,6 @@ export class CollectionFacets extends LitElement {
           >
             ${this.collapsableFacets ? collapser : nothing} ${facetGroup.title}
           </h1>
-          ${this.facetsLoading
-            ? nothing
-            : this.moreFacetsSortingIcon(facetGroup)}
         </div>
         <div class="facet-group-content ${isOpen ? 'open' : ''}">
           ${this.facetsLoading
@@ -423,23 +420,6 @@ export class CollectionFacets extends LitElement {
         () => html`<facet-tombstone-row></facet-tombstone-row>`
       )}
     `;
-  }
-
-  private moreFacetsSortingIcon(
-    facetGroup: FacetGroup
-  ): TemplateResult | typeof nothing {
-    // Display the sorting icon for every facet group except lending
-    return facetGroup.key === 'lending'
-      ? nothing
-      : html`
-          <input
-            class="sorting-icon"
-            type="image"
-            @click=${() => this.showMoreFacetsModal(facetGroup, 'alpha')}
-            src="https://archive.org/images/filter-count.png"
-            alt="Sort alphabetically"
-          />
-        `;
   }
 
   /**

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -397,26 +397,21 @@ export class MoreFacetsContent extends LitElement {
   }
 
   private get getModalHeaderTemplate(): TemplateResult {
-    const title =
-      this.sortedBy === 'alpha' ? 'Sort by count' : 'Sort by alphabetically';
-
-    const image =
-      this.sortedBy === 'alpha'
-        ? 'https://archive.org/images/filter-alpha.png'
-        : 'https://archive.org/images/filter-count.png';
+    const title = this.sortedBy === 'alpha' ? 'Sort by count' : 'Sort by value';
 
     return html`<span class="sr-only">More facets for:</span>
       <span class="title">
         ${this.facetGroupTitle}
-        <input
-          class="sorting-icon"
-          type="image"
-          @click=${() => this.sortFacetAggregation()}
-          src="${image}"
-          title=${title}
-          alt="sort facets"
-        />
-      </span> `;
+        <a
+          class="sort-link"
+          href="#"
+          @click=${(e: Event) => {
+            e.preventDefault();
+            this.sortFacetAggregation();
+          }}
+          >${title}</a
+        >
+      </span>`;
   }
 
   render() {
@@ -480,6 +475,16 @@ export class MoreFacetsContent extends LitElement {
         font-size: 1.8rem;
         padding: 0 10px;
         font-weight: bold;
+      }
+      .sort-link {
+        margin-left: 0.7rem;
+        color: var(--ia-theme-link-color, #4b64ff);
+        font-size: 1.3rem;
+        font-weight: normal;
+        text-decoration: none;
+      }
+      .sort-link:hover {
+        text-decoration: underline;
       }
       .facets-content {
         font-size: 1.2rem;

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -402,15 +402,15 @@ export class MoreFacetsContent extends LitElement {
     return html`<span class="sr-only">More facets for:</span>
       <span class="title">
         ${this.facetGroupTitle}
-        <a
-          class="sort-link"
-          href="#"
+        <button
+          class="sort-button"
           @click=${(e: Event) => {
             e.preventDefault();
             this.sortFacetAggregation();
           }}
-          >${title}</a
         >
+          ${title}
+        </button>
       </span>`;
   }
 
@@ -476,14 +476,17 @@ export class MoreFacetsContent extends LitElement {
         padding: 0 10px;
         font-weight: bold;
       }
-      .sort-link {
+      .sort-button {
         margin-left: 0.7rem;
+        padding: 0;
+        border: none;
+        background: transparent;
         color: var(--ia-theme-link-color, #4b64ff);
         font-size: 1.3rem;
         font-weight: normal;
-        text-decoration: none;
+        cursor: pointer;
       }
-      .sort-link:hover {
+      .sort-button:hover {
         text-decoration: underline;
       }
       .facets-content {

--- a/test/collection-facets.test.ts
+++ b/test/collection-facets.test.ts
@@ -542,52 +542,6 @@ describe('Collection Facets', () => {
       expect(moreLink).to.be.null;
     });
 
-    it('renders sorting icons', async () => {
-      const el = await fixture<CollectionFacets>(
-        html`<collection-facets></collection-facets>`
-      );
-
-      const aggs: Record<string, Aggregation> = {
-        subject: new Aggregation({
-          buckets: [
-            {
-              key: 'foo',
-              doc_count: 5,
-            },
-          ],
-        }),
-      };
-
-      el.aggregations = aggs;
-      await el.updateComplete;
-
-      const sortingIcon = el.shadowRoot?.querySelector('.sorting-icon');
-      expect(sortingIcon).to.exist;
-    });
-
-    it('does not render sorting icon for lending facets', async () => {
-      const el = await fixture<CollectionFacets>(
-        html`<collection-facets></collection-facets>`
-      );
-
-      const aggs: Record<string, Aggregation> = {
-        lending: new Aggregation({
-          buckets: [
-            {
-              key: 'is_readable',
-              doc_count: 5,
-            },
-          ],
-        }),
-      };
-
-      el.aggregations = aggs;
-      await el.updateComplete;
-
-      const sortingIcon = el.shadowRoot?.querySelector('.sorting-icon');
-      expect(sortingIcon).not.to.exist;
-    });
-
     it('Render More Facets', async () => {
       const el = await fixture<CollectionFacets>(
         html`<collection-facets


### PR DESCRIPTION
The little sorting toggle buttons in the facet sidebar are confusing and unclear. There is already a means of sorting the facets within the More dialog, so the minor shortcut these buttons provide is not particularly helpful.

This PR removes those toggle buttons from the sidebar, and adjusts the sorting affordance in the More dialog to use a textual label describing the sort rather than the previous button's unclear visuals.