### PR TITLE
WEBDEV-5733 Fix date line positioning on grid tiles

### DIFF
--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -51,7 +51,7 @@ export const baseTileStyles = css`
   .archivist-since {
     display: flex;
     justify-content: left;
-    align-items: flex-end; /* Important to start text from bottom */
+    align-items: flex-start;
     padding: 0 5px;
   }
 


### PR DESCRIPTION
Makes sure the date line appears at the top of its available space (like the creator line), not the bottom.