### PR TITLE
WEBDEV-5800 Fix 3-line truncation of list tiles in Safari

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -305,7 +305,7 @@ export class TileList extends LitElement {
     if (!text) return nothing;
     return html`
       <div id=${ifDefined(id)} class="metadata">
-        ${this.labelTemplate(label)} ${text}
+        <p class="inline-wrap">${this.labelTemplate(label)} ${text}</p>
       </div>
     `;
   }
@@ -601,6 +601,10 @@ export class TileList extends LitElement {
       #dates-line,
       #views-line {
         flex-wrap: wrap;
+      }
+
+      .inline-wrap {
+        display: inline;
       }
     `;
   }

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -506,6 +506,11 @@ export class TileList extends LitElement {
         line-height: 20px;
       }
 
+      .inline-wrap {
+        display: inline;
+        margin: 0;
+      }
+
       #description,
       #creator,
       #topics,
@@ -601,10 +606,6 @@ export class TileList extends LitElement {
       #dates-line,
       #views-line {
         flex-wrap: wrap;
-      }
-
-      .inline-wrap {
-        display: inline;
       }
     `;
   }

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -305,7 +305,7 @@ export class TileList extends LitElement {
     if (!text) return nothing;
     return html`
       <div id=${ifDefined(id)} class="metadata">
-        <p class="inline-wrap">${this.labelTemplate(label)} ${text}</p>
+        ${this.labelTemplate(label)} ${text}
       </div>
     `;
   }
