### PR TITLE
WEBDEV-5786 Fix facet analytics not sending

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -609,7 +609,7 @@ export class CollectionBrowser
         ?collapsableFacets=${this.mobileView}
         ?facetsLoading=${this.facetsLoading}
         ?fullYearAggregationLoading=${this.facetsLoading}
-        .onFacetClick=${this.facetClickHandler}
+        @facetClick=${this.facetClickHandler}
         .analyticsHandler=${this.analyticsHandler}
       >
       </collection-facets>

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -55,7 +55,7 @@ import {
   PrefixFilterType,
   PrefixFilterCounts,
   prefixFilterAggregationKeys,
-  FacetOption,
+  FacetEventDetails,
 } from './models';
 import {
   RestorationStateHandlerInterface,
@@ -1136,26 +1136,26 @@ export class CollectionBrowser
     this.selectedFacets = e.detail;
   }
 
-  facetClickHandler(
-    name: FacetOption,
-    facetSelected: boolean,
-    negative: boolean
-  ): void {
+  facetClickHandler({
+    detail: { key, state: facetState, negative },
+  }: CustomEvent<FacetEventDetails>): void {
     if (negative) {
       this.analyticsHandler?.sendEvent({
         category: this.searchContext,
-        action: facetSelected
-          ? analyticsActions.facetNegativeSelected
-          : analyticsActions.facetNegativeDeselected,
-        label: name,
+        action:
+          facetState !== 'none'
+            ? analyticsActions.facetNegativeSelected
+            : analyticsActions.facetNegativeDeselected,
+        label: key,
       });
     } else {
       this.analyticsHandler?.sendEvent({
         category: this.searchContext,
-        action: facetSelected
-          ? analyticsActions.facetSelected
-          : analyticsActions.facetDeselected,
-        label: name,
+        action:
+          facetState !== 'none'
+            ? analyticsActions.facetSelected
+            : analyticsActions.facetDeselected,
+        label: key,
       });
     }
   }

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -42,7 +42,6 @@ import {
   LendingFacetKey,
   suppressedCollections,
   defaultFacetSort,
-  FacetEventDetails,
 } from './models';
 import './collection-facets/more-facets-content';
 import './collection-facets/facets-template';
@@ -99,11 +98,6 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object, attribute: false })
   collectionNameCache?: CollectionNameCacheInterface;
