### PR TITLE
WEBDEV-5785 Prevent query mismatch via uid param (and trim queries)

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1252,8 +1252,8 @@ export class CollectionBrowser
    * no longer relevant.
    */
   private get pageFetchQueryKey(): string {
-    const sortField = this.sortParam?.field ?? '';
-    const sortDirection = this.sortParam?.direction ?? '';
+    const sortField = this.sortParam?.field ?? 'none';
+    const sortDirection = this.sortParam?.direction ?? 'none';
     return `${this.fullQuery}-${this.searchType}-${sortField}-${sortDirection}`;
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -345,7 +345,7 @@ export class CollectionBrowser
 
   private setPlaceholderType() {
     this.placeholderType = null;
-    if (!this.baseQuery) {
+    if (!this.baseQuery?.trim()) {
       this.placeholderType = 'empty-query';
     }
 
@@ -1008,7 +1008,7 @@ export class CollectionBrowser
   /** The base query joined with any title/creator letter filters */
   private get filteredQuery(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let filteredQuery = this.baseQuery;
+    let filteredQuery = this.baseQuery.trim();
 
     const { sortFilterQueries } = this;
     if (sortFilterQueries) {
@@ -1021,7 +1021,7 @@ export class CollectionBrowser
   /** The full query, including year facets and date range clauses */
   private get fullQuery(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let fullQuery = this.baseQuery;
+    let fullQuery = this.baseQuery.trim();
 
     const { facetQuery, dateRangeQueryClause, sortFilterQueries } = this;
 
@@ -1040,7 +1040,7 @@ export class CollectionBrowser
   /** The full query without any title/creator letter filters */
   private get fullQueryWithoutAlphaFilters(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let fullQuery = this.baseQuery;
+    let fullQuery = this.baseQuery.trim();
 
     const { facetQuery, dateRangeQueryClause } = this;
 
@@ -1190,11 +1190,17 @@ export class CollectionBrowser
     this.facetsLoading = false;
 
     if (!success) {
-      // @ts-ignore: Property 'Sentry' does not exist on type 'Window & typeof globalThis'
-      window?.Sentry?.captureMessage?.(
-        'Missing or malformed facet response from backend',
-        'error'
-      );
+      const errorMsg = searchResponse?.error?.message;
+      const detailMsg = searchResponse?.error?.details?.message;
+
+      if (!errorMsg && !detailMsg) {
+        // @ts-ignore: Property 'Sentry' does not exist on type 'Window & typeof globalThis'
+        window?.Sentry?.captureMessage?.(
+          'Missing or malformed facet response from backend',
+          'error'
+        );
+      }
+
       return;
     }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1008,7 +1008,7 @@ export class CollectionBrowser
   /** The base query joined with any title/creator letter filters */
   private get filteredQuery(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let filteredQuery = this.baseQuery;
+    let filteredQuery = this.baseQuery.trim();
 
     const { sortFilterQueries } = this;
     if (sortFilterQueries) {
@@ -1040,7 +1040,7 @@ export class CollectionBrowser
   /** The full query without any title/creator letter filters */
   private get fullQueryWithoutAlphaFilters(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let fullQuery = this.baseQuery;
+    let fullQuery = this.baseQuery.trim();
 
     const { facetQuery, dateRangeQueryClause } = this;
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1008,14 +1008,14 @@ export class CollectionBrowser
   /** The base query joined with any title/creator letter filters */
   private get filteredQuery(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let filteredQuery = this.baseQuery.trim();
+    let filteredQuery = this.baseQuery;
 
     const { sortFilterQueries } = this;
     if (sortFilterQueries) {
       filteredQuery += ` AND ${sortFilterQueries}`;
     }
 
-    return filteredQuery;
+    return filteredQuery.trim();
   }
 
   /** The full query, including year facets and date range clauses */
@@ -1034,13 +1034,13 @@ export class CollectionBrowser
     if (sortFilterQueries) {
       fullQuery += ` AND ${sortFilterQueries}`;
     }
-    return fullQuery;
+    return fullQuery.trim();
   }
 
   /** The full query without any title/creator letter filters */
   private get fullQueryWithoutAlphaFilters(): string | undefined {
     if (!this.baseQuery) return undefined;
-    let fullQuery = this.baseQuery.trim();
+    let fullQuery = this.baseQuery;
 
     const { facetQuery, dateRangeQueryClause } = this;
 
@@ -1050,7 +1050,7 @@ export class CollectionBrowser
     if (dateRangeQueryClause) {
       fullQuery += ` AND ${dateRangeQueryClause}`;
     }
-    return fullQuery;
+    return fullQuery.trim();
   }
 
   /**
@@ -1066,7 +1066,7 @@ export class CollectionBrowser
     )) {
       facetClauses.push(this.buildFacetClause(facetName, facetValues));
     }
-    return this.joinFacetClauses(facetClauses);
+    return this.joinFacetClauses(facetClauses)?.trim();
   }
 
   /**
@@ -1178,17 +1178,37 @@ export class CollectionBrowser
       aggregationsSize: 10,
       // Note: we don't need an aggregations param to fetch the default aggregations from the PPS.
       // The default aggregations for the search_results page type should be what we need here.
+      uid: this.facetFetchQueryKey,
     };
 
     this.facetsLoading = true;
-    const results = await this.searchService?.search(params, this.searchType);
+    const searchResponse = await this.searchService?.search(
+      params,
+      this.searchType
+    );
+    const success = searchResponse?.success;
     this.facetsLoading = false;
 
-    this.aggregations = results?.success?.response.aggregations;
+    if (!success) {
+      // @ts-ignore: Property 'Sentry' does not exist on type 'Window & typeof globalThis'
+      window?.Sentry?.captureMessage?.(
+        'Missing or malformed facet response from backend',
+        'error'
+      );
+      return;
+    }
+
+    // This is checking to see if the query has changed since the data was fetched.
+    // If so, we just want to discard this set of aggregations because they are
+    // likely no longer valid for the newer query.
+    const returnedUid = (success.request.clientParameters as any).uid;
+    const queryChangedSinceFetch = returnedUid !== this.facetFetchQueryKey;
+    if (queryChangedSinceFetch) return;
+
+    this.aggregations = success?.response.aggregations;
 
     this.fullYearsHistogramAggregation =
-      results?.success?.response?.aggregations?.year_histogram ??
-      results?.success?.response?.aggregations?.['year-histogram']; // Temp fix until PPS FTS key is fixed to use underscore
+      success?.response?.aggregations?.year_histogram;
   }
 
   private scrollToPage(pageNumber: number): Promise<void> {
@@ -1225,8 +1245,18 @@ export class CollectionBrowser
    * This lets us keep track of queries so we don't persist data that's
    * no longer relevant.
    */
-  private get pageFetchQueryKey() {
-    return `${this.fullQuery}-${this.searchType}-${this.sortParam?.field}-${this.sortParam?.direction}`;
+  private get pageFetchQueryKey(): string {
+    const sortField = this.sortParam?.field ?? '';
+    const sortDirection = this.sortParam?.direction ?? '';
+    return `${this.fullQuery}-${this.searchType}-${sortField}-${sortDirection}`;
+  }
+
+  /**
+   * Similar to `pageFetchQueryKey` above, but excludes sort fields since they
+   * are not relevant in determining aggregation queries.
+   */
+  private get facetFetchQueryKey(): string {
+    return `${this.fullQuery}-${this.searchType}`;
   }
 
   // this maps the query to the pages being fetched for that query
@@ -1256,6 +1286,7 @@ export class CollectionBrowser
       sort: sortParams,
       filters: this.filterMap,
       aggregations: { omit: true },
+      uid: this.pageFetchQueryKey,
     };
     const searchResponse = await this.searchService?.search(
       params,
@@ -1280,35 +1311,14 @@ export class CollectionBrowser
       return;
     }
 
-    this.totalResults = success.response.totalResults;
-
-    // this is checking to see if the query has changed since the data was fetched
-    // if so, we just want to discard the data since there should be a new query
-    // right behind it
-    const searchQuery = success.request.clientParameters.user_query;
-    const searchSort = success.request.clientParameters.sort;
-    let sortChanged = false;
-    if (!searchSort || searchSort.length === 0) {
-      // if we went from no sort to sort, the sort has changed
-      if (this.sortParam) {
-        sortChanged = true;
-      }
-    } else {
-      // check if the sort has changed
-      for (const sortType of searchSort) {
-        const [field, direction] = sortType.split(':');
-        if (
-          field !== this.sortParam?.field ||
-          direction !== this.sortParam?.direction
-        ) {
-          sortChanged = true;
-          break;
-        }
-      }
-    }
-    const queryChangedSinceFetch =
-      searchQuery !== this.filteredQuery || sortChanged;
+    // This is checking to see if the query has changed since the data was fetched.
+    // If so, we just want to discard the data since there should be a new query
+    // right behind it.
+    const returnedUid = (success.request.clientParameters as any).uid;
+    const queryChangedSinceFetch = returnedUid !== this.pageFetchQueryKey;
     if (queryChangedSinceFetch) return;
+
+    this.totalResults = success.response.totalResults;
 
     const { results } = success.response;
     if (results && results.length > 0) {

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -5,11 +5,12 @@ import {
   SearchResponse,
   SearchServiceError,
 } from '@internetarchive/search-service';
+import { SearchServiceErrorType } from '@internetarchive/search-service/dist/src/search-service-error';
 
-export const mockSuccessSingleResult: Result<
+export const getMockSuccessSingleResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -39,12 +40,12 @@ export const mockSuccessSingleResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessWithYearHistogramAggs: Result<
+export const getMockSuccessWithYearHistogramAggs: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -84,12 +85,12 @@ export const mockSuccessWithYearHistogramAggs: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessLoggedInResult: Result<
+export const getMockSuccessLoggedInResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -121,12 +122,12 @@ export const mockSuccessLoggedInResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessNoPreviewResult: Result<
+export const getMockSuccessNoPreviewResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -156,12 +157,12 @@ export const mockSuccessNoPreviewResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessLoggedInAndNoPreviewResult: Result<
+export const getMockSuccessLoggedInAndNoPreviewResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -191,12 +192,12 @@ export const mockSuccessLoggedInAndNoPreviewResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessFirstTitleResult: Result<
+export const getMockSuccessFirstTitleResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -230,12 +231,12 @@ export const mockSuccessFirstTitleResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessFirstCreatorResult: Result<
+export const getMockSuccessFirstCreatorResult: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -269,7 +270,7 @@ export const mockSuccessFirstCreatorResult: Result<
       query_time: 0,
     },
   },
-};
+});
 
 export const getMockSuccessSingleResultWithSort: (
   resultsSpy: Function
@@ -308,10 +309,10 @@ export const getMockSuccessSingleResultWithSort: (
   },
 });
 
-export const mockSuccessMultipleResults: Result<
+export const getMockSuccessMultipleResults: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -347,12 +348,12 @@ export const mockSuccessMultipleResults: Result<
       query_time: 0,
     },
   },
-};
+});
 
