### PR TITLE
Remove feedback widget from date picker

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1534,7 +1534,10 @@ export class CollectionBrowser
       flex: 1;
       position: relative;
       border-left: 1px solid rgb(232, 232, 232);
+      border-right: 1px solid rgb(232, 232, 232);
       padding-left: 1rem;
+      padding-right: 1rem;
+      background: #fff;
     }
 
     .mobile #right-column {

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -126,16 +126,7 @@ export class CollectionFacets extends LitElement {
         (this.fullYearsHistogramAggregation || this.fullYearAggregationLoading)
           ? html`
               <div class="facet-group">
-                <h1>
-                  Year Published
-                  <feature-feedback
-                    featureIdentifier="HistogramDatePicker"
-                    prompt="What do you think of the Histogram Date Picker?"
-                    .featureFeedbackService=${this.featureFeedbackService}
-                    .resizeObserver=${this.resizeObserver}
-                    .recaptchaManager=${this.recaptchaManager}
-                  ></feature-feedback>
-                </h1>
+                <h1>Year Published</h1>
                 ${this.histogramTemplate}
               </div>
             `


### PR DESCRIPTION
The date picker no longer needs a feedback widget. This PR removes it.