### PR TITLE
WEBDEV-5637 Ensure alphabet filter counts load when present on initial page load

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1162,10 +1162,12 @@ export class CollectionBrowser
   }
 
   private async fetchFacets() {
-    if (!this.filteredQuery) return;
+    const trimmedQuery = this.baseQuery?.trim();
+    if (!trimmedQuery) return;
+    if (!this.searchService) return;
 
     const params: SearchParams = {
-      query: this.filteredQuery,
+      query: trimmedQuery,
       rows: 0,
       filters: this.filterMap,
       // Fetch a few extra buckets beyond the 6 we show, in case some get suppressed
@@ -1176,7 +1178,7 @@ export class CollectionBrowser
     };
 
     this.facetsLoading = true;
-    const searchResponse = await this.searchService?.search(
+    const searchResponse = await this.searchService.search(
       params,
       this.searchType
     );
@@ -1263,7 +1265,9 @@ export class CollectionBrowser
   private pageFetchesInProgress: Record<string, Set<number>> = {};
 
   async fetchPage(pageNumber: number) {
-    if (!this.filteredQuery) return;
+    const trimmedQuery = this.baseQuery?.trim();
+    if (!trimmedQuery) return;
+    if (!this.searchService) return;
 
     // if we already have data, don't fetch again
     if (this.dataSource[pageNumber]) return;
@@ -1280,7 +1284,7 @@ export class CollectionBrowser
 
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
-      query: this.filteredQuery,
+      query: trimmedQuery,
       page: pageNumber,
       rows: this.pageSize,
       sort: sortParams,
@@ -1288,7 +1292,7 @@ export class CollectionBrowser
       aggregations: { omit: true },
       uid: this.pageFetchQueryKey,
     };
-    const searchResponse = await this.searchService?.search(
+    const searchResponse = await this.searchService.search(
       params,
       this.searchType
     );

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -491,21 +491,30 @@ export class CollectionBrowser
     }
   }
 
+  /**
+   * Returns a query clause identifying the currently selected title filter,
+   * e.g., `firstTitle:X`.
+   */
   private get titleQuery(): string | undefined {
     return this.selectedTitleFilter
       ? `firstTitle:${this.selectedTitleFilter}`
       : undefined;
   }
 
+  /**
+   * Returns a query clause identifying the currently selected creator filter,
+   * e.g., `firstCreator:X`.
+   */
   private get creatorQuery(): string | undefined {
     return this.selectedCreatorFilter
       ? `firstCreator:${this.selectedCreatorFilter}`
       : undefined;
   }
 
-  /** Send Analytics when sorting by title's first letter
+  /**
+   * Send Analytics when sorting by title's first letter
    * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
-   * */
+   */
   private sendFilterByTitleAnalytics(prevSelectedLetter: string | null): void {
     if (!prevSelectedLetter && !this.selectedTitleFilter) {
       return;
@@ -521,9 +530,10 @@ export class CollectionBrowser
     });
   }
 
-  /** Send Analytics when filtering by creator's first letter
+  /**
+   * Send Analytics when filtering by creator's first letter
    * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
-   * */
+   */
   private sendFilterByCreatorAnalytics(
     prevSelectedLetter: string | null
   ): void {
@@ -541,6 +551,9 @@ export class CollectionBrowser
     });
   }
 
+  /**
+   * Handler for changes to which letter is selected in the title alphabet bar.
+   */
   private titleLetterSelected(
     e: CustomEvent<{ selectedLetter: string | null }>
   ): void {
@@ -548,6 +561,9 @@ export class CollectionBrowser
     this.selectedTitleFilter = e.detail.selectedLetter;
   }
 
+  /**
+   * Handler for changes to which letter is selected in the creator alphabet bar.
+   */
   private creatorLetterSelected(
     e: CustomEvent<{ selectedLetter: string | null }>
   ): void {
@@ -942,6 +958,11 @@ export class CollectionBrowser
     this.searchResultsLoading = false;
   }
 
+  /**
+   * Constructs a search service FilterMap object from the combination of
+   * all the currently-applied filters. This includes any facets, letter
+   * filters, and date range.
+   */
   private get filterMap(): FilterMap {
     const builder = new FilterMapBuilder();
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1024,19 +1024,6 @@ export class CollectionBrowser
     return filterMap;
   }
 
-  /** The base query joined with any title/creator letter filters */
-  private get filteredQuery(): string | undefined {
-    if (!this.baseQuery) return undefined;
-    let filteredQuery = this.baseQuery.trim();
-
-    const { sortFilterQueries } = this;
-    if (sortFilterQueries) {
-      filteredQuery += ` AND ${sortFilterQueries}`;
-    }
-
-    return filteredQuery.trim();
-  }
-
   /** The full query, including year facets and date range clauses */
   private get fullQuery(): string | undefined {
     if (!this.baseQuery) return undefined;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1005,6 +1005,19 @@ export class CollectionBrowser
     return filterMap;
   }
 