-export const mockSuccessMultiLineDescription: Result<
+export const getMockSuccessMultiLineDescription: () => Result<
   SearchResponse,
   SearchServiceError
-> = {
+> = () => ({
   success: {
     request: {
       clientParameters: {
@@ -383,4 +384,18 @@ export const mockSuccessMultiLineDescription: Result<
       query_time: 0,
     },
   },
-};
+});
+
+export const getMockErrorResult: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  error: new SearchServiceError(SearchServiceErrorType.networkError, 'foo', {
+    message: 'bar',
+  }),
+});
+
+export const getMockMalformedResult: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({});

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -73,11 +73,11 @@ export class MockSearchService implements SearchServiceInterface {
     }
 
     const resultFn: () => Result<SearchResponse, SearchServiceError> =
-      responses[this.searchParams?.query] ?? getMockSuccessMultipleResults;
+      responses[this.searchParams.query] ?? getMockSuccessMultipleResults;
     let result = resultFn();
 
     // with-sort query has special handling
-    if (this.searchParams?.query === 'with-sort') {
+    if (this.searchParams.query === 'with-sort') {
       result = getMockSuccessSingleResultWithSort(this.resultsSpy);
     }
 

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -7,17 +7,35 @@ import type {
   SearchType,
 } from '@internetarchive/search-service';
 import {
-  mockSuccessSingleResult,
-  mockSuccessMultipleResults,
+  getMockSuccessSingleResult,
+  getMockSuccessMultipleResults,
   getMockSuccessSingleResultWithSort,
-  mockSuccessLoggedInResult,
-  mockSuccessNoPreviewResult,
-  mockSuccessLoggedInAndNoPreviewResult,
-  mockSuccessWithYearHistogramAggs,
-  mockSuccessMultiLineDescription,
-  mockSuccessFirstTitleResult,
-  mockSuccessFirstCreatorResult,
+  getMockSuccessLoggedInResult,
+  getMockSuccessNoPreviewResult,
+  getMockSuccessLoggedInAndNoPreviewResult,
+  getMockSuccessWithYearHistogramAggs,
+  getMockSuccessMultiLineDescription,
+  getMockSuccessFirstTitleResult,
+  getMockSuccessFirstCreatorResult,
+  getMockErrorResult,
+  getMockMalformedResult,
 } from './mock-search-responses';
+
+const responses: Record<
+  string,
+  () => Result<SearchResponse, SearchServiceError>
+> = {
+  'single-result': getMockSuccessSingleResult,
+  years: getMockSuccessWithYearHistogramAggs,
+  'multi-line-description': getMockSuccessMultiLineDescription,
+  loggedin: getMockSuccessLoggedInResult,
+  'no-preview': getMockSuccessNoPreviewResult,
+  'loggedin-no-preview': getMockSuccessLoggedInAndNoPreviewResult,
+  'first-title': getMockSuccessFirstTitleResult,
+  'first-creator': getMockSuccessFirstCreatorResult,
+  error: getMockErrorResult,
+  malformed: getMockMalformedResult,
+};
 
 export class MockSearchService implements SearchServiceInterface {
   searchParams?: SearchParams;
@@ -26,10 +44,17 @@ export class MockSearchService implements SearchServiceInterface {
 
   asyncResponse: boolean;
 
+  asyncResponseDelay: number;
+
   resultsSpy: Function;
 
-  constructor({ asyncResponse = false, resultsSpy = () => {} } = {}) {
+  constructor({
+    asyncResponse = false,
+    asyncResponseDelay = 0,
+    resultsSpy = () => {},
+  } = {}) {
     this.asyncResponse = asyncResponse;
+    this.asyncResponseDelay = asyncResponseDelay;
     this.resultsSpy = resultsSpy;
   }
 
@@ -43,31 +68,24 @@ export class MockSearchService implements SearchServiceInterface {
     if (this.asyncResponse) {
       // Add an artificial 1-tick delay
       await new Promise(res => {
-        setTimeout(res, 0);
+        setTimeout(res, this.asyncResponseDelay);
       });
     }
 
-    switch (this.searchParams?.query) {
-      case 'single-result':
-        return mockSuccessSingleResult;
-      case 'years':
-        return mockSuccessWithYearHistogramAggs;
-      case 'multi-line-description':
-        return mockSuccessMultiLineDescription;
-      case 'loggedin':
-        return mockSuccessLoggedInResult;
-      case 'no-preview':
-        return mockSuccessNoPreviewResult;
-      case 'loggedin-no-preview':
-        return mockSuccessLoggedInAndNoPreviewResult;
-      case 'first-title':
-        return mockSuccessFirstTitleResult;
-      case 'first-creator':
-        return mockSuccessFirstCreatorResult;
-      case 'with-sort':
-        return getMockSuccessSingleResultWithSort(this.resultsSpy);
-      default:
-        return mockSuccessMultipleResults;
+    const resultFn: () => Result<SearchResponse, SearchServiceError> =
+      responses[this.searchParams?.query] ?? getMockSuccessMultipleResults;
+    let result = resultFn();
+
+    // with-sort query has special handling
+    if (this.searchParams?.query === 'with-sort') {
+      result = getMockSuccessSingleResultWithSort(this.resultsSpy);
     }
+
+    // Apply any uid param from the request
+    if (result.success) {
+      (result.success.request.clientParameters as any).uid = params.uid;
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
Search queries with leading or trailing spaces are currently being sent to the backend as-is. Although the backend trims the queries anyway, the response we get back consequently has a different query string than the one we sent. Currently, the tile renderer treats this query mismatch by ignoring what it assumes is an obsolete response to an old query, rendering nothing.

While the simple fix is just to trim the query, we can go one step further and mitigate future “query mismatch” issues of this nature by sending a `uid` parameter with each search request to the PPS. This parameter is not processed and should always be returned as-is on the response. If we maintain a consistent `uid` for queries that should be considered the same, then we can use this as a much better signal of response-freshness than matching query strings (which the server may alter, as in this case).

This PR updates the page & facet fetch logic to use the `uid` parameter as described above, and ensures that queries are trimmed before sending to the PPS.