### PR TITLE
WEBDEV-5810 Only show year when date published is Jan 1 at midnight

### DIFF
--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -11,7 +11,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import type { SortParam } from '@internetarchive/search-service';
 
-import { formatDate } from '../../utils/format-date';
+import { DateFormat, formatDate } from '../../utils/format-date';
+import { isFirstMillisecondOfUTCYear } from '../../utils/local-date-from-utc';
 import type { TileModel } from '../../models';
 
 import { baseTileStyles } from './styles/tile-grid-shared-styles';
@@ -104,10 +105,16 @@ export class ItemTile extends LitElement {
 
   private get sortedDateInfoTemplate() {
     let sortedValue;
+    let format: DateFormat = 'long';
     switch (this.sortParam?.field) {
-      case 'date':
-        sortedValue = { field: 'published', value: this.model?.datePublished };
+      case 'date': {
+        const datePublished = this.model?.datePublished;
+        sortedValue = { field: 'published', value: datePublished };
+        if (isFirstMillisecondOfUTCYear(datePublished)) {
+          format = 'year-only';
+        }
         break;
+      }
       case 'reviewdate':
         sortedValue = { field: 'reviewed', value: this.model?.dateReviewed };
         break;
@@ -127,7 +134,7 @@ export class ItemTile extends LitElement {
     return html`
       <div class="date-sorted-by truncated">
         <span>
-          ${sortedValue?.field} ${formatDate(sortedValue?.value, 'long')}
+          ${sortedValue?.field} ${formatDate(sortedValue?.value, format)}
         </span>
       </div>
     `;

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -6,6 +6,7 @@ import type { TileModel } from '../../models';
 
 import { formatCount, NumberFormat } from '../../utils/format-count';
 import { formatDate, DateFormat } from '../../utils/format-date';
+import { isFirstMillisecondOfUTCYear } from '../../utils/local-date-from-utc';
 import { accountLabel } from './account-label';
 
 import '../image-block';
@@ -49,7 +50,7 @@ export class TileListCompact extends LitElement {
             ? accountLabel(this.model?.dateAdded)
             : DOMPurify.sanitize(this.model?.creator ?? '')}
         </div>
-        <div id="date">${formatDate(this.date, this.formatSize)}</div>
+        <div id="date">${formatDate(this.date, this.dateFormatSize)}</div>
         <div id="icon">
           <mediatype-icon
             .mediatype=${this.model?.mediatype}
@@ -111,7 +112,20 @@ export class TileListCompact extends LitElement {
     return 'desktop';
   }
 
-  private get formatSize(): DateFormat | NumberFormat {
+  private get dateFormatSize(): DateFormat {
+    // If we're showing a date published of Jan 1 at midnight, only show the year.
+    // This is because items with only a year for their publication date are normalized to
+    // Jan 1 at midnight timestamps in the search engine documents.
+    if (
+      (!this.sortParam?.field || this.sortParam.field === 'date') && // No sort or date published
+      isFirstMillisecondOfUTCYear(this.model?.datePublished)
+    ) {
+      return 'year-only';
+    }
+    return this.formatSize;
+  }
+
+  private get formatSize(): NumberFormat {
     if (
       this.mobileBreakpoint &&
       this.currentWidth &&

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -21,6 +21,7 @@ import { dateLabel } from './date-label';
 import { accountLabel } from './account-label';
 import { formatCount, NumberFormat } from '../../utils/format-count';
 import { formatDate, DateFormat } from '../../utils/format-date';
+import { isFirstMillisecondOfUTCYear } from '../../utils/local-date-from-utc';
 
 import '../image-block';
 import '../mediatype-icon';
@@ -205,10 +206,16 @@ export class TileList extends LitElement {
   }
 
   private get datePublishedTemplate() {
-    return this.metadataTemplate(
-      formatDate(this.model?.datePublished, 'long'),
-      'Published'
-    );
+    // If we're showing a date published of Jan 1 at midnight, only show the year.
+    // This is because items with only a year for their publication date are normalized to
+    // Jan 1 at midnight timestamps in the search engine documents.
+    const date: Date | undefined = this.model?.datePublished;
+    let format: DateFormat = 'long';
+    if (isFirstMillisecondOfUTCYear(date)) {
+      format = 'year-only';
+    }
+
+    return this.metadataTemplate(formatDate(date, format), 'Published');
   }
 
   // Show date label/value when sorted by date type
@@ -430,7 +437,7 @@ export class TileList extends LitElement {
     return 'desktop';
   }
 
-  private get formatSize(): DateFormat | NumberFormat {
+  private get formatSize(): NumberFormat {
     if (
       this.mobileBreakpoint &&
       this.currentWidth &&

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -3,6 +3,7 @@
  * Override browser timezone to always display same date as in data
  */
 export type DateFormat =
+  | 'year-only' // 2020
   | 'short' // Dec 2020
   | 'long'; // Dec 20, 2020
 
@@ -18,6 +19,9 @@ export function formatDate(
     timeZone: 'UTC', // Override browser timezone
   };
   switch (format) {
+    case 'year-only':
+      options.year = 'numeric';
+      break;
     case 'short':
       options.month = 'short';
       options.year = 'numeric';

--- a/src/utils/local-date-from-utc.ts
+++ b/src/utils/local-date-from-utc.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a given UTC date into the equivalent local-timestamp one.
+ */
+export function localDateFromUTC(date: Date): Date {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 1000 * 60);
+}
+
+/**
+ * Returns whether a given UTC date corresponds to the first
+ * millisecond of the year (e.g., Jan 1 at exactly midnight).
+ */
+export function isFirstMillisecondOfUTCYear(date?: Date): boolean {
+  if (!date) return false;
+  return localDateFromUTC(date).toISOString().endsWith('-01-01T00:00:00.000Z');
+}

--- a/test/tiles/grid/item-tile.test.ts
+++ b/test/tiles/grid/item-tile.test.ts
@@ -5,6 +5,7 @@ import { html } from 'lit';
 import type { ItemTile } from '../../../src/tiles/grid/item-tile';
 
 import '../../../src/tiles/grid/item-tile';
+import type { TileModel } from '../../../src/models';
 
 describe('Item Tile', () => {
   it('should render initial component', async () => {
@@ -115,7 +116,7 @@ describe('Item Tile', () => {
     expect(dateSortedBy).to.not.exist;
   });
 
-  it('should render with created-by when sorting not related to date', async () => {
+  it('should render without created-by when sorting by a date field', async () => {
     const el = await fixture<ItemTile>(
       html`<item-tile .model=${{ dateAdded: new Date() }}></item-tile>`
     );
@@ -135,7 +136,7 @@ describe('Item Tile', () => {
     expect(dateSortedBy).to.exist;
   });
 
-  it('should render with created-by when sort field id not like date', async () => {
+  it('should render with created-by when sort field is not a date', async () => {
     const el = await fixture<ItemTile>(
       html`<item-tile .model=${{ creator: 'someone' }}></item-tile>`
     );
@@ -151,8 +152,149 @@ describe('Item Tile', () => {
     const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
 
     expect(itemInfo).to.exist;
-    expect(dateSortedBy).to.not.exist; // it should be exist because this is not related to date sort
+    expect(dateSortedBy).to.not.exist; // it should not exist because this is not a date sort
     expect(createdBy).to.exist;
+  });
+
+  it('should render published date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.contain(
+      'published Jan 02, 2012'
+    );
+  });
+
+  it('should render added date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.contain('added Jan 02, 2010');
+  });
+
+  it('should render archived date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'publicdate', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.contain(
+      'archived Jan 02, 2011'
+    );
+  });
+
+  it('should render reviewed date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'reviewdate', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.contain(
+      'reviewed Jan 02, 2013'
+    );
+  });
+
+  it('should only show the year for a date published of Jan 1 at midnight UTC', async () => {
+    const model: Partial<TileModel> = {
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    const dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.equal('published 2012');
+  });
+
+  it('should show full date added/archived/reviewed, even on Jan 1 at midnight UTC', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date(2010, 0, 1, 0, 0, 0, 0),
+      dateArchived: new Date(2011, 0, 1, 0, 0, 0, 0),
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+      dateReviewed: new Date(2013, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<ItemTile>(html`
+      <item-tile
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </item-tile>
+    `);
+
+    let dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.equal('added Jan 01, 2010');
+
+    el.sortParam = { field: 'publicdate', direction: 'desc' };
+    await el.updateComplete;
+    dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.equal('archived Jan 01, 2011');
+
+    el.sortParam = { field: 'reviewdate', direction: 'desc' };
+    await el.updateComplete;
+    dateSortedBy = el.shadowRoot?.querySelector('.date-sorted-by');
+    expect(dateSortedBy).to.exist;
+    expect(dateSortedBy?.textContent?.trim()).to.equal('reviewed Jan 01, 2013');
   });
 
   it('should render with snippet block when it has snippets', async () => {

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -78,10 +78,10 @@ describe('List Tile Compact', () => {
 
   it('should render published date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-01'),
-      dateArchived: new Date('2011-01-01'),
-      datePublished: new Date('2012-01-01'),
-      dateReviewed: new Date('2013-01-01'),
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -94,15 +94,15 @@ describe('List Tile Compact', () => {
 
     const dateColumn = el.shadowRoot?.getElementById('date');
     expect(dateColumn).to.exist;
-    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2012');
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 02, 2012');
   });
 
   it('should render added date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-01'),
-      dateArchived: new Date('2011-01-01'),
-      datePublished: new Date('2012-01-01'),
-      dateReviewed: new Date('2013-01-01'),
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -115,15 +115,15 @@ describe('List Tile Compact', () => {
 
     const dateColumn = el.shadowRoot?.getElementById('date');
     expect(dateColumn).to.exist;
-    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2010');
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 02, 2010');
   });
 
   it('should render archived date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-01'),
-      dateArchived: new Date('2011-01-01'),
-      datePublished: new Date('2012-01-01'),
-      dateReviewed: new Date('2013-01-01'),
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -136,15 +136,15 @@ describe('List Tile Compact', () => {
 
     const dateColumn = el.shadowRoot?.getElementById('date');
     expect(dateColumn).to.exist;
-    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2011');
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 02, 2011');
   });
 
   it('should render reviewed date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-01'),
-      dateArchived: new Date('2011-01-01'),
-      datePublished: new Date('2012-01-01'),
-      dateReviewed: new Date('2013-01-01'),
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -156,6 +156,57 @@ describe('List Tile Compact', () => {
     `);
 
     const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 02, 2013');
+  });
+
+  it('should only show the year for a date published of Jan 1 at midnight UTC', async () => {
+    const model: Partial<TileModel> = {
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    const dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('2012');
+  });
+
+  it('should show full date added/archived/reviewed, even on Jan 1 at midnight UTC', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date(2010, 0, 1, 0, 0, 0, 0),
+      dateArchived: new Date(2011, 0, 1, 0, 0, 0, 0),
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+      dateReviewed: new Date(2013, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<TileListCompact>(html`
+      <tile-list-compact
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </tile-list-compact>
+    `);
+
+    let dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2010');
+
+    el.sortParam = { field: 'publicdate', direction: 'desc' };
+    await el.updateComplete;
+    dateColumn = el.shadowRoot?.getElementById('date');
+    expect(dateColumn).to.exist;
+    expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2011');
+
+    el.sortParam = { field: 'reviewdate', direction: 'desc' };
+    await el.updateComplete;
+    dateColumn = el.shadowRoot?.getElementById('date');
     expect(dateColumn).to.exist;
     expect(dateColumn?.textContent?.trim()).to.equal('Jan 01, 2013');
   });

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -136,12 +136,33 @@ describe('List Tile', () => {
     expect(viewsRow?.textContent?.trim()).to.equal('Views:  10');
   });
 
+  it('should render published date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Published:  Jan 02, 2012');
+  });
+
   it('should render added date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-01'),
-      dateArchived: new Date('2011-01-01'),
-      datePublished: new Date('2012-01-01'),
-      dateReviewed: new Date('2013-01-01'),
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
     };
 
     const el = await fixture<TileList>(html`
@@ -154,7 +175,100 @@ describe('List Tile', () => {
 
     const dateRow = el.shadowRoot?.getElementById('dates-line');
     expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Added:  Jan 02, 2010');
+  });
+
+  it('should render archived date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'publicdate', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Archived:  Jan 02, 2011');
+  });
+
+  it('should render reviewed date when sorting by it', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date('2010-01-02'),
+      dateArchived: new Date('2011-01-02'),
+      datePublished: new Date('2012-01-02'),
+      dateReviewed: new Date('2013-01-02'),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'reviewdate', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Reviewed:  Jan 02, 2013');
+  });
+
+  it('should only show the year for a date published of Jan 1 at midnight', async () => {
+    const model: Partial<TileModel> = {
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'date', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Published:  2012');
+  });
+
+  it('should show full date added/archived/reviewed, even on Jan 1 at midnight', async () => {
+    const model: Partial<TileModel> = {
+      dateAdded: new Date(2010, 0, 1, 0, 0, 0, 0),
+      dateArchived: new Date(2011, 0, 1, 0, 0, 0, 0),
+      datePublished: new Date(2012, 0, 1, 0, 0, 0, 0),
+      dateReviewed: new Date(2013, 0, 1, 0, 0, 0, 0),
+    };
+
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${model}
+        .sortParam=${{ field: 'addeddate', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    let dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
     expect(dateRow?.textContent?.trim()).to.contain('Added:  Jan 01, 2010');
+
+    el.sortParam = { field: 'publicdate', direction: 'desc' };
+    await el.updateComplete;
+    dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Archived:  Jan 01, 2011');
+
+    el.sortParam = { field: 'reviewdate', direction: 'desc' };
+    await el.updateComplete;
+    dateRow = el.shadowRoot?.getElementById('dates-line');
+    expect(dateRow).to.exist;
+    expect(dateRow?.textContent?.trim()).to.contain('Reviewed:  Jan 01, 2013');
   });
 
   it('should render links to /search pages (not search.php) for subject, creator, and source', async () => {

--- a/test/utils/local-date-from-utc.test.ts
+++ b/test/utils/local-date-from-utc.test.ts
@@ -1,0 +1,37 @@
+import { expect } from '@open-wc/testing';
+import {
+  localDateFromUTC,
+  isFirstMillisecondOfUTCYear,
+} from '../../src/utils/local-date-from-utc';
+
+describe('localDateFromUTC', () => {
+  it('converts dates from UTC to local timezone', async () => {
+    const date = new Date(1990, 1, 2, 3, 4, 5, 6);
+    const dateFromUTC = new Date(Date.UTC(1990, 1, 2, 3, 4, 5, 6));
+    expect(localDateFromUTC(date).toISOString()).to.equal(
+      dateFromUTC.toISOString()
+    );
+  });
+});
+
+describe('isFirstMillisecondOfUTCYear', () => {
+  it('returns true when date is exactly Jan 1 at midnight in UTC', async () => {
+    const midnightOnNewYearsDay = new Date(2010, 0, 1, 0, 0, 0, 0);
+    expect(isFirstMillisecondOfUTCYear(midnightOnNewYearsDay)).to.be.true;
+  });
+
+  it('returns false when date is not exactly Jan 1 at midnight in UTC', async () => {
+    const oneMillisecondTooEarly = new Date(2009, 11, 31, 23, 59, 59, 999);
+    expect(isFirstMillisecondOfUTCYear(oneMillisecondTooEarly)).to.be.false;
+
+    const oneMillisecondTooLate = new Date(2010, 0, 1, 0, 0, 0, 1);
+    expect(isFirstMillisecondOfUTCYear(oneMillisecondTooLate)).to.be.false;
+
+    const middleOfTheYear = new Date(2010, 6, 1, 0, 0, 0, 0);
+    expect(isFirstMillisecondOfUTCYear(middleOfTheYear)).to.be.false;
+  });
+
+  it('returns false when no date provided', async () => {
+    expect(isFirstMillisecondOfUTCYear(undefined)).to.be.false;
+  });
+});


### PR DESCRIPTION
When items are uploaded with only a year in the date field, the search engine normalizes this to a date of Jan 1 at midnight. This normalized date is what gets returned on search queries, including those that we use for rendering tiles. So in these cases, tiles show an (incorrect) Jan 1 date published.

The legacy search page approached this by assuming that all dates occurring on Jan 1 at midnight should be just a raw year. This is likely true in most cases, though it also clobbers any “Jan 1 at midnight” date that an uploader actually intended.

This PR implements the same assumption as legacy search whenever it renders a date published on a result tile. So items with a normalized UTC date of Jan 1 at midnight (for any year) should only render it as a year, with no month/day. This is only applicable to date published, not the other three types of dates (which are software-defined, not uploader-specified).