@@ -504,10 +504,6 @@ export class TileList extends LitElement {
 
       .metadata {
         line-height: 20px;
-      }
-
-      .inline-wrap {
-        display: inline;
       }
 
       #description,

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -364,15 +364,6 @@ export class TileList extends LitElement {
   }
 
   protected updated(changed: PropertyValues): void {
-    // tsc has trouble recognizing that NodeLists are iterable
-    // so we any-cast the result to allow iterating it.
-    const wrappers = this.querySelectorAll('.inline-wrap') as any;
-    if (wrappers) {
-      for (const wrapper of wrappers) {
-        (wrapper as HTMLElement).style.margin = '0';
-      }
-    }
-
     if (changed.has('model')) {
       this.fetchCollectionNames();
     }
@@ -531,6 +522,12 @@ export class TileList extends LitElement {
         word-break: break-word;
         -webkit-line-clamp: 3; /* number of lines to show */
         line-clamp: 3;
+
+        /*
+         * Safari doesn't always respect the line-clamping rules above,
+         * so we add this to ensure these fields still get truncated
+         */
+        max-height: 60px;
       }
 
       #collections {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -364,6 +364,15 @@ export class TileList extends LitElement {
   }
 
   protected updated(changed: PropertyValues): void {
+    // tsc has trouble recognizing that NodeLists are iterable
+    // so we any-cast the result to allow iterating it.
+    const wrappers = this.querySelectorAll('.inline-wrap') as any;
+    if (wrappers) {
+      for (const wrapper of wrappers) {
+        (wrapper as HTMLElement).style.margin = '0';
+      }
+    }
+
     if (changed.has('model')) {
       this.fetchCollectionNames();
     }
@@ -508,7 +517,6 @@ export class TileList extends LitElement {
 
       .inline-wrap {
         display: inline;
-        margin: 0;
       }
 
       #description,

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -27,6 +27,13 @@ export class TextSnippetBlock extends LitElement {
     `;
   }
 
+  updated() {
+    const wrapper = this.shadowRoot?.querySelector(
+      '.inline-wrap'
+    ) as HTMLParagraphElement;
+    if (wrapper) wrapper.style.margin = '0';
+  }
+
   /**
    * An array of HTML templates derived from the snippets, with ellipses inserted
    * at the beginning, end, and between each pair of snippets.
@@ -118,7 +125,6 @@ export class TextSnippetBlock extends LitElement {
 
       .inline-wrap {
         display: inline;
-        margin: 0;
       }
 
       mark {

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -21,7 +21,7 @@ export class TextSnippetBlock extends LitElement {
     return html`
       <div class="container">
         <div class="snippet-view ${this.viewSize}">
-          <p class="inline-wrap">${this.ellipsisJoinedSnippets}</p>
+          ${this.ellipsisJoinedSnippets}
         </div>
       </div>
     `;
@@ -120,10 +120,6 @@ export class TextSnippetBlock extends LitElement {
          * so we add this to ensure these fields still get truncated.
          */
         max-height: 6rem;
-      }
-
-      .inline-wrap {
-        display: inline;
       }
 
       mark {

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -21,7 +21,7 @@ export class TextSnippetBlock extends LitElement {
     return html`
       <div class="container">
         <div class="snippet-view ${this.viewSize}">
-          ${this.ellipsisJoinedSnippets}
+          <p class="inline-wrap">${this.ellipsisJoinedSnippets}</p>
         </div>
       </div>
     `;
@@ -114,6 +114,10 @@ export class TextSnippetBlock extends LitElement {
         padding-left: 15px;
         font-size: 1.4rem;
         line-height: 2rem;
+      }
+
+      .inline-wrap {
+        display: inline;
       }
 
       mark {

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -27,13 +27,6 @@ export class TextSnippetBlock extends LitElement {
     `;
   }
 
-  updated() {
-    const wrapper = this.shadowRoot?.querySelector(
-      '.inline-wrap'
-    ) as HTMLParagraphElement;
-    if (wrapper) wrapper.style.margin = '0';
-  }
-
   /**
    * An array of HTML templates derived from the snippets, with ellipses inserted
    * at the beginning, end, and between each pair of snippets.
@@ -121,6 +114,12 @@ export class TextSnippetBlock extends LitElement {
         padding-left: 15px;
         font-size: 1.4rem;
         line-height: 2rem;
+
+        /*
+         * Safari doesn't always respect the line-clamping rules,
+         * so we add this to ensure these fields still get truncated.
+         */
+        max-height: 6rem;
       }
 
       .inline-wrap {

--- a/src/tiles/text-snippet-block.ts
+++ b/src/tiles/text-snippet-block.ts
@@ -118,6 +118,7 @@ export class TextSnippetBlock extends LitElement {
 
       .inline-wrap {
         display: inline;
+        margin: 0;
       }
 
       mark {

--- a/test/text-snippet-block.test.ts
+++ b/test/text-snippet-block.test.ts
@@ -30,7 +30,7 @@ describe('TextSnippetBlock component', () => {
       html`<text-snippet-block .snippets=${snippets}></text-snippet-block>`
     );
 
-    const container = el.shadowRoot?.querySelector('.snippet-view > p');
+    const container = el.shadowRoot?.querySelector('.snippet-view');
 
     // Has the correct number of snippets and highlights
     expect(container?.children.length).to.equal(snippets.length);
@@ -47,7 +47,7 @@ describe('TextSnippetBlock component', () => {
       html`<text-snippet-block .snippets=${snippets}></text-snippet-block>`
     );
 
-    const container = el.shadowRoot?.querySelector('.snippet-view > p');
+    const container = el.shadowRoot?.querySelector('.snippet-view');
 
     // Has the correct number of snippets and highlights
     expect(container?.children.length).to.equal(snippets.length);

--- a/test/text-snippet-block.test.ts
+++ b/test/text-snippet-block.test.ts
@@ -30,7 +30,7 @@ describe('TextSnippetBlock component', () => {
       html`<text-snippet-block .snippets=${snippets}></text-snippet-block>`
     );
 
-    const container = el.shadowRoot?.querySelector('.snippet-view');
+    const container = el.shadowRoot?.querySelector('.snippet-view > p');
 
     // Has the correct number of snippets and highlights
     expect(container?.children.length).to.equal(snippets.length);
@@ -47,7 +47,7 @@ describe('TextSnippetBlock component', () => {
       html`<text-snippet-block .snippets=${snippets}></text-snippet-block>`
     );
 
-    const container = el.shadowRoot?.querySelector('.snippet-view');
+    const container = el.shadowRoot?.querySelector('.snippet-view > p');
 
     // Has the correct number of snippets and highlights
     expect(container?.children.length).to.equal(snippets.length);


### PR DESCRIPTION
Several blocks of metadata on list view tiles (esp. the description and full text snippets) are meant to be truncated after the first 3 lines. While this appears to be working across other browsers, Safari is not truncating them at all, which leads to excessively long walls of text in hover panes.

This PR introduces a wrapper element around these blocks of text that makes Safari truncate them properly.