### PR TITLE
WEBDEV-5699 Add on-hover feedback to alphabet bar

### DIFF
--- a/src/sort-filter-bar/alpha-bar-tooltip.ts
+++ b/src/sort-filter-bar/alpha-bar-tooltip.ts
@@ -9,7 +9,9 @@ export class AlphaBarTooltip extends LitElement {
     return html`
       <div id="tooltip-container" role="tooltip">
         <div id="arrow"></div>
-        <div id="tooltip-text">${this.numResults} results</div>
+        <div id="tooltip-text">
+          ${this.numResults} ${this.numResults === 1 ? 'result' : 'results'}
+        </div>
       </div>
     `;
   }

--- a/src/sort-filter-bar/alpha-bar-tooltip.ts
+++ b/src/sort-filter-bar/alpha-bar-tooltip.ts
@@ -1,0 +1,47 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('alpha-bar-tooltip')
+export class AlphaBarTooltip extends LitElement {
+  @property({ type: Number }) numResults: number = 0;
+
+  render() {
+    return html`
+      <div id="tooltip-container" role="tooltip">
+        <div id="arrow"></div>
+        <div id="tooltip-text">${this.numResults} results</div>
+      </div>
+    `;
+  }
+
+  static styles = css`
+    #tooltip-container {
+      width: max-content;
+      max-width: 200px;
+      padding-top: var(--tooltipArrowSize, 5px);
+      pointer-events: none;
+    }
+
+    #arrow {
+      position: absolute;
+      left: calc(50% + var(--tooltipArrowOffset, 0px));
+      top: 0;
+      width: 0;
+      height: 0;
+      margin-top: calc(-1 * var(--tooltipArrowSize, 5px));
+      margin-left: calc(-1 * var(--tooltipArrowSize, 5px));
+      border: var(--tooltipArrowSize, 5px) solid transparent;
+      border-bottom-color: black;
+    }
+
+    #tooltip-text {
+      padding: 3px 8px;
+      border-radius: 4px;
+      background-color: #000;
+      color: white;
+      font-size: 1.2rem;
+      text-align: center;
+      text-decoration: none;
+    }
+  `;
+}