-
-  /** Fires when a facet is clicked */
-  @property({ type: Function }) onFacetClick?: (
-    e: CustomEvent<FacetEventDetails>
-  ) => void;
 
   @state() openFacets: Record<FacetOption, boolean> = {
     subject: false,
@@ -512,7 +506,6 @@ export class CollectionFacets extends LitElement {
         .selectedFacets=${this.selectedFacets}
         .renderOn=${'page'}
         .collectionNameCache=${this.collectionNameCache}
-        @facetClick=${this.onFacetClick}
         @selectedFacetsChanged=${(e: CustomEvent) => {
           const event = new CustomEvent<SelectedFacets>('facetsChanged', {
             detail: e.detail,

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -42,6 +42,7 @@ import {
   LendingFacetKey,
   suppressedCollections,
   defaultFacetSort,
+  FacetEventDetails,
 } from './models';
 import './collection-facets/more-facets-content';
 import './collection-facets/facets-template';
@@ -101,9 +102,7 @@ export class CollectionFacets extends LitElement {
 
   /** Fires when a facet is clicked */
   @property({ type: Function }) onFacetClick?: (
-    name: FacetOption,
-    facetChecked: boolean,
-    negative: boolean
+    e: CustomEvent<FacetEventDetails>
   ) => void;
 
   @state() openFacets: Record<FacetOption, boolean> = {
@@ -513,6 +512,7 @@ export class CollectionFacets extends LitElement {
         .selectedFacets=${this.selectedFacets}
         .renderOn=${'page'}
         .collectionNameCache=${this.collectionNameCache}
+        @facetClick=${this.onFacetClick}
         @selectedFacetsChanged=${(e: CustomEvent) => {
           const event = new CustomEvent<SelectedFacets>('facetsChanged', {
             detail: e.detail,

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -99,6 +99,7 @@ export class FacetsTemplate extends LitElement {
   ) {
     const event = new CustomEvent<FacetEventDetails>('facetClick', {
       detail: { key, state, negative },
+      composed: true,
     });
     this.dispatchEvent(event);
   }

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -10,6 +10,8 @@ import {
   FacetBucket,
   SelectedFacets,
   getDefaultSelectedFacets,
+  FacetEventDetails,
+  FacetState,
 } from '../models';
 
 @customElement('facets-template')
@@ -31,6 +33,12 @@ export class FacetsTemplate extends LitElement {
     } else {
       this.facetUnchecked(name as FacetOption, value);
     }
+
+    this.dispatchFacetClickEvent(
+      name as FacetOption,
+      this.getFacetState(checked, negative),
+      negative
+    );
   }
 
   private facetChecked(
@@ -49,7 +57,7 @@ export class FacetsTemplate extends LitElement {
       newFacets = getDefaultSelectedFacets();
     }
     newFacets[key][value] = {
-      state: negative ? 'hidden' : 'selected',
+      state: this.getFacetState(true, negative),
       count,
     } as FacetBucket;
 
@@ -71,6 +79,28 @@ export class FacetsTemplate extends LitElement {
 
     this.selectedFacets = newFacets;
     this.dispatchSelectedFacetsChanged();
+  }
+
+  /** Returns the composed facet state corresponding to a positive or negative facet's checked state */
+  private getFacetState(checked: boolean, negative: boolean): FacetState {
+    let state: FacetState;
+    if (checked) {
+      state = negative ? 'hidden' : 'selected';
+    } else {
+      state = 'none';
+    }
+    return state;
+  }
+
+  private dispatchFacetClickEvent(
+    key: FacetOption,
+    state: FacetState,
+    negative: boolean
+  ) {
+    const event = new CustomEvent<FacetEventDetails>('facetClick', {
+      detail: { key, state, negative },
+    });
+    this.dispatchEvent(event);
   }
 
   private dispatchSelectedFacetsChanged() {

--- a/src/models.ts
+++ b/src/models.ts
@@ -220,6 +220,12 @@ export interface FacetGroup {
   buckets: FacetBucket[];
 }
 
+export type FacetEventDetails = {
+  key: FacetOption;
+  state: FacetState;
+  negative: boolean;
+};
+
 export type FacetValue = string;
 
 export type SelectedFacets = Record<

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -174,12 +174,20 @@ describe('Collection Browser', () => {
     el.selectedFacets = mockedSelectedFacets;
     await el.updateComplete;
 
-    el.facetClickHandler('mediatype', true, false);
+    el.facetClickHandler(
+      new CustomEvent('facetClick', {
+        detail: { key: 'mediatype', state: 'selected', negative: false },
+      })
+    );
     expect(mockAnalyticsHandler.callCategory).to.equal('search-service');
     expect(mockAnalyticsHandler.callAction).to.equal('facetSelected');
     expect(mockAnalyticsHandler.callLabel).to.equal('mediatype');
 
-    el.facetClickHandler('mediatype', false, false);
+    el.facetClickHandler(
+      new CustomEvent('facetClick', {
+        detail: { key: 'mediatype', state: 'none', negative: false },
+      })
+    );
     expect(el.selectedFacets).to.equal(mockedSelectedFacets);
     expect(mockAnalyticsHandler.callCategory).to.equal('search-service');
     expect(mockAnalyticsHandler.callAction).to.equal('facetDeselected');
@@ -208,12 +216,20 @@ describe('Collection Browser', () => {
     el.selectedFacets = mockedSelectedFacets;
     await el.updateComplete;
 
-    el.facetClickHandler('mediatype', true, true);
+    el.facetClickHandler(
+      new CustomEvent('facetClick', {
+        detail: { key: 'mediatype', state: 'hidden', negative: true },
+      })
+    );
     expect(mockAnalyticsHandler.callCategory).to.equal('beta-search-service');
     expect(mockAnalyticsHandler.callAction).to.equal('facetNegativeSelected');
     expect(mockAnalyticsHandler.callLabel).to.equal('mediatype');
 
-    el.facetClickHandler('mediatype', false, true);
+    el.facetClickHandler(
+      new CustomEvent('facetClick', {
+        detail: { key: 'mediatype', state: 'none', negative: true },
+      })
+    );
     expect(el.selectedFacets).to.equal(mockedSelectedFacets);
     expect(mockAnalyticsHandler.callCategory).to.equal('beta-search-service');
     expect(mockAnalyticsHandler.callAction).to.equal('facetNegativeDeselected');

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -1,7 +1,9 @@
 import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
 import { html } from 'lit';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 import '../../src/collection-facets/facets-template';
+import { defaultSelectedFacets, FacetEventDetails } from '../../src/models';
 
 const facetGroup = {
   title: 'Media Type',
@@ -101,5 +103,101 @@ describe('Render facets', () => {
     expect(selectedFacet?.getAttribute('title')).equal(
       'Hide mediatype: movies'
     );
+  });
+
+  it('emits facetClick events for normal facets', async () => {
+    const facetClickSpy = sinon.spy();
+    const mediatypeGroup = {
+      title: 'Media Type',
+      key: 'mediatype',
+      buckets: [
+        { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
+      ],
+    };
+    const selectedFacets = { ...defaultSelectedFacets };
+    const el = await fixture<FacetsTemplate>(
+      html`<facets-template
+        .facetGroup=${mediatypeGroup}
+        .selectedFacets=${selectedFacets}
+        @facetClick=${facetClickSpy}
+      ></facets-template>`
+    );
+
+    const checkbox = el.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(checkbox).to.exist;
+
+    // Select it
+    checkbox.click();
+    await el.updateComplete;
+    expect(facetClickSpy.callCount).to.equal(1);
+
+    const selectEvent = facetClickSpy
+      .args[0][0] as CustomEvent<FacetEventDetails>;
+    expect(selectEvent).to.exist;
+    expect(selectEvent?.detail?.key).to.equal('mediatype');
+    expect(selectEvent?.detail?.state).to.equal('selected');
+    expect(selectEvent?.detail?.negative).to.be.false;
+
+    // Unselect it
+    checkbox.click();
+    await el.updateComplete;
+    expect(facetClickSpy.callCount).to.equal(2);
+
+    const unselectEvent = facetClickSpy
+      .args[1][0] as CustomEvent<FacetEventDetails>;
+    expect(unselectEvent).to.exist;
+    expect(unselectEvent?.detail?.key).to.equal('mediatype');
+    expect(unselectEvent?.detail?.state).to.equal('none');
+    expect(unselectEvent?.detail?.negative).to.be.false;
+  });
+
+  it('emits facetClick events for negative facets', async () => {
+    const facetClickSpy = sinon.spy();
+    const mediatypeGroup = {
+      title: 'Media Type',
+      key: 'mediatype',
+      buckets: [
+        { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
+      ],
+    };
+    const selectedFacets = { ...defaultSelectedFacets };
+    const el = await fixture<FacetsTemplate>(
+      html`<facets-template
+        .facetGroup=${mediatypeGroup}
+        .selectedFacets=${selectedFacets}
+        @facetClick=${facetClickSpy}
+      ></facets-template>`
+    );
+
+    const checkbox = el.shadowRoot?.querySelector(
+      '.hide-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(checkbox).to.exist;
+
+    // Select it
+    checkbox.click();
+    await el.updateComplete;
+    expect(facetClickSpy.callCount).to.equal(1);
+
+    const selectEvent = facetClickSpy
+      .args[0][0] as CustomEvent<FacetEventDetails>;
+    expect(selectEvent).to.exist;
+    expect(selectEvent?.detail?.key).to.equal('mediatype');
+    expect(selectEvent?.detail?.state).to.equal('hidden');
+    expect(selectEvent?.detail?.negative).to.be.true;
+
+    // Unselect it
+    checkbox.click();
+    await el.updateComplete;
+    expect(facetClickSpy.callCount).to.equal(2);
+
+    const unselectEvent = facetClickSpy
+      .args[1][0] as CustomEvent<FacetEventDetails>;
+    expect(unselectEvent).to.exist;
+    expect(unselectEvent?.detail?.key).to.equal('mediatype');
+    expect(unselectEvent?.detail?.state).to.equal('none');
+    expect(unselectEvent?.detail?.negative).to.be.true;
   });
 });

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { html } from 'lit';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 import '../../src/collection-facets/facets-template';
-import { defaultSelectedFacets, FacetEventDetails } from '../../src/models';
+import { getDefaultSelectedFacets, FacetEventDetails } from '../../src/models';
 
 const facetGroup = {
   title: 'Media Type',
@@ -114,7 +114,7 @@ describe('Render facets', () => {
         { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
       ],
     };
-    const selectedFacets = { ...defaultSelectedFacets };
+    const selectedFacets = getDefaultSelectedFacets();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${mediatypeGroup}
@@ -162,7 +162,7 @@ describe('Render facets', () => {
         { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
       ],
     };
-    const selectedFacets = { ...defaultSelectedFacets };
+    const selectedFacets = getDefaultSelectedFacets();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${mediatypeGroup}


### PR DESCRIPTION
We had some facet analytics handlers added a while back, but it appears that they were never fully hooked up. This PR connects the wires so that clicks on facets trigger the desired analytics events.