### PR TITLE
WEBDEV-5803 Improve facet sidebar scroll discoverability & clamp to page height

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     body {
       background: #F5F5F7;
       color: #2C2C2C;
+      line-height: 1.42857143; /* Same as production */
     }
   </style>
 <script

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -548,6 +548,18 @@ export class AppRoot extends LitElement {
       --facet-row-border-bottom: 1px solid blue;
     }
 
+    collection-browser {
+      /* Same as production */
+      max-width: 135rem;
+      margin: auto;
+    }
+
+    #collection-browser-container {
+      /* Same as production */
+      padding-left: 0.5rem;
+      margin-bottom: 2rem;
+    }
+
     #base-query-field {
       width: 300px;
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1717,6 +1717,7 @@ export class CollectionBrowser
       width: var(--leftColumnWidth, 18rem);
       /* Prevents Safari from shrinking col at first draw */
       min-width: var(--leftColumnWidth, 18rem);
+      padding-top: 0;
       /* Reduced padding by 0.2rem to add the invisible border in the rule below */
       padding-right: calc(var(--leftColumnPaddingRight, 2.5rem) - 0.2rem);
       border-right: 0.2rem solid transparent; /* Pads to the right of the scrollbar a bit */
@@ -1726,9 +1727,10 @@ export class CollectionBrowser
     .desktop #left-column {
       top: 0;
       position: sticky;
-      height: 100vh;
-      max-height: 100vh;
-      overflow: scroll;
+      height: calc(100vh - 2rem);
+      max-height: calc(100vh - 2rem);
+      overflow-x: hidden;
+      overflow-y: scroll;
 
       /*
        * Firefox doesn't support any of the -webkit-scrollbar stuff below, but
@@ -1767,8 +1769,9 @@ export class CollectionBrowser
     #facets-bottom-fade {
       background: linear-gradient(
         to bottom,
-        transparent 0%,
+        #f5f5f700 0%,
         #f5f5f7c0 50%,
+        #f5f5f7 80%,
         #f5f5f7 100%
       );
       position: fixed;
@@ -1788,7 +1791,7 @@ export class CollectionBrowser
 
     .desktop #left-column-scroll-sentinel {
       width: 1px;
-      height: 2000px;
+      height: 100vh;
       background: transparent;
     }
 
@@ -1807,6 +1810,10 @@ export class CollectionBrowser
       display: flex;
       justify-content: space-between;
       align-items: center;
+    }
+
+    .desktop #mobile-header-container {
+      padding-top: 2rem;
     }
 
     #facets-container {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -679,9 +679,12 @@ export class CollectionBrowser
 
   updated(changed: PropertyValues) {
     if (changed.has('placeholderType') && this.placeholderType === null) {
-      if (!this.leftColIntersectionObserver)
+      if (!this.leftColIntersectionObserver) {
         this.setupLeftColumnScrollListeners();
-      if (!this.facetsIntersectionObserver) this.setupFacetsScrollListeners();
+      }
+      if (!this.facetsIntersectionObserver) {
+        this.setupFacetsScrollListeners();
+      }
       this.updateLeftColumnHeight();
     }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -191,8 +191,6 @@ export class CollectionBrowser
 
   @query('#left-column') private leftColumn?: HTMLDivElement;
 
-  @query('#scroll-sentinel') private scrollSentinel?: HTMLDivElement;
-
   @property({ type: Object, attribute: false })
   private analyticsHandler?: AnalyticsManagerInterface;
 
@@ -848,7 +846,7 @@ export class CollectionBrowser
     );
     if (facetsSentinel) {
       this.facetsIntersectionObserver = new IntersectionObserver(
-        this.handleLeftColumnScroll
+        this.updateFacetFadeOut
       );
       this.facetsIntersectionObserver.observe(facetsSentinel);
     }
@@ -871,13 +869,11 @@ export class CollectionBrowser
   };
 
   /**
-   * Toggles whether the fade-out is visible at the bottom of the left column.
-   * It should only be visible if the column is not scrolled to the bottom.
+   * Toggles whether the fade-out is visible at the bottom of the facets.
+   * It should only be visible if the facets are not scrolled to the bottom.
    * Arrow function ensures proper `this` binding.
    */
-  private handleLeftColumnScroll = (
-    entries: IntersectionObserverEntry[]
-  ): void => {
+  private updateFacetFadeOut = (entries: IntersectionObserverEntry[]): void => {
     const fadeElmt = this.shadowRoot?.getElementById('facets-bottom-fade');
     fadeElmt?.classList.toggle('hidden', entries?.[0]?.isIntersecting);
   };

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -554,7 +554,7 @@ export class CollectionFacets extends LitElement {
         transform: rotate(90deg);
       }
 
-      .facet-group {
+      .facet-group:not(:last-child) {
         margin-bottom: 2rem;
       }
 


### PR DESCRIPTION
The facet sidebar is scrollable via mouse wheel (or similar), but shows no affordance indicating this. Moreover, it does not provide any easy way to scroll with input devices lacking a built-in scroll mechanism (e.g., old 2-button mouse with no wheel).

This PR adds a subtle scrollbar when hovering the sidebar to address both the discoverability and to allow scrolling via clicks only. It also adds a fade-out effect at the bottom of the sidebar whenever it is not scrolled to the bottom, indicating that there is more to view below.

Lastly, the column containing the facet sidebar was originally sized a way that flowed it off the bottom of the page, meaning that even with the sidebar scrolled all the way to the bottom, it was possible for its last few facet groups to be hidden until the rest of the page was scrolled down as well. This PR fixes that bug by ensuring the entire left column is dynamically sized to fit within the available screen height, so the user should always be able to see the bottom of the facets regardless of where they are on the page.