--- a/src/sort-filter-bar/alpha-bar-tooltip.ts
+++ b/src/sort-filter-bar/alpha-bar-tooltip.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, CSSResultGroup } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 @customElement('alpha-bar-tooltip')
@@ -14,34 +14,39 @@ export class AlphaBarTooltip extends LitElement {
     `;
   }
 
-  static styles = css`
-    #tooltip-container {
-      width: max-content;
-      max-width: 200px;
-      padding-top: var(--tooltipArrowSize, 5px);
-      pointer-events: none;
-    }
+  static get styles(): CSSResultGroup {
+    const arrowSize = css`var(--tooltipArrowSize, 5px)`;
+    const arrowOffset = css`var(--tooltipArrowOffset, 0px)`;
 
-    #arrow {
-      position: absolute;
-      left: calc(50% + var(--tooltipArrowOffset, 0px));
-      top: 0;
-      width: 0;
-      height: 0;
-      margin-top: calc(-1 * var(--tooltipArrowSize, 5px));
-      margin-left: calc(-1 * var(--tooltipArrowSize, 5px));
-      border: var(--tooltipArrowSize, 5px) solid transparent;
-      border-bottom-color: black;
-    }
+    return css`
+      #tooltip-container {
+        width: max-content;
+        max-width: 200px;
+        padding-top: ${arrowSize};
+        pointer-events: none;
+      }
 
-    #tooltip-text {
-      padding: 3px 8px;
-      border-radius: 4px;
-      background-color: #000;
-      color: white;
-      font-size: 1.2rem;
-      text-align: center;
-      text-decoration: none;
-    }
-  `;
+      #arrow {
+        position: absolute;
+        left: calc(50% + ${arrowOffset});
+        top: 0;
+        width: 0;
+        height: 0;
+        margin-top: calc(-1 * ${arrowSize});
+        margin-left: calc(-1 * ${arrowSize});
+        border: ${arrowSize} solid transparent;
+        border-bottom-color: black;
+      }
+
+      #tooltip-text {
+        padding: 3px 8px;
+        border-radius: 4px;
+        background-color: #000;
+        color: white;
+        font-size: 1.2rem;
+        text-align: center;
+        text-decoration: none;
+      }
+    `;
+  }
 }

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -188,7 +188,7 @@ export class AlphaBar extends LitElement {
       max-width: 2.5rem;
     }
 
-    li:hover:not(.selected) {
+    li:hover:not(.selected) a {
       background-color: #ccc;
     }
 

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -186,17 +186,21 @@ export class AlphaBar extends LitElement {
       flex: 1;
       text-align: center;
       max-width: 2.5rem;
+      border-radius: 50%;
     }
 
     li:hover:not(.selected) a {
-      background-color: #ccc;
+      background-color: #c0c0c0;
     }
 
     a {
       color: #333;
       text-decoration: none;
-      padding: 0.5rem 0;
-      display: block;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      aspect-ratio: 1 / 1;
+      border-radius: 50%;
     }
 
     span {
@@ -206,7 +210,7 @@ export class AlphaBar extends LitElement {
     }
 
     .selected {
-      background-color: darkgray;
+      background-color: #2c2c2c;
     }
 
     .selected a {

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -193,20 +193,23 @@ export class AlphaBar extends LitElement {
       background-color: #c0c0c0;
     }
 
-    a {
-      color: #333;
-      text-decoration: none;
+    a,
+    span {
       display: flex;
       justify-content: center;
       align-items: center;
       aspect-ratio: 1 / 1;
+    }
+
+    a {
+      color: #333;
+      text-decoration: none;
       border-radius: 4px;
     }
 
     span {
       color: #aaa;
-      padding: 0.5rem 0;
-      display: block;
+      cursor: default;
     }
 
     .selected {

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -186,7 +186,7 @@ export class AlphaBar extends LitElement {
       flex: 1;
       text-align: center;
       max-width: 2.5rem;
-      border-radius: 50%;
+      border-radius: 4px;
     }
 
     li:hover:not(.selected) a {
@@ -200,7 +200,7 @@ export class AlphaBar extends LitElement {
       justify-content: center;
       align-items: center;
       aspect-ratio: 1 / 1;
-      border-radius: 50%;
+      border-radius: 4px;
     }
 
     span {

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { PrefixFilterCounts } from '../models';
 
@@ -22,7 +22,7 @@ export class AlphaBar extends LitElement {
                 <li
                   class=${letter === this.selectedUppercaseLetter
                     ? 'selected'
-                    : ''}
+                    : nothing}
                 >
                   ${this.letterCounts?.[letter]
                     ? this.letterLinkTemplate(letter)
@@ -87,6 +87,10 @@ export class AlphaBar extends LitElement {
       flex: 1;
       text-align: center;
       max-width: 2.5rem;
+    }
+
+    li:hover:not(.selected) {
+      background-color: #ccc;
     }
 
     a {

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -1,12 +1,26 @@
-import { LitElement, html, css, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { LitElement, html, css, nothing, TemplateResult } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
 import type { PrefixFilterCounts } from '../models';
+
+import './alpha-bar-tooltip';
+import type { AlphaBarTooltip } from './alpha-bar-tooltip';
 
 @customElement('alpha-bar')
 export class AlphaBar extends LitElement {
   @property({ type: String }) selectedLetter: string | null = null;
 
   @property({ type: Object }) letterCounts?: PrefixFilterCounts;
+
+  @state()
+  private tooltipShown: boolean = false;
+
+  @state()
+  private hoveredLetter?: string;
+
+  @query('alpha-bar-tooltip')
+  private tooltip?: AlphaBarTooltip;
+
+  private readonly alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
   private get selectedUppercaseLetter(): string | undefined {
     return this.selectedLetter?.toUpperCase();
@@ -23,10 +37,13 @@ export class AlphaBar extends LitElement {
                   class=${letter === this.selectedUppercaseLetter
                     ? 'selected'
                     : nothing}
+                  @mousemove=${this.handleMouseMove}
+                  @mouseleave=${this.handleMouseLeave}
                 >
                   ${this.letterCounts?.[letter]
                     ? this.letterLinkTemplate(letter)
                     : html`<span>${letter}</span>`}
+                  ${this.tooltipTemplate(letter)}
                 </li>
               `
           )}
