### PR TITLE
WEBDEV-5796 Ensure sort direction icon svg is properly sized on all supported browsers

### DIFF
--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -851,6 +851,11 @@ export class SortFilterBar
       height: 14px;
     }
 
+    .sort-direction-icon > svg {
+      height: -webkit-fit-content;
+      height: fit-content;
+    }
+
     #date-sort-selector,
     #view-sort-selector {
       position: absolute;

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -852,8 +852,7 @@ export class SortFilterBar
     }
 
     .sort-direction-icon > svg {
-      height: -webkit-fit-content;
-      height: fit-content;
+      flex: 1;
     }
 
     #date-sort-selector,


### PR DESCRIPTION
For some browsers (esp. on Mac/iOS), the sort direction icons are rendering at their intrinsic size rather than fitting within the available space, causing them to not be visible. This PR restricts the height of those icon svgs to that of the sort bar, preventing the issue.