### PR TITLE
WEBDEV-5717 Allow mediatype links with empty baseNavigationUrl

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -339,7 +339,9 @@ export class TileList extends LitElement {
 
   /** The URL of this item's mediatype collection, if defined. */
   private get mediatypeURL(): string | typeof nothing {
-    if (!this.baseNavigationUrl || !this.model?.mediatype) return nothing;
+    // NB: baseNavigationUrl can be an empty string
+    if (this.baseNavigationUrl === undefined || !this.model?.mediatype)
+      return nothing;
 
     // Need special handling for certain mediatypes that don't have a top-level collection page
     switch (this.model.mediatype) {

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -202,6 +202,20 @@ describe('List Tile', () => {
     );
   });
 
+  it('should render mediatype icon as link even with empty baseNavigationUrl', async () => {
+    const model: Partial<TileModel> = {
+      mediatype: 'texts',
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list .baseNavigationUrl=${''} .model=${model}></tile-list>
+    `);
+
+    const mediatypeLink = el.shadowRoot?.querySelector('a#icon-right');
+    expect(mediatypeLink).to.exist;
+    expect(mediatypeLink?.getAttribute('href')).to.equal(`/details/texts`);
+  });
+
   it('should render collection mediatype icon as link to search page', async () => {
     const model: Partial<TileModel> = {
       mediatype: 'collection',


### PR DESCRIPTION
Patches an issue with #188 where the links were not generating correctly in the production environment where `baseNavigationUrl` is an empty string.