### PR TITLE
WEBDEV-5746 Remove special language facet handling as PPS no longer requires it

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -41,7 +41,6 @@ import {
   LendingFacetKey,
   suppressedCollections,
 } from './models';
-import type { LanguageCodeHandlerInterface } from './language-code-handler/language-code-handler';
 import './collection-facets/more-facets-content';
 import './collection-facets/facets-template';
 import './collection-facets/facet-tombstone-row';
@@ -94,9 +93,6 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object, attribute: false })
   analyticsHandler?: AnalyticsManagerInterface;
-
-  @property({ type: Object, attribute: false })
-  languageCodeHandler?: LanguageCodeHandlerInterface;
 
   @property({ type: Object, attribute: false })
   collectionNameCache?: CollectionNameCacheInterface;
@@ -292,14 +288,6 @@ export class CollectionFacets extends LitElement {
         const buckets: FacetBucket[] = Object.entries(selectedFacets).map(
           ([value, facetData]) => {
             let displayText: string = value;
-            // for selected languages, we store the language code instead of the
-            // display name, so look up the name from the mapping
-            if (option === 'language') {
-              displayText =
-                this.languageCodeHandler?.getLanguageNameFromCodeString(
-                  value
-                ) ?? value;
-            }
             // for lending facets, convert the key to a readable format
             if (option === 'lending') {
               displayText =
@@ -351,18 +339,8 @@ export class CollectionFacets extends LitElement {
       }
 
       const facetBuckets: FacetBucket[] = castedBuckets.map(bucket => {
-        let bucketKey = bucket.key;
+        const bucketKey = bucket.key;
         let displayText = `${bucket.key}`;
-        // for languages, we need to search by language code instead of the
-        // display name, which is what we get from the search engine result
-        if (option === 'language') {
-          // const languageCodeKey = languageToCodeMap[bucket.key];
-          bucketKey =
-            this.languageCodeHandler?.getCodeStringFromLanguageName(
-              `${bucket.key}`
-            ) ?? bucket.key;
-          // bucketKey = languageCodeKey ?? bucket.key;
-        }
         // for lending facets, convert the bucket key to a readable format
         if (option === 'lending') {
           displayText =
@@ -499,7 +477,6 @@ export class CollectionFacets extends LitElement {
         .searchService=${this.searchService}
         .searchType=${this.searchType}
         .collectionNameCache=${this.collectionNameCache}
-        .languageCodeHandler=${this.languageCodeHandler}
         .selectedFacets=${this.selectedFacets}
         .sortedBy=${sortedBy}
         @facetsChanged=${(e: CustomEvent) => {

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -30,7 +30,6 @@ import {
   facetTitles,
   suppressedCollections,
 } from '../models';
-import type { LanguageCodeHandlerInterface } from '../language-code-handler/language-code-handler';
 import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
 import './more-facets-pagination';
 import './facets-template';
@@ -57,9 +56,6 @@ export class MoreFacetsContent extends LitElement {
 
   @property({ type: Object })
   collectionNameCache?: CollectionNameCacheInterface;
-
-  @property({ type: Object })
-  languageCodeHandler?: LanguageCodeHandlerInterface;
 
   @property({ type: Object }) selectedFacets?: SelectedFacets;
 
@@ -222,15 +218,7 @@ export class MoreFacetsContent extends LitElement {
 
         const buckets: FacetBucket[] = Object.entries(selectedFacets).map(
           ([value, data]) => {
-            let displayText: string = value;
-            // for selected languages, we store the language code instead of the
-            // display name, so look up the name from the mapping
-            if (option === 'language') {
-              displayText =
-                this.languageCodeHandler?.getLanguageNameFromCodeString(
-                  value
-                ) ?? value;
-            }
+            const displayText: string = value;
             return {
               displayText,
               key: value,
@@ -294,15 +282,7 @@ export class MoreFacetsContent extends LitElement {
       );
 
       const facetBucket: FacetBucket[] = bucketsMaxSix.map(bucket => {
-        let bucketKey = bucket.key;
-        // for languages, we need to search by language code instead of the
-        // display name, which is what we get from the search engine result
-        if (option === 'language') {
-          bucketKey =
-            this.languageCodeHandler?.getCodeStringFromLanguageName(
-              `${bucket.key}`
-            ) ?? bucket.key;
-        }
+        const bucketKey = bucket.key;
         return {
           displayText: `${bucket.key}`,
           key: `${bucketKey}`,

--- a/test/collection-facets.test.ts
+++ b/test/collection-facets.test.ts
@@ -11,10 +11,6 @@ import type { CollectionFacets } from '../src/collection-facets';
 import '@internetarchive/modal-manager';
 import '../src/collection-facets';
 import type { FacetOption, SelectedFacets } from '../src/models';
-import {
-  LanguageCodeHandler,
-  LanguageCodeHandlerInterface,
-} from '../src/language-code-handler/language-code-handler';
 import { MockAnalyticsHandler } from './mocks/mock-analytics-handler';
 
 describe('Collection Facets', () => {
@@ -257,69 +253,6 @@ describe('Collection Facets', () => {
       ?.item(0)
       .querySelector(`a[href='/details/foo']`);
     expect(collectionLink).to.exist;
-  });
-
-  it('renders language facets with their human-readable names', async () => {
-    const el = await fixture<CollectionFacets>(
-      html`<collection-facets></collection-facets>`
-    );
-
-    const languageCodeHandler: LanguageCodeHandlerInterface =
-      new LanguageCodeHandler();
-
-    const aggs: Record<string, Aggregation> = {
-      language: new Aggregation({
-        buckets: [
-          {
-            key: 'English',
-            doc_count: 3,
-          },
-        ],
-      }),
-    };
-
-    el.languageCodeHandler = languageCodeHandler;
-    el.aggregations = aggs;
-    await el.updateComplete;
-
-    const facetsTemplate = el.shadowRoot?.querySelector('facets-template');
-    const languageTitle =
-      facetsTemplate?.shadowRoot?.querySelector('.facet-title');
-    expect(languageTitle?.textContent?.trim()).to.equal('English');
-  });
-
-  it('renders selected/negative language facets with human-readable names', async () => {
-    const el = await fixture<CollectionFacets>(
-      html`<collection-facets></collection-facets>`
-    );
-
-    const languageCodeHandler: LanguageCodeHandlerInterface =
-      new LanguageCodeHandler();
-
-    const selectedFacets: SelectedFacets = {
-      subject: {},
-      lending: {},
-      mediatype: {},
-      language: {
-        en: {
-          key: 'en',
-          count: 5,
-          state: 'selected',
-        },
-      },
-      creator: {},
-      collection: {},
-      year: {},
-    };
-
-    el.languageCodeHandler = languageCodeHandler;
-    el.selectedFacets = selectedFacets;
-    await el.updateComplete;
-
-    const facetsTemplate = el.shadowRoot?.querySelector('facets-template');
-    const languageTitle =
-      facetsTemplate?.shadowRoot?.querySelector('.facet-title');
-    expect(languageTitle?.textContent?.trim()).to.equal('English');
   });
 
   it('renders lending facets with human-readable names', async () => {


### PR DESCRIPTION
Way back when collection browser's results were backed by advancedsearch.php, there were some extra steps required to correctly filter on language facets. These entailed converting between human-readable language names and one or more corresponding language codes.

However, the PPS facet model requires that the facet keys passed in as filters exactly match those that were provided as aggregations, so it is no longer correct to perform these language name/code conversions. The PPS should be providing human-readable language names for facet buckets, and should accept those same human-readable language names as filters.

So, this PR removes the language code conversions from the facet logic, both for rendering facets and for applying filters. Two tests checking that language facets had these conversions applied have also been removed as they are no longer correct or useful.