@@ -49,6 +66,17 @@ export class AlphaBar extends LitElement {
     `;
   }
 
+  private tooltipTemplate(letter: string): TemplateResult | typeof nothing {
+    if (this.hoveredLetter !== letter) return nothing;
+
+    return this.tooltipShown
+      ? html`<alpha-bar-tooltip
+          data-letter=${letter}
+          .numResults=${this.letterCounts?.[this.hoveredLetter] ?? 0}
+        ></alpha-bar-tooltip>`
+      : nothing;
+  }
+
   private letterClicked(letter: string) {
     if (letter === this.selectedUppercaseLetter) {
       this.selectedLetter = null;
@@ -62,7 +90,77 @@ export class AlphaBar extends LitElement {
     );
   }
 
-  private readonly alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+  private async handleMouseMove(e: MouseEvent) {
+    const target = e.target as HTMLLIElement;
+    if (target && !this.tooltipShown) {
+      const targetLetter = target.textContent?.trim() ?? undefined;
+      this.tooltipShown = true;
+      this.hoveredLetter = targetLetter;
+
+      await this.updateComplete;
+      await new Promise(resolve => {
+        setTimeout(resolve, 0);
+      });
+
+      if (this.tooltip && this.tooltip.dataset.letter === targetLetter) {
+        this.positionTooltip(target);
+      }
+    }
+  }
+
+  private handleMouseLeave() {
+    this.tooltipShown = false;
+    this.hoveredLetter = undefined;
+  }
+
+  private positionTooltip(targetElmt: HTMLElement) {
+    if (!this.tooltip) return;
+
+    // Basic positioning is just to center the whole tooltip on the letter box.
+    const tooltipWidth = this.tooltip.clientWidth;
+    const letterWidth = targetElmt.clientWidth;
+    let left = letterWidth / 2 - tooltipWidth / 2;
+
+    // But we also need to ensure the tooltip doesn't flow outside the viewport.
+    // First, calculate the full width of the document body, including margins
+    // (but not including any scrollbar).
+    const bodyStyle = getComputedStyle(document.body);
+    const bodyMarginLeft = parseFloat(
+      bodyStyle.getPropertyValue('margin-left')
+    );
+    const bodyMarginRight = parseFloat(
+      bodyStyle.getPropertyValue('margin-right')
+    );
+    const bodyWidthWithMargin =
+      document.body.clientWidth + bodyMarginLeft + bodyMarginRight;
+
+    // Calculate the positions of the tooltip's left/right edges, and determine
+    // how much they overflow the viewport by (if at all).
+    const targetRect = targetElmt.getBoundingClientRect();
+    const tooltipLeft = targetRect.left + left;
+    const tooltipRight = tooltipLeft + tooltipWidth;
+    const offset = 1; // How many pixels the tooltip must be offset from the left/right edges
+    let overflowAmt;
+    if (tooltipLeft < offset) {
+      // Tooltip overflows left edge of viewport
+      overflowAmt = tooltipLeft - offset;
+    } else if (tooltipRight > bodyWidthWithMargin - offset) {
+      // Tooltip overflows right edge of viewport
+      overflowAmt = tooltipRight - bodyWidthWithMargin + offset;
+    }
+
+    // Apply any needed adjustment to the tooltip and its arrow to keep it in the viewport
+    if (overflowAmt) {
+      left -= overflowAmt;
+      this.tooltip.style.setProperty(
+        '--tooltipArrowOffset',
+        `${overflowAmt}px`
+      );
+    }
+
+    this.tooltip.style.left = `${left}px`;
+    this.tooltip.classList.add('fade-in');
+  }
 
   static styles = css`
     h1 {
@@ -84,6 +182,7 @@ export class AlphaBar extends LitElement {
     }
 
     ul li {
+      position: relative;
       flex: 1;
       text-align: center;
       max-width: 2.5rem;
@@ -112,6 +211,20 @@ export class AlphaBar extends LitElement {
 
     .selected a {
       color: white;
+    }
+
+    alpha-bar-tooltip {
+      position: absolute;
+      top: 100%;
+      left: -9999px;
+      margin-top: 3px;
+
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    alpha-bar-tooltip.fade-in {
+      opacity: 1;
     }
   `;
 }

--- a/test/sort-filter-bar/alpha-bar-tooltip.test.ts
+++ b/test/sort-filter-bar/alpha-bar-tooltip.test.ts
@@ -1,0 +1,17 @@
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { AlphaBarTooltip } from '../../src/sort-filter-bar/alpha-bar-tooltip';
+
+import '../../src/sort-filter-bar/alpha-bar-tooltip';
+
+describe('Alphabet Filter Bar Tooltips', () => {
+  it('renders component', async () => {
+    const el = await fixture<AlphaBarTooltip>(
+      html`<alpha-bar-tooltip .numResults=${42}></alpha-bar-tooltip>`
+    );
+
+    // Should render the number of results
+    const tooltipText = el.shadowRoot?.querySelector('#tooltip-text');
+    expect(tooltipText?.textContent?.trim()).to.equal('42 results');
+  });
+});

--- a/test/sort-filter-bar/alpha-bar.test.ts
+++ b/test/sort-filter-bar/alpha-bar.test.ts
@@ -1,8 +1,9 @@
-import { expect, fixture } from '@open-wc/testing';
+import { aTimeout, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit';
 import type { AlphaBar } from '../../src/sort-filter-bar/alpha-bar';
 
 import '../../src/sort-filter-bar/alpha-bar';
+import type { AlphaBarTooltip } from '../../src/sort-filter-bar/alpha-bar-tooltip';
 
 describe('Alphabetical Filter Bar', () => {
   it('renders component', async () => {
@@ -48,5 +49,49 @@ describe('Alphabetical Filter Bar', () => {
     const selectedLetter = el.shadowRoot?.querySelector('li.selected');
     expect(selectedLetter).to.exist;
     expect(selectedLetter?.textContent?.trim()).to.equal('B');
+  });
+
+  it('renders a tooltip when hovered and removes it when un-hovered', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+    const firstLetter = el.shadowRoot?.querySelector('li') as HTMLLIElement;
+    expect(firstLetter).to.exist;
+
+    firstLetter.dispatchEvent(new MouseEvent('mousemove'));
+    await el.updateComplete;
+
+    const tooltip = el.shadowRoot?.querySelector(
+      'alpha-bar-tooltip'
+    ) as AlphaBarTooltip;
+    expect(tooltip).to.exist;
+
+    // Should be positioned after next tick
+    await aTimeout(0);
+    expect(tooltip.style.left).to.exist;
+
+    firstLetter.dispatchEvent(new MouseEvent('mouseleave'));
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('alpha-bar-tooltip')).not.to.exist;
+  });
+
+  it('positions tooltip correctly when it would overflow viewport', async () => {
+    const el = await fixture<AlphaBar>(html`<alpha-bar></alpha-bar>`);
+    const letters = el.shadowRoot?.querySelectorAll('li');
+    const lastLetter = letters?.item(letters.length - 1) as HTMLLIElement;
+    expect(lastLetter).to.exist;
+
+    lastLetter.dispatchEvent(new MouseEvent('mousemove'));
+    await el.updateComplete;
+
+    const tooltip = el.shadowRoot?.querySelector(
+      'alpha-bar-tooltip'
+    ) as AlphaBarTooltip;
+    expect(tooltip).to.exist;
+
+    // Should be positioned after next tick, but not off-screen
+    await aTimeout(0);
+    expect(tooltip.getBoundingClientRect().right).to.be.lessThan(
+      window.innerWidth
+    );
   });
 });


### PR DESCRIPTION
The letters in the alphabet filter bar currently provide no visual feedback when hovered, making for a rather stale-feeling UI.

This PR brings the hover interaction closer to that of legacy search, darkening the background of the hovered letter and providing a tooltip with the number of results for that letter.