### PR TITLE
WEBDEV-5803 Improve facet sidebar scroll discoverability & clamp to page height

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     body {
       background: #F5F5F7;
       color: #2C2C2C;
+      line-height: 1.42857143; /* Same as production */
     }
   </style>
 <script

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -548,6 +548,18 @@ export class AppRoot extends LitElement {
       --facet-row-border-bottom: 1px solid blue;
     }
 
+    collection-browser {
+      /* Same as production */
+      max-width: 135rem;
+      margin: auto;
+    }
+
+    #collection-browser-container {
+      /* Same as production */
+      padding-left: 0.5rem;
+      margin-bottom: 2rem;
+    }
+
     #base-query-field {
       width: 300px;
     }


### PR DESCRIPTION
The facet sidebar is scrollable via mouse wheel (or similar), but shows no affordance indicating this. Moreover, it does not provide any easy way to scroll with input devices lacking a built-in scroll mechanism (e.g., old 2-button mouse with no wheel).

This PR adds a subtle scrollbar when hovering the sidebar to address both the discoverability and to allow scrolling via clicks only. It also adds a fade-out effect at the bottom of the sidebar whenever it is not scrolled to the bottom, indicating that there is more to view below.

Lastly, the column containing the facet sidebar was originally sized a way that flowed it off the bottom of the page, meaning that even with the sidebar scrolled all the way to the bottom, it was possible for its last few facet groups to be hidden until the rest of the page was scrolled down as well. This PR fixes that bug by ensuring the entire left column is dynamically sized to fit within the available screen height, so the user should always be able to see the bottom of the facets regardless of where they are on the page.