### PR TITLE
WEBDEV-5737 Use PPS-provided href for tile links if available

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1340,6 +1340,7 @@ export class CollectionBrowser
         dateReviewed: result.reviewdate?.value,
         description: result.description?.values.join('\n'),
         favCount: result.num_favorites?.value ?? 0,
+        href: result.__href__?.value,
         identifier: result.identifier,
         issue: result.issue?.value,
         itemCount: result.item_count?.value ?? 0,

--- a/src/models.ts
+++ b/src/models.ts
@@ -16,6 +16,7 @@ export interface TileModel {
   dateReviewed?: Date; // Date reviewed (user-created) most recent review [from: reviewdate]
   description?: string;
   favCount: number;
+  href?: string;
   identifier: string;
   issue?: string;
   itemCount: number;

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -140,7 +140,15 @@ export class TileList extends LitElement {
     if (!this.model?.title) {
       return nothing;
     }
-    return html` ${this.detailsLink(this.model.identifier, this.model.title)} `;
+
+    if (this.model?.href) {
+      // If the model has a server-specified href, use it
+      return html`<a href="${this.baseNavigationUrl}${this.model.href}"
+        >${this.model.title ?? this.model.identifier}</a
+      >`;
+    }
+    // Otherwise construct a details link using the identifier
+    return this.detailsLink(this.model.identifier, this.model.title);
   }
 
   private get itemLineTemplate() {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -141,14 +141,13 @@ export class TileList extends LitElement {
       return nothing;
     }
 
-    if (this.model?.href) {
-      // If the model has a server-specified href, use it
-      return html`<a href="${this.baseNavigationUrl}${this.model.href}"
-        >${this.model.title ?? this.model.identifier}</a
-      >`;
-    }
+    // If the model has a server-specified href, use it
     // Otherwise construct a details link using the identifier
-    return this.detailsLink(this.model.identifier, this.model.title);
+    return this.model?.href
+      ? html`<a href="${this.baseNavigationUrl}${this.model.href}"
+          >${this.model.title ?? this.model.identifier}</a
+        >`
+      : this.detailsLink(this.model.identifier, this.model.title);
   }
 
   private get itemLineTemplate() {

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -122,7 +122,7 @@ export class TileDispatcher
   private get linkTileTemplate() {
     return html`
       <a
-        href="${this.baseNavigationUrl}/details/${this.model?.identifier}"
+        href="${this.linkTileHref}"
         title=${this.shouldPrepareHoverPane
           ? nothing // Don't show title tooltips when we have the tile info popups
           : ifDefined(this.model?.title)}
@@ -134,6 +134,15 @@ export class TileDispatcher
         ${this.tile}
       </a>
     `;
+  }
+
+  private get linkTileHref() {
+    // Use the server-specified href if available.
+    // Otherwise, construct a details page URL from the item identifier.
+    return (
+      `${this.baseNavigationUrl}${this.model?.href}` ??
+      `${this.baseNavigationUrl}/details/${this.model?.identifier}`
+    );
   }
 
   /**

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -139,10 +139,9 @@ export class TileDispatcher
   private get linkTileHref() {
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
-    return (
-      `${this.baseNavigationUrl}${this.model?.href}` ??
-      `${this.baseNavigationUrl}/details/${this.model?.identifier}`
-    );
+    return this.model?.href
+      ? `${this.baseNavigationUrl}${this.model?.href}`
+      : `${this.baseNavigationUrl}/details/${this.model?.identifier}`;
   }
 
   /**


### PR DESCRIPTION
On legacy search, FTS tiles include the current search query as a parameter when linking to items' details pages. This allows the theatre on the details page to perform its search-inside function when loaded. However, currently on the beta search page, FTS results don’t include this parameter.

The PPS provides an href field on FTS hits that includes the full link target, including the query string. Moreover, this field is intended to hold other contextual information (like start/end times) for TV/Radio hits when those are eventually enabled. So where possible, we should be making use of this field instead of constructing details page links manually.

This PR ensures that for FTS results (and other future result types), the tile links use the PPS href field that includes additional context params.