### PR TITLE
WEBDEV-5804 Correct handling of `sin` param

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.6-alpha.2",
+    "@internetarchive/collection-name-cache": "^0.2.6",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -32,7 +32,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.6-alpha.2",
+    "@internetarchive/search-service": "^0.4.6",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.5",
+    "@internetarchive/collection-name-cache": "^0.2.6-alpha.2",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -32,7 +32,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.5",
+    "@internetarchive/search-service": "^0.4.6-alpha.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -90,10 +90,6 @@ export class AppRoot extends LitElement {
     this.searchQuery = this.baseQueryField.value;
     this.collectionBrowser.searchType = this.searchType;
 
-    // Need to request a search in cases where the search type was previously changed but not the query.
-    // If the query was changed above, this should be a no-op.
-    this.collectionBrowser.requestSearch();
-
     if ((this.currentPage ?? 1) > 1) {
       this.collectionBrowser.goToPage(this.currentPage ?? 1);
     }
@@ -154,7 +150,7 @@ export class AppRoot extends LitElement {
                 id="metadata-search"
                 name="search-type"
                 value="metadata"
-                ?checked=${this.searchType === SearchType.METADATA}
+                .checked=${this.searchType === SearchType.METADATA}
                 @click=${this.searchTypeSelected}
               />
               <label for="metadata-search">Metadata</label>
@@ -165,7 +161,7 @@ export class AppRoot extends LitElement {
                 id="fulltext-search"
                 name="search-type"
                 value="fulltext"
-                ?checked=${this.searchType === SearchType.FULLTEXT}
+                .checked=${this.searchType === SearchType.FULLTEXT}
                 @click=${this.searchTypeSelected}
               />
               <label for="fulltext-search">Full text</label>

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -321,14 +321,6 @@ export class CollectionBrowser
     return false;
   }
 
-  /**
-   * Manually requests to perform a search, which will only be executed if one of
-   * the query, the search type, or the sort has changed.
-   */
-  requestSearch() {
-    this.handleQueryChange();
-  }
-
   render() {
     this.setPlaceholderType();
     return html`

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -679,10 +679,11 @@ export class CollectionBrowser
     }
 
     if (changed.has('baseQuery') || changed.has('searchType')) {
-      // Unless this query/search type update is the result of hitting the back button,
+      // Unless this query/search type update is from the initial page load or the
+      // result of hitting the back button,
       // we need to clear any existing filters since they may no longer be valid for
       // the new set of search results.
-      if (!this.historyPopOccurred) {
+      if (!this.historyPopOccurred && this.initialQueryChangeHappened) {
         // Only clear filters that haven't been simultaneously applied in this update
         this.clearFilters({
           facets: !changed.has('selectedFacets'),

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -29,6 +29,8 @@ import {
   FacetOption,
   facetTitles,
   suppressedCollections,
+  valueFacetSort,
+  defaultFacetSort,
 } from '../models';
 import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
 import './more-facets-pagination';
@@ -86,7 +88,13 @@ export class MoreFacetsContent extends LitElement {
   private facetsPerPage = 35;
 
   updated(changed: PropertyValues) {
-    if (changed.has('facetKey')) {
+    if (
+      changed.has('facetKey') ||
+      changed.has('facetAggregationKey') ||
+      changed.has('query') ||
+      changed.has('searchType') ||
+      changed.has('filterMap')
+    ) {
       this.facetsLoading = true;
       this.pageNumber = 1;
 
@@ -377,20 +385,30 @@ export class MoreFacetsContent extends LitElement {
   }
 
   private get getModalHeaderTemplate(): TemplateResult {
+    const facetSort = defaultFacetSort[this.facetKey as FacetOption];
+    const defaultSwitchSide =
+      facetSort === AggregationSortType.COUNT ? 'left' : 'right';
+
     return html`<span class="sr-only">More facets for:</span>
       <span class="title">
         ${this.facetGroupTitle}
+
         <label class="sort-label">Sort by:</label>
-        <toggle-switch
-          class="sort-toggle"
-          leftValue=${AggregationSortType.COUNT}
-          leftLabel="Count"
-          rightValue=${AggregationSortType.ALPHABETICAL}
-          rightLabel=${this.facetGroupTitle}
-          @change=${(e: CustomEvent<string>) => {
-            this.sortFacetAggregation(Number(e.detail) as AggregationSortType);
-          }}
-        ></toggle-switch>
+        ${this.facetKey
+          ? html`<toggle-switch
+              class="sort-toggle"
+              leftValue=${AggregationSortType.COUNT}
+              leftLabel="Count"
+              rightValue=${valueFacetSort[this.facetKey]}
+              rightLabel=${this.facetGroupTitle}
+              side=${defaultSwitchSide}
+              @change=${(e: CustomEvent<string>) => {
+                this.sortFacetAggregation(
+                  Number(e.detail) as AggregationSortType
+                );
+              }}
+            ></toggle-switch>`
+          : nothing}
       </span>`;
   }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,5 +1,8 @@
 import type { MediaType } from '@internetarchive/field-parsers';
-import type { SortDirection } from '@internetarchive/search-service';
+import {
+  AggregationSortType,
+  SortDirection,
+} from '@internetarchive/search-service';
 
 export interface TileModel {
   averageRating?: number;
@@ -252,6 +255,33 @@ export const facetTitles: Record<FacetOption, string> = {
   creator: 'Creator',
   collection: 'Collection',
   year: 'Year',
+};
+
+/**
+ * The default sort type to use for each facet type
+ */
+export const defaultFacetSort: Record<FacetOption, AggregationSortType> = {
+  subject: AggregationSortType.COUNT,
+  lending: AggregationSortType.COUNT,
+  mediatype: AggregationSortType.COUNT,
+  language: AggregationSortType.COUNT,
+  creator: AggregationSortType.COUNT,
+  collection: AggregationSortType.COUNT,
+  year: AggregationSortType.NUMERIC,
+};
+
+/**
+ * The sort type corresponding to facet bucket values, for each facet type
+ * (i.e., the opposite of "sort by count" for that type).
+ */
+export const valueFacetSort: Record<FacetOption, AggregationSortType> = {
+  subject: AggregationSortType.ALPHABETICAL,
+  lending: AggregationSortType.ALPHABETICAL,
+  mediatype: AggregationSortType.ALPHABETICAL,
+  language: AggregationSortType.ALPHABETICAL,
+  creator: AggregationSortType.ALPHABETICAL,
+  collection: AggregationSortType.ALPHABETICAL,
+  year: AggregationSortType.NUMERIC,
 };
 
 export type LendingFacetKey =

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -233,10 +233,8 @@ export class RestorationStateHandler
       restorationState.baseQuery = legacySearchQuery;
     }
 
-    if (searchInside) {
-      restorationState.searchType =
-        searchInside === 'TXT' ? SearchType.FULLTEXT : SearchType.METADATA;
-    }
+    restorationState.searchType =
+      searchInside === 'TXT' ? SearchType.FULLTEXT : SearchType.METADATA;
 
     if (pageNumber) {
       const parsed = parseInt(pageNumber, 10);

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -234,15 +234,12 @@ export class RestorationStateHandler
     }
 
     switch (searchInside) {
-      case '':
-        restorationState.searchType = SearchType.METADATA;
-        break;
+      // Eventually there will be TV/Radio search types here too.
       case 'TXT':
         restorationState.searchType = SearchType.FULLTEXT;
         break;
       default:
-        // Don't restore a search type.
-        // Eventually there will be TV/Radio search types here too.
+        restorationState.searchType = SearchType.METADATA;
         break;
     }
 

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -233,8 +233,18 @@ export class RestorationStateHandler
       restorationState.baseQuery = legacySearchQuery;
     }
 
-    restorationState.searchType =
-      searchInside === 'TXT' ? SearchType.FULLTEXT : SearchType.METADATA;
+    switch (searchInside) {
+      case '':
+        restorationState.searchType = SearchType.METADATA;
+        break;
+      case 'TXT':
+        restorationState.searchType = SearchType.FULLTEXT;
+        break;
+      default:
+        // Don't restore a search type.
+        // Eventually there will be TV/Radio search types here too.
+        break;
+    }
 
     if (pageNumber) {
       const parsed = parseInt(pageNumber, 10);

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -261,12 +261,12 @@ describe('Collection Browser', () => {
     const searchService = new MockSearchService();
 
     const el = await fixture<CollectionBrowser>(
-      html` <collection-browser
-        .searchService=${searchService}
-        .searchType=${SearchType.METADATA}
-      >
+      html` <collection-browser .searchService=${searchService}>
       </collection-browser>`
     );
+
+    el.searchType = SearchType.METADATA;
+    await el.updateComplete;
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
@@ -300,12 +300,12 @@ describe('Collection Browser', () => {
     const searchService = new MockSearchService();
 
     const el = await fixture<CollectionBrowser>(
-      html` <collection-browser
-        .searchService=${searchService}
-        .searchType=${SearchType.FULLTEXT}
-      >
+      html` <collection-browser .searchService=${searchService}>
       </collection-browser>`
     );
+
+    el.searchType = SearchType.FULLTEXT;
+    await el.updateComplete;
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -279,7 +279,7 @@ describe('Collection Browser', () => {
     ).to.contains('Results');
   });
 
-  it('can request a search when changing search type', async () => {
+  it('can change search type', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser .searchService=${searchService}>
@@ -290,7 +290,6 @@ describe('Collection Browser', () => {
     await el.updateComplete;
 
     el.searchType = SearchType.FULLTEXT;
-    el.requestSearch();
     await el.updateComplete;
     await nextTick();
 

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -15,7 +15,7 @@ describe('Restoration state handler', () => {
     expect(restorationState.baseQuery).to.equal('boop');
   });
 
-  it('should not restore any search type from URL without valid sin', async () => {
+  it('should restore metadata search type from URL without valid sin', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });
 
     const url = new URL(window.location.href);
@@ -23,7 +23,7 @@ describe('Restoration state handler', () => {
     window.history.replaceState({ path: url.href }, '', url.href);
 
     const restorationState = handler.getRestorationState();
-    expect(restorationState.searchType).to.not.exist;
+    expect(restorationState.searchType).to.equal(SearchType.METADATA);
   });
 
   it('should restore metadata search type if sin explicitly empty in URL', async () => {

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -15,7 +15,7 @@ describe('Restoration state handler', () => {
     expect(restorationState.baseQuery).to.equal('boop');
   });
 
-  it('should restore metadata search type from URL without valid sin', async () => {
+  it('should not restore any search type from URL without valid sin', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });
 
     const url = new URL(window.location.href);
@@ -23,7 +23,7 @@ describe('Restoration state handler', () => {
     window.history.replaceState({ path: url.href }, '', url.href);
 
     const restorationState = handler.getRestorationState();
-    expect(restorationState.searchType).to.equal(SearchType.METADATA);
+    expect(restorationState.searchType).to.not.exist;
   });
 
   it('should restore full text search type from URL', async () => {

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -26,6 +26,17 @@ describe('Restoration state handler', () => {
     expect(restorationState.searchType).to.not.exist;
   });
 
+  it('should restore metadata search type if sin explicitly empty in URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?sin=';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.searchType).to.equal(SearchType.METADATA);
+  });
+
   it('should restore full text search type from URL', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.6-alpha.2":
-  version "0.2.6-alpha.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.6-alpha.2.tgz#37a308a2841e81b36983fde40828d242528db9ec"
-  integrity sha512-eOu9iFGJLLbZqgpqarHwkOu1EKZrBI3XUWrlMNTT2XECuko/A4vA4KUkNsAHpeOz3K0Ak/hFNKnzyeTMqNFPJg==
+"@internetarchive/collection-name-cache@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.6.tgz#25a5a2cb2d1d4636066e9954514ae3276ca9e608"
+  integrity sha512-ydS56vTKMZF7Hkqv2ggtxzuV7pFkv0fAJcq18x1w72Y7UDa8uITptbVEVdEDLkE1fCqnVl2dmi+7iv0pTjTGiA==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.6-alpha.2"
+    "@internetarchive/search-service" "^0.4.6"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -198,10 +198,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.6-alpha.2":
-  version "0.4.6-alpha.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.6-alpha.2.tgz#0df99e8ce55a03a1c9df86e7e3291950333a9e16"
-  integrity sha512-43zaaduSDdX2mesAgCoB22dVoqzxM58fWuN9p6SVwOS3xxPDMAj3Ggr76gzmPPAh8eKNwcyIK83Z529u+8OVpg==
+"@internetarchive/search-service@^0.4.6":
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.6.tgz#8c3f441a323a009123b93d0d1404ddb8d3904305"
+  integrity sha512-3BvPg5uHb7oVa92PHIkzsBNm3fbryGF0kDxtl4XH+6LqMM/cL5WfHY647tTT+0k98VUQhJMZTp16+T1zzXIZGw==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.5.tgz#8c6a0b6988ff8e9041b75737deeb51e8dfd8ba15"
-  integrity sha512-Fn/+Bld7XPyx4s2b5qt7cYB304ruAKdqOEHkmxEDwQReClPwdZio5Uzu68fuPgK4QqgffrJyWuS3dgsJ9NecQw==
+"@internetarchive/collection-name-cache@^0.2.6-alpha.2":
+  version "0.2.6-alpha.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.6-alpha.2.tgz#37a308a2841e81b36983fde40828d242528db9ec"
+  integrity sha512-eOu9iFGJLLbZqgpqarHwkOu1EKZrBI3XUWrlMNTT2XECuko/A4vA4KUkNsAHpeOz3K0Ak/hFNKnzyeTMqNFPJg==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.5"
+    "@internetarchive/search-service" "^0.4.6-alpha.2"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -198,10 +198,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.5.tgz#a50b6d0ffa5362b7b88b30bc16a7aaf62495f4f9"
-  integrity sha512-lnBptf+4cPh4yWsXLmaZn22/rH1pXKP1pV+sY4P2JUcb4ZzERD2rnMKRPXa0306/ckj5wPXP14XPCFGyrUFD3g==
+"@internetarchive/search-service@^0.4.6-alpha.2":
+  version "0.4.6-alpha.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.6-alpha.2.tgz#0df99e8ce55a03a1c9df86e7e3291950333a9e16"
+  integrity sha512-43zaaduSDdX2mesAgCoB22dVoqzxM58fWuN9p6SVwOS3xxPDMAj3Ggr76gzmPPAh8eKNwcyIK83Z529u+8OVpg==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
This PR simplifies how the search types are provided to collection browser from its parent component, so that requesting an additional search is no longer required. Search type changes due to history stack pops now correctly propagate upwards (e.g., to set the correct radio button option on the search page).