### PR TITLE
WEBDEV-5763 Allow links on extended & compact list view to use visited styling

### DIFF
--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -66,7 +66,7 @@ export class TileListCompact extends LitElement {
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
     return this.model?.href
-      ? `${this.baseNavigationUrl}${this.model?.href}`
+      ? `${this.baseNavigationUrl}${this.model.href}`
       : `${this.baseNavigationUrl}/details/${this.model?.identifier}`;
   }
 

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -41,7 +41,9 @@ export class TileListCompact extends LitElement {
           .loggedIn=${this.loggedIn}
         >
         </image-block>
-        <div id="title">${DOMPurify.sanitize(this.model?.title ?? '')}</div>
+        <a href=${this.href} id="title"
+          >${DOMPurify.sanitize(this.model?.title ?? '')}</a
+        >
         <div id="creator">
           ${this.model?.mediatype === 'account'
             ? accountLabel(this.model?.dateAdded)
@@ -58,6 +60,14 @@ export class TileListCompact extends LitElement {
         <div id="views">${formatCount(this.views ?? 0, this.formatSize)}</div>
       </div>
     `;
+  }
+
+  private get href(): string {
+    // Use the server-specified href if available.
+    // Otherwise, construct a details page URL from the item identifier.
+    return this.model?.href
+      ? `${this.baseNavigationUrl}${this.model?.href}`
+      : `${this.baseNavigationUrl}/details/${this.model?.identifier}`;
   }
 
   /*
@@ -145,8 +155,11 @@ export class TileListCompact extends LitElement {
       }
 
       #title {
-        color: #4b64ff;
         text-decoration: none;
+      }
+
+      #title:link {
+        color: var(--ia-theme-link-color, #4b64ff);
       }
 
       #title,

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -453,6 +453,9 @@ export class TileList extends LitElement {
 
       div a {
         text-decoration: none;
+      }
+
+      div a:link {
         color: var(--ia-theme-link-color, #4b64ff);
       }
 

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -37,6 +37,20 @@ describe('List Tile Compact', () => {
     expect(creator).to.exist;
   });
 
+  it('should render title link with model href if provided', async () => {
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .baseNavigationUrl=${''}
+        .model=${{ href: '/foo/bar' }}
+      ></tile-list-compact>
+    `);
+
+    const title = el.shadowRoot?.querySelector('#title');
+
+    expect(title).to.exist;
+    expect(title?.getAttribute('href')).to.equal('/foo/bar');
+  });
+
   it('should render weekly views when sorting by week', async () => {
     const el = await fixture<TileListCompact>(html`
       <tile-list-compact

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -41,7 +41,7 @@ describe('List Tile Compact', () => {
     const el = await fixture<TileListCompact>(html`
       <tile-list-compact
         .baseNavigationUrl=${''}
-        .model=${{ href: '/foo/bar' }}
+        .model=${{ title: 'foo', href: '/foo/bar' }}
       ></tile-list-compact>
     `);
 

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -37,6 +37,20 @@ describe('List Tile', () => {
     expect(bottomLine).to.exist;
   });
 
+  it('should render title link with model href if provided', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .baseNavigationUrl=${''}
+        .model=${{ title: 'foo', href: '/foo/bar' }}
+      ></tile-list>
+    `);
+
+    const title = el.shadowRoot?.querySelector('#title > a');
+
+    expect(title).to.exist;
+    expect(title?.getAttribute('href')).to.equal('/foo/bar');
+  });
+
   it('should render with creator element but not dates', async () => {
     const el = await fixture<TileList>(html`
       <tile-list .model=${{ creators: ['someone'] }}></tile-list>


### PR DESCRIPTION
To support users who rely on knowing which links they have visited from a search page, we should allow links to present their “visited” styling rather than forcing the blue color in all cases.