### PR TITLE
WEBDEV-5759 Remove special handling from etree item titles

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1325,11 +1325,7 @@ export class CollectionBrowser
         snippets: result.highlight?.values ?? [],
         source: result.source?.value,
         subjects: result.subject?.values ?? [],
-        title: this.etreeTitle(
-          result.title?.value,
-          result.mediatype?.value,
-          result.collection?.values
-        ),
+        title: result.title?.value ?? '',
         volume: result.volume?.value,
         viewCount: result.downloads?.value ?? 0,
         weeklyViewCount: result.week?.value,
@@ -1411,28 +1407,6 @@ export class CollectionBrowser
   private refreshLetterCounts(): void {
     this.prefixFilterCountMap = {};
     this.updatePrefixFiltersForCurrentSort();
-  }
-
-  /*
-   * Convert etree titles
-   * "[Creator] Live at [Place] on [Date]" => "[Date]: [Place]"
-   *
-   * Todo: Check collection(s) for etree, need to get as array.
-   * Current search-service only returns first collection as string.
-   */
-  private etreeTitle(
-    title: string | undefined,
-    mediatype: string | undefined,
-    collections: string[] | undefined
-  ): string {
-    if (mediatype === 'etree' || collections?.includes('etree')) {
-      const regex = /^(.*) Live at (.*) on (\d\d\d\d-\d\d-\d\d)$/;
-      const newTitle = title?.replace(regex, '$3: $2');
-      if (newTitle) {
-        return `${newTitle}`;
-      }
-    }
-    return title ?? '';
   }
 
   /**


### PR DESCRIPTION
Currently, items with etree mediatype are given special handling by the tile renderer. Their item titles, which are generally of the form `[Creator] Live at [Place] on [Date]`, are converted to the more concise `[Date]: [Place]` on the tiles.

For consistency’s sake going forward, we are removing this special handling so that the titles shown on the tiles always match the actual item’s title. Our new tiles have more space available for long titles than the legacy search ones, making it less important that they be short.