### PR TITLE
v0.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.5-alpha.1",
+    "@internetarchive/collection-name-cache": "^0.2.5",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -31,7 +31,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.5-alpha.1",
+    "@internetarchive/search-service": "^0.4.5",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.5-alpha.1":
-  version "0.2.5-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.5-alpha.1.tgz#d051ff927a5fe23af9b03fca3713451c1e97f393"
-  integrity sha512-Uc4ulthVsRbOl3RTNsGJ/iQLouHK2v0DuDv8z9rPjh6Bk8/Uh2HSgCYYSqmf8F8SmrM23f5wFuBOo2eh4s9pkA==
+"@internetarchive/collection-name-cache@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.5.tgz#8c6a0b6988ff8e9041b75737deeb51e8dfd8ba15"
+  integrity sha512-Fn/+Bld7XPyx4s2b5qt7cYB304ruAKdqOEHkmxEDwQReClPwdZio5Uzu68fuPgK4QqgffrJyWuS3dgsJ9NecQw==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.5-alpha.1"
+    "@internetarchive/search-service" "^0.4.5"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -191,10 +191,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.5-alpha.1":
-  version "0.4.5-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.5-alpha.1.tgz#2a4cedbba9e98c8262253a7b743ea2d677053147"
-  integrity sha512-3DW5dZg4NKUHhQhPIRDDi3J996tF7w/JWxJ+WPMtcSfeu4To4SQmI8ichWIi6o4F83S4q9JIHOHKxj8J22+zZg==
+"@internetarchive/search-service@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.5.tgz#a50b6d0ffa5362b7b88b30bc16a7aaf62495f4f9"
+  integrity sha512-lnBptf+4cPh4yWsXLmaZn22/rH1pXKP1pV+sY4P2JUcb4ZzERD2rnMKRPXa0306/ckj5wPXP14XPCFGyrUFD3g==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Also upgrades `search-service` and `collection-name-cache` dependences from their alpha tags to their latest versions.