### PR TITLE
WEBDEV-5806 Ensure long error messages wrap properly

### DIFF
--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -119,6 +119,7 @@ export class EmptyPlaceholder extends LitElement {
 
       .error-details {
         font-size: 1.2rem;
+        word-break: break-word;
       }
     `;
   }


### PR DESCRIPTION
Search engine error messages that contain long words unbroken by whitespace, such as a long URL, currently overflow off the right side of the page. This PR just adds a style rule to make them wrap mid-word on these long strings if necessary.