### PR TITLE
WEBDEV-5707 Allow info popups to be toggled by tapping info icon

### DIFF
--- a/src/tiles/grid/account-tile.ts
+++ b/src/tiles/grid/account-tile.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, TemplateResult } from 'lit';
+import { css, html, LitElement, nothing, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { TileModel } from '../../models';
 
@@ -12,9 +12,12 @@ export class AccountTile extends LitElement {
 
   @property({ type: String }) baseImageUrl?: string;
 
+  @property({ type: Boolean }) showInfoButton = false;
+
   render() {
     return html`
       <div class="container">
+        ${this.infoButtonTemplate}
         <div class="tile-details">
           <div class="item-info">
             ${this.getAvatarTemplate} ${this.getTitleTemplate}
@@ -57,6 +60,24 @@ export class AccountTile extends LitElement {
       .commentCount=${this.model?.commentCount}
     >
     </tile-stats>`;
+  }
+
+  private get infoButtonTemplate(): TemplateResult | typeof nothing {
+    // &#9432; is an information icon
+    return this.showInfoButton
+      ? html`<button class="info-button" @click=${this.infoButtonPressed}>
+          &#128712;
+        </button>`
+      : nothing;
+  }
+
+  private infoButtonPressed(e: PointerEvent) {
+    e.preventDefault();
+    const event = new CustomEvent<{ x: number; y: number }>(
+      'infoButtonPressed',
+      { detail: { x: e.clientX, y: e.clientY } }
+    );
+    this.dispatchEvent(event);
   }
 
   /**

--- a/src/tiles/grid/account-tile.ts
+++ b/src/tiles/grid/account-tile.ts
@@ -66,7 +66,7 @@ export class AccountTile extends LitElement {
     // &#9432; is an information icon
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
-          &#128712;
+          &#9432;
           <span class="sr-only">More info</span>
         </button>`
       : nothing;

--- a/src/tiles/grid/account-tile.ts
+++ b/src/tiles/grid/account-tile.ts
@@ -67,6 +67,7 @@ export class AccountTile extends LitElement {
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
           &#128712;
+          <span class="sr-only">More info</span>
         </button>`
       : nothing;
   }

--- a/src/tiles/grid/collection-tile.ts
+++ b/src/tiles/grid/collection-tile.ts
@@ -86,6 +86,7 @@ export class CollectionTile extends LitElement {
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
           &#128712;
+          <span class="sr-only">More info</span>
         </button>`
       : nothing;
   }

--- a/src/tiles/grid/collection-tile.ts
+++ b/src/tiles/grid/collection-tile.ts
@@ -1,4 +1,11 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { collectionIcon } from '../../assets/img/icons/mediatype/collection';
 import type { TileModel } from '../../models';
@@ -12,9 +19,12 @@ export class CollectionTile extends LitElement {
 
   @property({ type: String }) baseImageUrl?: string;
 
+  @property({ type: Boolean }) showInfoButton = false;
+
   render() {
     return html`
       <div class="container">
+        ${this.infoButtonTemplate}
         <div class="tile-details">
           <div class="item-info">
             ${this.getImageBlockTemplate} ${this.getTitleTemplate}
@@ -69,6 +79,24 @@ export class CollectionTile extends LitElement {
     return collectionSize
       ? html`<span id="item-size">${formatUnitSize(collectionSize, 1)}</span>`
       : ``;
+  }
+
+  private get infoButtonTemplate(): TemplateResult | typeof nothing {
+    // &#9432; is an information icon
+    return this.showInfoButton
+      ? html`<button class="info-button" @click=${this.infoButtonPressed}>
+          &#128712;
+        </button>`
+      : nothing;
+  }
+
+  private infoButtonPressed(e: PointerEvent) {
+    e.preventDefault();
+    const event = new CustomEvent<{ x: number; y: number }>(
+      'infoButtonPressed',
+      { detail: { x: e.clientX, y: e.clientY } }
+    );
+    this.dispatchEvent(event);
   }
 
   static get styles(): CSSResultGroup {

--- a/src/tiles/grid/collection-tile.ts
+++ b/src/tiles/grid/collection-tile.ts
@@ -66,7 +66,7 @@ export class CollectionTile extends LitElement {
   }
 
   private get getItemsTemplate() {
-    const collectionItems = this.model?.itemCount.toLocaleString();
+    const collectionItems = this.model?.itemCount?.toLocaleString();
 
     return html`<span id="item-count"
       >${collectionItems} item${Number(collectionItems) !== 1 ? 's' : ''}</span

--- a/src/tiles/grid/collection-tile.ts
+++ b/src/tiles/grid/collection-tile.ts
@@ -85,7 +85,7 @@ export class CollectionTile extends LitElement {
     // &#9432; is an information icon
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
-          &#128712;
+          &#9432;
           <span class="sr-only">More info</span>
         </button>`
       : nothing;

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -133,6 +133,7 @@ export class ItemTile extends LitElement {
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
           &#128712;
+          <span class="sr-only">More info</span>
         </button>`
       : nothing;
   }

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -31,11 +31,14 @@ export class ItemTile extends LitElement {
 
   @property({ type: Object }) sortParam?: SortParam;
 
+  @property({ type: Boolean }) showInfoButton = false;
+
   render() {
     const itemTitle = this.model?.title;
 
     return html`
       <div class="container">
+        ${this.infoButtonTemplate}
         <div class="tile-details">
           <div class="item-info">
             ${this.imageBlockTemplate}
@@ -96,8 +99,6 @@ export class ItemTile extends LitElement {
 
   private get sortedDateInfoTemplate() {
     let sortedValue;
-
-    // console.log('model: ', this.model)
     switch (this.sortParam?.field) {
       case 'date':
         sortedValue = { field: 'published', value: this.model?.datePublished };
@@ -125,6 +126,15 @@ export class ItemTile extends LitElement {
         </span>
       </div>
     `;
+  }
+
+  private get infoButtonTemplate(): TemplateResult | typeof nothing {
+    // &#9432; is an information icon
+    return this.showInfoButton
+      ? html`<button class="info-button" @click=${this.infoButtonPressed}>
+          &#128712;
+        </button>`
+      : nothing;
   }
 
   private get textSnippetsTemplate(): TemplateResult | typeof nothing {
@@ -156,6 +166,15 @@ export class ItemTile extends LitElement {
 
   private get hasSnippets(): boolean {
     return !!this.model?.snippets?.length;
+  }
+
+  private infoButtonPressed(e: PointerEvent): void {
+    e.preventDefault();
+    const event = new CustomEvent<{ x: number; y: number }>(
+      'infoButtonPressed',
+      { detail: { x: e.clientX, y: e.clientY } }
+    );
+    this.dispatchEvent(event);
   }
 
   /**

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -132,7 +132,7 @@ export class ItemTile extends LitElement {
     // &#9432; is an information icon
     return this.showInfoButton
       ? html`<button class="info-button" @click=${this.infoButtonPressed}>
-          &#128712;
+          &#9432;
           <span class="sr-only">More info</span>
         </button>`
       : nothing;

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -97,6 +97,25 @@ export const baseTileStyles = css`
     text-decoration: underline;
   }
 
+  .info-button {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    margin: -1px 0;
+    padding: 0;
+    border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: transparent;
+    color: white;
+    font-size: 2.5rem;
+    line-height: 1;
+    text-shadow: black 1px 1px 4px;
+    aspect-ratio: 1 / 1;
+    z-index: 1;
+  }
+
   .hidden {
     display: none;
   }

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -119,4 +119,18 @@ export const baseTileStyles = css`
   .hidden {
     display: none;
   }
+
+  .sr-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    clip: rect(1px, 1px, 1px, 1px) !important;
+    -webkit-clip-path: inset(50%) !important;
+    clip-path: inset(50%) !important;
+  }
 `;

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -101,17 +101,20 @@ export const baseTileStyles = css`
     position: absolute;
     right: 10px;
     top: 10px;
-    margin: -1px 0;
+    margin: 0;
     padding: 0;
     border: none;
+    border-radius: 50%;
     display: flex;
     justify-content: center;
     align-items: center;
-    background: transparent;
+    background: rgba(220, 220, 220, 0.5);
     color: white;
-    font-size: 2.5rem;
+    font-size: 2rem;
+    font-weight: bold;
     line-height: 1;
-    text-shadow: black 1px 1px 4px;
+    text-shadow: black 1px 1px 3px;
+    overflow: visible;
     aspect-ratio: 1 / 1;
     z-index: 1;
   }

--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -38,6 +38,11 @@ export interface HoverPaneProviderInterface {
   getHoverPaneProps(): HoverPaneProperties;
 }
 
+export interface ToggleHoverPaneOptions {
+  coords: { x: number; y: number };
+  enableTouchBackdrop?: boolean;
+}
+
 /**
  * An interface for interacting with hover pane controllers (e.g.,
  * to retrieve their current hover pane template).
@@ -56,7 +61,7 @@ export interface HoverPaneControllerInterface extends ReactiveController {
    * subsequently be hidden and removed. If the hover pane is already fading
    * out or hidden, it will fade back in and be shown.
    */
-  toggleHoverPane(coords: { x: number; y: number }): void;
+  toggleHoverPane(options: ToggleHoverPaneOptions): void;
 }
 
 const clamp = (val: number, min = -Infinity, max = Infinity) =>
@@ -131,6 +136,12 @@ export class HoverPaneController implements HoverPaneControllerInterface {
   /** The timer ID for recognizing a long press event */
   private longPressTimer?: number;
 
+  /**
+   * Whether the touch backdrop should currently be rendered irrespective of other touch
+   * interactions being enabled.
+   */
+  private forceTouchBackdrop: boolean = false;
+
   /** A record of the last mouse position on the host element, for positioning the hover pane */
   private lastPointerClientPos = { x: 0, y: 0 };
 
@@ -182,11 +193,13 @@ export class HoverPaneController implements HoverPaneControllerInterface {
   }
 
   /** @inheritdoc */
-  toggleHoverPane(coords: { x: number; y: number }): void {
+  toggleHoverPane(options: ToggleHoverPaneOptions): void {
     if (this.hoverPaneState === 'shown') {
       this.fadeOutHoverPane();
+      this.forceTouchBackdrop = false;
     } else {
-      this.lastPointerClientPos = coords;
+      this.lastPointerClientPos = options.coords;
+      this.forceTouchBackdrop = options.enableTouchBackdrop ?? false;
       this.showHoverPane();
     }
   }
@@ -199,7 +212,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
    * affect the state of the hover pane (e.g., fading it back in).
    */
   private get touchBackdropTemplate(): HTMLTemplateResult | typeof nothing {
-    return this.isTouchEnabled && this.enableLongPress
+    return this.showTouchBackdrop
       ? html`<div
           id="touch-backdrop"
           @touchstart=${this.handleBackdropInteraction}
@@ -211,6 +224,12 @@ export class HoverPaneController implements HoverPaneControllerInterface {
           @mouseleave=${(e: MouseEvent) => e.stopPropagation()}
         ></div>`
       : nothing;
+  }
+
+  private get showTouchBackdrop(): boolean {
+    return (
+      (this.isTouchEnabled && this.enableLongPress) || this.forceTouchBackdrop
+    );
   }
 
   /** Whether to use the mobile layout */

--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -49,6 +49,14 @@ export interface HoverPaneControllerInterface extends ReactiveController {
    * pane should not currently be rendered.
    */
   getTemplate(): HTMLTemplateResult | typeof nothing;
+
+  /**
+   * Requests to manually toggle the state of the hover pane.
+   * If the hover pane is already shown, it will begin fading out and then
+   * subsequently be hidden and removed. If the hover pane is already fading
+   * out or hidden, it will fade back in and be shown.
+   */
+  toggleHoverPane(coords: { x: number; y: number }): void;
 }
 
 const clamp = (val: number, min = -Infinity, max = Infinity) =>
@@ -171,6 +179,16 @@ export class HoverPaneController implements HoverPaneControllerInterface {
             .collectionNameCache=${this.hoverPaneProps?.collectionNameCache}
           ></tile-hover-pane>`
       : nothing;
+  }
+
+  /** @inheritdoc */
+  toggleHoverPane(coords: { x: number; y: number }): void {
+    if (this.hoverPaneState === 'shown') {
+      this.fadeOutHoverPane();
+    } else {
+      this.lastPointerClientPos = coords;
+      this.showHoverPane();
+    }
   }
 
   /**

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -199,7 +199,10 @@ export class TileDispatcher
   private tileInfoButtonPressed(
     e: CustomEvent<{ x: number; y: number }>
   ): void {
-    this.hoverPaneController?.toggleHoverPane(e.detail);
+    this.hoverPaneController?.toggleHoverPane({
+      coords: e.detail,
+      enableTouchBackdrop: true,
+    });
   }
 
   private get tile() {

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -148,6 +148,10 @@ export class TileDispatcher
     );
   }
 
+  private get isHoverEnabled(): boolean {
+    return window.matchMedia('(hover: hover)').matches;
+  }
+
   /** @inheritdoc */
   getHoverPane(): TileHoverPane | undefined {
     return this.hoverPane;
@@ -192,6 +196,12 @@ export class TileDispatcher
     }
   }
 
+  private tileInfoButtonPressed(
+    e: CustomEvent<{ x: number; y: number }>
+  ): void {
+    this.hoverPaneController?.toggleHoverPane(e.detail);
+  }
+
   private get tile() {
     const {
       model,
@@ -213,6 +223,8 @@ export class TileDispatcher
               .baseImageUrl=${this.baseImageUrl}
               .currentWidth=${currentWidth}
               .currentHeight=${currentHeight}
+              ?showInfoButton=${!this.isHoverEnabled}
+              @infoButtonPressed=${this.tileInfoButtonPressed}
             >
             </collection-tile>`;
           case 'account':
@@ -221,6 +233,8 @@ export class TileDispatcher
               .baseImageUrl=${this.baseImageUrl}
               .currentWidth=${currentWidth}
               .currentHeight=${currentHeight}
+              ?showInfoButton=${!this.isHoverEnabled}
+              @infoButtonPressed=${this.tileInfoButtonPressed}
             >
             </account-tile>`;
           default:
@@ -232,6 +246,8 @@ export class TileDispatcher
               .baseImageUrl=${this.baseImageUrl}
               .sortParam=${sortParam}
               .loggedIn=${this.loggedIn}
+              ?showInfoButton=${!this.isHoverEnabled}
+              @infoButtonPressed=${this.tileInfoButtonPressed}
             >
             </item-tile>`;
         }

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -337,7 +337,7 @@ export class TileDispatcher
         height: 100vh;
         top: 0;
         left: 0;
-        z-index: 1;
+        z-index: 2;
         background: transparent;
       }
 

--- a/test/tiles/grid/account-tile.test.ts
+++ b/test/tiles/grid/account-tile.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-duplicates */
 import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
 import { html } from 'lit';
 import type { AccountTile } from '../../../src/tiles/grid/account-tile';
 
@@ -91,5 +92,31 @@ describe('Account Tile', () => {
       ?.querySelectorAll('.col')[3]
       .querySelector('.status-text');
     expect(reviewCounts?.textContent).contains(3);
+  });
+
+  it('should render info button when showInfoButton flag is set', async () => {
+    const el = await fixture<AccountTile>(html`
+      <account-tile ?showInfoButton=${true}> </account-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector('.info-button');
+
+    expect(infoButton).to.exist;
+  });
+
+  it('should dispatch event when info button tapped', async () => {
+    const infoButtonSpy = sinon.spy();
+    const el = await fixture<AccountTile>(html`
+      <account-tile ?showInfoButton=${true} @infoButtonPressed=${infoButtonSpy}>
+      </account-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector(
+      '.info-button'
+    ) as HTMLButtonElement;
+    infoButton.click();
+    await el.updateComplete;
+
+    expect(infoButtonSpy.callCount).to.equal(1);
   });
 });

--- a/test/tiles/grid/collection-tile.test.ts
+++ b/test/tiles/grid/collection-tile.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-duplicates */
 import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
 import { html } from 'lit';
 import type { CollectionTile } from '../../../src/tiles/grid/collection-tile';
 
@@ -81,5 +82,34 @@ describe('Collection Tile', () => {
     expect(itemMediaType).to.exist;
     expect(itemCount).to.exist;
     expect(itemSize).to.exist;
+  });
+
+  it('should render info button when showInfoButton flag is set', async () => {
+    const el = await fixture<CollectionTile>(html`
+      <collection-tile ?showInfoButton=${true}> </collection-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector('.info-button');
+
+    expect(infoButton).to.exist;
+  });
+
+  it('should dispatch event when info button tapped', async () => {
+    const infoButtonSpy = sinon.spy();
+    const el = await fixture<CollectionTile>(html`
+      <collection-tile
+        ?showInfoButton=${true}
+        @infoButtonPressed=${infoButtonSpy}
+      >
+      </collection-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector(
+      '.info-button'
+    ) as HTMLButtonElement;
+    infoButton.click();
+    await el.updateComplete;
+
+    expect(infoButtonSpy.callCount).to.equal(1);
   });
 });