+  /** The base query joined with any title/creator letter filters */
+  private get filteredQuery(): string | undefined {
+    if (!this.baseQuery) return undefined;
+    let filteredQuery = this.baseQuery.trim();
+
+    const { sortFilterQueries } = this;
+    if (sortFilterQueries) {
+      filteredQuery += ` AND ${sortFilterQueries}`;
+    }
+
+    return filteredQuery.trim();
+  }
+
   /** The full query, including year facets and date range clauses */
   private get fullQuery(): string | undefined {
     if (!this.baseQuery) return undefined;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -104,10 +104,6 @@ export class CollectionBrowser
 
   @property({ type: Object }) resizeObserver?: SharedResizeObserverInterface;
 
-  @property({ type: String }) titleQuery?: string;
-
-  @property({ type: String }) creatorQuery?: string;
-
   @property({ type: Number }) currentPage?: number;
 
   @property({ type: String }) minSelectedDate?: string;
@@ -294,8 +290,6 @@ export class CollectionBrowser
     if (letterFilters) {
       this.selectedTitleFilter = null;
       this.selectedCreatorFilter = null;
-      this.titleQuery = undefined;
-      this.creatorQuery = undefined;
     }
 
     if (sort) {
@@ -497,6 +491,18 @@ export class CollectionBrowser
     }
   }
 
+  private get titleQuery(): string | undefined {
+    return this.selectedTitleFilter
+      ? `firstTitle:${this.selectedTitleFilter}`
+      : undefined;
+  }
+
+  private get creatorQuery(): string | undefined {
+    return this.selectedCreatorFilter
+      ? `firstCreator:${this.selectedCreatorFilter}`
+      : undefined;
+  }
+
   /** Send Analytics when sorting by title's first letter
    * labels: 'start-<ToLetter>' | 'clear-<FromLetter>' | '<FromLetter>-<ToLetter>'
    * */
@@ -513,12 +519,6 @@ export class CollectionBrowser
         ? `clear-${prevSelectedLetter}`
         : `${prevSelectedLetter || 'start'}-${this.selectedTitleFilter}`,
     });
