### PR TITLE
WEBDEV-5767 Provide proper error message when queries fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.3",
+    "@internetarchive/collection-name-cache": "^0.2.5-alpha.1",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.3",
+    "@internetarchive/search-service": "^0.4.5-alpha.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -182,6 +182,8 @@ export class CollectionBrowser
 
   @state() private totalResults?: number;
 
+  @state() private queryErrorMessage?: string;
+
   @state() private mobileView = false;
 
   @state() private mobileFacetsVisible = false;
@@ -324,6 +326,10 @@ export class CollectionBrowser
     ) {
       this.placeholderType = 'null-result';
     }
+
+    if (this.queryErrorMessage) {
+      this.placeholderType = 'query-error';
+    }
   }
 
   private get emptyPlaceholderTemplate() {
@@ -331,6 +337,8 @@ export class CollectionBrowser
       <empty-placeholder
         .placeholderType=${this.placeholderType}
         ?isMobileView=${this.mobileView}
+        .detailMessage=${this.queryErrorMessage ?? ''}
+        .baseNavigationUrl=${this.baseNavigationUrl}
       ></empty-placeholder>
       ${this.infiniteScrollerTemplate}
     `;
@@ -806,6 +814,7 @@ export class CollectionBrowser
     this.pageFetchesInProgress = {};
     this.endOfDataReached = false;
     this.pagesToRender = this.initialPageNumber;
+    this.queryErrorMessage = undefined;
 
     // Reset the infinite scroller's item count, so that it
     // shows tile placeholders until the new query's results load in
@@ -1194,7 +1203,19 @@ export class CollectionBrowser
     );
     const success = searchResponse?.success;
 
-    if (!success) return;
+    if (!success) {
+      const errorMsg = searchResponse?.error?.message;
+      const detailMsg = searchResponse?.error?.details?.message;
+
+      this.queryErrorMessage = `${errorMsg ?? ''}${
+        detailMsg ? `; ${detailMsg}` : ''
+      }`;
+
+      if (!this.queryErrorMessage)
+        this.queryErrorMessage = 'Missing or malformed response from backend';
+
+      return;
+    }
 
     this.totalResults = success.response.totalResults;
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1211,8 +1211,11 @@ export class CollectionBrowser
         detailMsg ? `; ${detailMsg}` : ''
       }`;
 
-      if (!this.queryErrorMessage)
+      if (!this.queryErrorMessage) {
         this.queryErrorMessage = 'Missing or malformed response from backend';
+        // @ts-ignore: Property 'Sentry' does not exist on type 'Window & typeof globalThis'
+        window?.Sentry?.captureMessage?.(this.queryErrorMessage, 'error');
+      }
 
       return;
     }

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -57,7 +57,7 @@ export class EmptyPlaceholder extends LitElement {
     `;
   }
 
-  private get queryErrorTemplate() {
+  private get queryErrorTemplate(): TemplateResult {
     return html`
       <h2 class="title">
         The search engine encountered an error, which might be related to your

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -5,12 +5,18 @@ import { choose } from 'lit/directives/choose.js';
 import emptyQueryIcon from './assets/img/icons/empty-query';
 import nullResultIcon from './assets/img/icons/null-result';
 
-export type PlaceholderType = 'empty-query' | 'null-result' | null;
+export type PlaceholderType =
+  | 'empty-query'
+  | 'null-result'
+  | 'query-error'
+  | null;
 @customElement('empty-placeholder')
 export class EmptyPlaceholder extends LitElement {
   @property({ type: String }) placeholderType: PlaceholderType = null;
 
   @property({ type: Boolean }) isMobileView?: false;
+
+  @property({ type: String }) detailMessage?: string = '';
 
   render() {
     return this.placeholderType ? html`${this.placeholderTemplate}` : nothing;
@@ -26,6 +32,7 @@ export class EmptyPlaceholder extends LitElement {
         ${choose(this.placeholderType, [
           ['empty-query', () => this.emptyQueryTemplate],
           ['null-result', () => this.nullResultTemplate],
+          ['query-error', () => this.queryErrorTemplate],
         ])}
       </div>
     `;
@@ -50,11 +57,37 @@ export class EmptyPlaceholder extends LitElement {
     `;
   }
 
+  private get queryErrorTemplate() {
+    return html`
+      <h2 class="title">
+        The search engine encountered an error, which might be related to your
+        search query.
+        <a
+          href="https://help.archive.org/help/search-building-powerful-complex-queries/"
+        >
+          Tips for constructing search queries.
+        </a>
+      </h2>
+      <div>${nullResultIcon}</div>
+      <p class="error-details">Error details: ${this.detailMessage}</p>
+    `;
+  }
+
   static get styles(): CSSResultGroup {
     return css`
       :host {
         text-align: center;
         width: 100%;
+      }
+
+      a {
+        text-decoration: none;
+      }
+      a:link {
+        color: var(--ia-theme-link-color, #4b64ff);
+      }
+      a:hover {
+        text-decoration: underline;
       }
 
       .placeholder {
@@ -64,15 +97,21 @@ export class EmptyPlaceholder extends LitElement {
       .desktop svg {
         max-height: 40rem;
       }
-      .desktop .title {
+      .desktop .title,
+      .desktop .error-details {
         margin: 4rem 0;
       }
 
       .mobile svg {
         max-height: 20rem;
       }
-      .mobile .title {
+      .mobile .title,
+      .mobile .error-details {
         margin: 2rem 0.5;
+      }
+
+      .error-details {
+        font-size: 1.2rem;
       }
     `;
   }

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -1,4 +1,11 @@
-import { css, html, LitElement, CSSResultGroup, nothing } from 'lit';
+import {
+  css,
+  html,
+  LitElement,
+  CSSResultGroup,
+  nothing,
+  TemplateResult,
+} from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
 
@@ -22,7 +29,7 @@ export class EmptyPlaceholder extends LitElement {
     return this.placeholderType ? html`${this.placeholderTemplate}` : nothing;
   }
 
-  private get placeholderTemplate() {
+  private get placeholderTemplate(): TemplateResult {
     return html`
       <div
         class="placeholder ${this.placeholderType} ${this.isMobileView
@@ -38,7 +45,7 @@ export class EmptyPlaceholder extends LitElement {
     `;
   }
 
-  private get emptyQueryTemplate() {
+  private get emptyQueryTemplate(): TemplateResult {
     return html`
       <h2 class="title">
         To begin searching, enter a search term in the box above and hit "Go".
@@ -47,7 +54,7 @@ export class EmptyPlaceholder extends LitElement {
     `;
   }
 
-  private get nullResultTemplate() {
+  private get nullResultTemplate(): TemplateResult {
     return html`
       <h2 class="title">
         Your search did not match any items in the Archive. Try different

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.3.tgz"
-  integrity sha512-CDfMqz4oh3f2BrvnyqD2Y9Y4sOs3fY3F5jI4xMyrdg/z3U0CRYpIQ8NSJFxbJ4EtNvaemlCbrRu5QLHdDYWZLg==
+"@internetarchive/collection-name-cache@^0.2.5-alpha.1":
+  version "0.2.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.5-alpha.1.tgz#d051ff927a5fe23af9b03fca3713451c1e97f393"
+  integrity sha512-Uc4ulthVsRbOl3RTNsGJ/iQLouHK2v0DuDv8z9rPjh6Bk8/Uh2HSgCYYSqmf8F8SmrM23f5wFuBOo2eh4s9pkA==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.3"
+    "@internetarchive/search-service" "^0.4.5-alpha.1"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.npmjs.org/@internetarchive/search-service/-/search-service-0.4.3.tgz"
-  integrity sha512-ANL8MdiZtw+0+tFvlHK96cRRceswH8aPZGdDNBVhlT3sYZsmF7tz41nkBBSxj4pzd/vAA05AQsgMWODCwSnUAQ==
+"@internetarchive/search-service@^0.4.5-alpha.1":
+  version "0.4.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.5-alpha.1.tgz#2a4cedbba9e98c8262253a7b743ea2d677053147"
+  integrity sha512-3DW5dZg4NKUHhQhPIRDDi3J996tF7w/JWxJ+WPMtcSfeu4To4SQmI8ichWIi6o4F83S4q9JIHOHKxj8J22+zZg==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
When a query results in an error on the backend, currently we either treat it the same as "0 results" or otherwise fail to act on it. This PR adds a third type of placeholder item for handling errors, with a link to the search help page and details about the error.