--- a/test/tiles/grid/item-tile.test.ts
+++ b/test/tiles/grid/item-tile.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-duplicates */
 import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
 import { html } from 'lit';
 import type { ItemTile } from '../../../src/tiles/grid/item-tile';
 
@@ -171,6 +172,32 @@ describe('Item Tile', () => {
     const snippetBlock = el.shadowRoot?.querySelector('text-snippet-block');
 
     expect(snippetBlock).to.not.exist;
+  });
+
+  it('should render info button when showInfoButton flag is set', async () => {
+    const el = await fixture<ItemTile>(html`
+      <item-tile ?showInfoButton=${true}> </item-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector('.info-button');
+
+    expect(infoButton).to.exist;
+  });
+
+  it('should dispatch event when info button tapped', async () => {
+    const infoButtonSpy = sinon.spy();
+    const el = await fixture<ItemTile>(html`
+      <item-tile ?showInfoButton=${true} @infoButtonPressed=${infoButtonSpy}>
+      </item-tile>
+    `);
+
+    const infoButton = el.shadowRoot?.querySelector(
+      '.info-button'
+    ) as HTMLButtonElement;
+    infoButton.click();
+    await el.updateComplete;
+
+    expect(infoButtonSpy.callCount).to.equal(1);
   });
 
   it('should render with volume/issue view', async () => {

--- a/test/tiles/tile-dispatcher.test.ts
+++ b/test/tiles/tile-dispatcher.test.ts
@@ -1,0 +1,122 @@
+import { aTimeout, expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { TileDispatcher } from '../../src/tiles/tile-dispatcher';
+
+import '../../src/tiles/tile-dispatcher';
+import type { ItemTile } from '../../src/tiles/grid/item-tile';
+import { TileHoverPane } from '../../src/tiles/hover/tile-hover-pane';
+import type { HoverPaneProperties } from '../../src/tiles/hover/hover-pane-controller';
+
+describe('Tile Dispatcher', () => {
+  it('should render item-tile for grid mode by default', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .tileDisplayMode=${'grid'}
+        .model=${{ mediatype: 'texts' }}
+      >
+      </tile-dispatcher>
+    `);
+
+    const itemTile = el.shadowRoot?.querySelector('item-tile');
+    expect(itemTile).to.exist;
+  });
+
+  it('should render collection-tile for grid mode and collection mediatype', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .tileDisplayMode=${'grid'}
+        .model=${{ mediatype: 'collection' }}
+      >
+      </tile-dispatcher>
+    `);
+
+    const collectionTile = el.shadowRoot?.querySelector('collection-tile');
+    expect(collectionTile).to.exist;
+  });
+
+  it('should render account-tile for grid mode and account mediatype', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .tileDisplayMode=${'grid'}
+        .model=${{ mediatype: 'account' }}
+      >
+      </tile-dispatcher>
+    `);
+
+    const accountTile = el.shadowRoot?.querySelector('account-tile');
+    expect(accountTile).to.exist;
+  });
+
+  it('should render tile-list for extended list mode', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher .tileDisplayMode=${'list-detail'} .model=${{}}>
+      </tile-dispatcher>
+    `);
+
+    const listTile = el.shadowRoot?.querySelector('tile-list');
+    expect(listTile).to.exist;
+  });
+
+  it('should render tile-list-compact for compact list mode', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher .tileDisplayMode=${'list-compact'} .model=${{}}>
+      </tile-dispatcher>
+    `);
+
+    const compactListTile = el.shadowRoot?.querySelector('tile-list-compact');
+    expect(compactListTile).to.exist;
+  });
+
+  it('should return hover pane props', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher .model=${{ identifier: 'foo' }}> </tile-dispatcher>
+    `);
+
+    expect(el.getHoverPaneProps()).to.satisfy(
+      (props: HoverPaneProperties) => props?.model?.identifier === 'foo'
+    );
+  });
+
+  describe('Hover pane info button behavior', () => {
+    let oldMatchMedia: typeof window.matchMedia;
+
+    before(() => {
+      oldMatchMedia = window.matchMedia;
+      // Pretend that there is no hover-capable input device
+      window.matchMedia = () => ({ matches: false } as MediaQueryList);
+    });
+
+    after(() => {
+      window.matchMedia = oldMatchMedia;
+    });
+
+    it('should toggle hover pane when tile info button is pressed', async () => {
+      const el = await fixture<TileDispatcher>(html`
+        <tile-dispatcher
+          .tileDisplayMode=${'grid'}
+          .model=${{ mediatype: 'texts' }}
+          .enableHoverPane=${true}
+        >
+        </tile-dispatcher>
+      `);
+
+      const itemTile = el.shadowRoot?.querySelector('item-tile') as ItemTile;
+      expect(itemTile).to.exist;
+
+      const infoButton = itemTile.shadowRoot?.querySelector(
+        '.info-button'
+      ) as HTMLButtonElement;
+      expect(infoButton).to.exist;
+
+      infoButton.click();
+      await aTimeout(500);
+      await el.updateComplete;
+      expect(el.getHoverPane()).to.be.instanceOf(TileHoverPane);
+
+      infoButton.click();
+      await aTimeout(500);
+      await el.updateComplete;
+      expect(el.getHoverPane()).not.to.exist;
+    });
+  });
+});


### PR DESCRIPTION
The info popups that appear when hovering over grid tiles are currently not available to mobile/touch device users that don't have hover capability. To present an alternative for these users, this PR adds a small info icon in the corner of grid tiles when hover interactions are not available, which the user can tap to show/hide the info popup for that tile.