-  }
-
-  private selectedTitleLetterChanged(): void {
-    this.titleQuery = this.selectedTitleFilter
-      ? `firstTitle:${this.selectedTitleFilter}`
-      : undefined;
   }
 
   /** Send Analytics when filtering by creator's first letter
@@ -541,18 +541,11 @@ export class CollectionBrowser
     });
   }
 
-  private selectedCreatorLetterChanged(): void {
-    this.creatorQuery = this.selectedCreatorFilter
-      ? `firstCreator:${this.selectedCreatorFilter}`
-      : undefined;
-  }
-
   private titleLetterSelected(
     e: CustomEvent<{ selectedLetter: string | null }>
   ): void {
     this.selectedCreatorFilter = null;
     this.selectedTitleFilter = e.detail.selectedLetter;
-    this.selectedTitleLetterChanged();
   }
 
   private creatorLetterSelected(
@@ -560,7 +553,6 @@ export class CollectionBrowser
   ): void {
     this.selectedTitleFilter = null;
     this.selectedCreatorFilter = e.detail.selectedLetter;
-    this.selectedCreatorLetterChanged();
   }
 
   private get mobileFacetsTemplate() {
@@ -729,13 +721,11 @@ export class CollectionBrowser
       this.sendFilterByTitleAnalytics(
         changed.get('selectedTitleFilter') as string
       );
-      this.selectedTitleLetterChanged();
     }
     if (changed.has('selectedCreatorFilter')) {
       this.sendFilterByCreatorAnalytics(
         changed.get('selectedCreatorFilter') as string
       );
-      this.selectedCreatorLetterChanged();
     }
 
     if (
@@ -1013,19 +1003,6 @@ export class CollectionBrowser
 
     const filterMap = builder.build();
     return filterMap;
-  }
-
-  /** The base query joined with any title/creator letter filters */
-  private get filteredQuery(): string | undefined {
-    if (!this.baseQuery) return undefined;
-    let filteredQuery = this.baseQuery.trim();
-
-    const { sortFilterQueries } = this;
-    if (sortFilterQueries) {
-      filteredQuery += ` AND ${sortFilterQueries}`;
-    }
-
-    return filteredQuery.trim();
   }
 
   /** The full query, including year facets and date range clauses */

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -130,7 +130,8 @@ export class MoreFacetsContent extends LitElement {
    * - this.aggregations - hold result of search service and being used for further processing.
    */
   async updateSpecificFacets(): Promise<void> {
-    if (!this.query?.trim()) return;
+    const trimmedQuery = this.query?.trim();
+    if (!trimmedQuery) return;
 
     const aggregations = {
       simpleParams: [this.facetAggregationKey as string],
@@ -138,7 +139,7 @@ export class MoreFacetsContent extends LitElement {
     const aggregationsSize = 65535; // todo - do we want to have all the records at once?
 
     const params: SearchParams = {
-      query: this.query.trim(),
+      query: trimmedQuery,
       filters: this.filterMap,
       aggregations,
       aggregationsSize,

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -130,13 +130,15 @@ export class MoreFacetsContent extends LitElement {
    * - this.aggregations - hold result of search service and being used for further processing.
    */
   async updateSpecificFacets(): Promise<void> {
+    if (!this.query?.trim()) return;
+
     const aggregations = {
       simpleParams: [this.facetAggregationKey as string],
     };
     const aggregationsSize = 65535; // todo - do we want to have all the records at once?
 
     const params: SearchParams = {
-      query: this.query as string,
+      query: this.query.trim(),
       filters: this.filterMap,
       aggregations,
       aggregationsSize,

--- a/src/collection-facets/more-facets-pagination.ts
+++ b/src/collection-facets/more-facets-pagination.ts
@@ -281,9 +281,6 @@ export class MoreFacetsPagination extends LitElement {
         background: #2c2c2c;
         color: white;
       }
-      .page-numbers button:not(.current):hover {
-        background: #d0d0d0;
-      }
       .page-numbers {
         display: inline-block;
       }

--- a/src/collection-facets/more-facets-pagination.ts
+++ b/src/collection-facets/more-facets-pagination.ts
@@ -281,6 +281,9 @@ export class MoreFacetsPagination extends LitElement {
         background: #2c2c2c;
         color: white;
       }
+      .page-numbers button:not(.current):hover {
+        background: #d0d0d0;
+      }
       .page-numbers {
         display: inline-block;
       }

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -793,6 +793,31 @@ describe('Collection Browser', () => {
     });
   });
 
+  it('resets letter filters when query changes', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'first-creator';
+    el.selectedSort = 'creator' as SortField;
+    el.sortDirection = 'asc';
+    el.selectedCreatorFilter = 'X';
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.query).to.equal('first-creator');
+    expect(searchService.searchParams?.filters?.firstCreator?.X).to.equal(
+      FilterConstraint.INCLUDE
+    );
+
+    el.baseQuery = 'collection:foo';
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.query).to.equal('collection:foo');
+    expect(searchService.searchParams?.filters?.firstCreator).not.to.exist;
+  });
+
   it('sets date range query when date picker selection changed', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -805,6 +805,7 @@ describe('Collection Browser', () => {
     el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
+    await nextTick();
 
     expect(searchService.searchParams?.query).to.equal('first-creator');
     expect(searchService.searchParams?.filters?.firstCreator?.X).to.equal(

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -3,7 +3,7 @@ import { aTimeout, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit';
 import sinon from 'sinon';
 import type { InfiniteScroller } from '@internetarchive/infinite-scroller';
-import { SearchType } from '@internetarchive/search-service';
+import { FilterConstraint, SearchType } from '@internetarchive/search-service';
 import type { HistogramDateRange } from '@internetarchive/histogram-date-range';
 import type { CollectionBrowser } from '../src/collection-browser';
 import '../src/collection-browser';
@@ -727,8 +727,9 @@ describe('Collection Browser', () => {
     el.selectedTitleFilter = 'X';
     await el.updateComplete;
 
-    expect(searchService.searchParams?.query).to.equal(
-      'first-title AND firstTitle:X'
+    expect(searchService.searchParams?.query).to.equal('first-title');
+    expect(searchService.searchParams?.filters?.firstTitle?.X).to.equal(
+      FilterConstraint.INCLUDE
     );
   });
 
@@ -745,8 +746,9 @@ describe('Collection Browser', () => {
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
 
-    expect(searchService.searchParams?.query).to.equal(
-      'first-creator AND firstCreator:X'
+    expect(searchService.searchParams?.query).to.equal('first-creator');
+    expect(searchService.searchParams?.filters?.firstCreator?.X).to.equal(
+      FilterConstraint.INCLUDE
     );
   });
 
@@ -776,9 +778,7 @@ describe('Collection Browser', () => {
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
 
-    expect(searchService.searchParams?.query).to.equal(
-      'first-creator AND firstCreator:X'
-    );
+    expect(searchService.searchParams?.query).to.equal('first-creator');
     expect(searchService.searchParams?.filters).to.deep.equal({
       collection: {
         foo: 'inc',
@@ -786,6 +786,9 @@ describe('Collection Browser', () => {
       year: {
         '1950': 'gte',
         '1970': 'lte',
+      },
+      firstCreator: {
+        X: 'inc',
       },
     });
   });


### PR DESCRIPTION
This PR fixes a bug that prevented the alphabet bar's bucket counts from loading correctly when they were part of the initial query on page load (e.g., via a `firstTitle` or `firstCreator` filter in the URL). It also updates the requests for these counts to properly use the search service's filter map instead of joining `AND` clauses to the base query.