### PR TITLE
WEBDEV-5842 Avoid collection title fetches when provided by original response

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.6",
+    "@internetarchive/collection-name-cache": "^0.2.7-alpha.3",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -32,7 +32,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.6",
+    "@internetarchive/search-service": "^0.4.7-alpha.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/analytics-manager": "^0.1.2",
-    "@internetarchive/collection-name-cache": "^0.2.7-alpha.3",
+    "@internetarchive/collection-name-cache": "^0.2.7",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
     "@internetarchive/histogram-date-range": "^0.1.8",
@@ -32,7 +32,7 @@
     "@internetarchive/infinite-scroller": "^0.1.3",
     "@internetarchive/local-cache": "^0.2.1",
     "@internetarchive/modal-manager": "^0.2.7",
-    "@internetarchive/search-service": "^0.4.7-alpha.1",
+    "@internetarchive/search-service": "^0.4.7",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1299,7 +1299,18 @@ export class CollectionBrowser
       return;
     }
 
-    this.aggregations = success?.response.aggregations;
+    const { aggregations, collectionTitles } = success.response;
+    this.aggregations = aggregations;
+
+    if (collectionTitles) {
+      this.collectionNameCache?.addKnownTitles(collectionTitles);
+    } else if (this.aggregations?.collection) {
+      this.collectionNameCache?.preloadIdentifiers(
+        (this.aggregations.collection.buckets as Bucket[]).map(bucket =>
+          bucket.key?.toString()
+        )
+      );
+    }
 
     this.fullYearsHistogramAggregation =
       success?.response?.aggregations?.year_histogram;
@@ -1419,9 +1430,13 @@ export class CollectionBrowser
 
     this.totalResults = success.response.totalResults;
 
-    const { results } = success.response;
+    const { results, collectionTitles } = success.response;
     if (results && results.length > 0) {
-      this.preloadCollectionNames(results);
+      if (collectionTitles) {
+        this.collectionNameCache?.addKnownTitles(collectionTitles);
+      } else {
+        this.preloadCollectionNames(results);
+      }
       this.updateDataSource(pageNumber, results);
     }
 

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -592,6 +592,50 @@ describe('Collection Browser', () => {
     ]);
   });
 
+  it('queries for collection names after an aggregations fetch', async () => {
+    const searchService = new MockSearchService();
+    const collectionNameCache = new MockCollectionNameCache();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .collectionNameCache=${collectionNameCache}
+      >
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection-aggregations';
+    await el.updateComplete;
+
+    expect(collectionNameCache.preloadIdentifiersRequested).to.deep.equal([
+      'foo',
+      'bar',
+    ]);
+  });
+
+  it('adds collection names to cache when present on response', async () => {
+    const searchService = new MockSearchService();
+    const collectionNameCache = new MockCollectionNameCache();
+
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .collectionNameCache=${collectionNameCache}
+      >
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'collection-titles';
+    await el.updateComplete;
+
+    expect(collectionNameCache.knownTitlesAdded).to.deep.equal({
+      foo: 'Foo Collection',
+      bar: 'Bar Collection',
+      baz: 'Baz Collection',
+      boop: 'Boop Collection',
+    });
+  });
+
   it('keeps search results from fetch if no change to query or sort param', async () => {
     const resultsSpy = sinon.spy();
     const searchService = new MockSearchService({

--- a/test/mocks/mock-collection-name-cache.ts
+++ b/test/mocks/mock-collection-name-cache.ts
@@ -5,6 +5,8 @@ export class MockCollectionNameCache implements CollectionNameCacheInterface {
 
   preloadIdentifiersRequested: string[] = [];
 
+  knownTitlesAdded: Record<string, string> = {};
+
   async collectionNameFor(identifier: string): Promise<string | null> {
     this.collectionNamesRequested.push(identifier);
     return `${identifier}-name`;
@@ -12,5 +14,11 @@ export class MockCollectionNameCache implements CollectionNameCacheInterface {
 
   async preloadIdentifiers(identifiers: string[]): Promise<void> {
     this.preloadIdentifiersRequested = identifiers;
+  }
+
+  async addKnownTitles(
+    identifierTitleMap: Record<string, string>
+  ): Promise<void> {
+    this.knownTitlesAdded = identifierTitleMap;
   }
 }

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -272,6 +272,95 @@ export const getMockSuccessFirstCreatorResult: () => Result<
   },
 });
 
+export const getMockSuccessWithCollectionTitles: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'collection:foo',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'collection:foo',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 2,
+      returnedCount: 2,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            collection: ['foo', 'bar'],
+          },
+        }),
+        new ItemHit({
+          fields: {
+            identifier: 'bar',
+            collection: ['baz', 'boop'],
+          },
+        }),
+      ],
+      collectionTitles: {
+        foo: 'Foo Collection',
+        bar: 'Bar Collection',
+        baz: 'Baz Collection',
+        boop: 'Boop Collection',
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
+export const getMockSuccessWithCollectionAggregations: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'collection:foo',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'collection:foo',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 0,
+      returnedCount: 0,
+      results: [],
+      aggregations: {
+        collection: new Aggregation({
+          buckets: [
+            {
+              key: 'foo',
+              doc_count: 10,
+            },
+            {
+              key: 'bar',
+              doc_count: 10,
+            },
+          ],
+        }),
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
 export const getMockSuccessSingleResultWithSort: (
   resultsSpy: Function
 ) => Result<SearchResponse, SearchServiceError> = (resultsSpy: Function) => ({

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -19,6 +19,8 @@ import {
   getMockSuccessFirstCreatorResult,
   getMockErrorResult,
   getMockMalformedResult,
+  getMockSuccessWithCollectionTitles,
+  getMockSuccessWithCollectionAggregations,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -33,6 +35,8 @@ const responses: Record<
   'loggedin-no-preview': getMockSuccessLoggedInAndNoPreviewResult,
   'first-title': getMockSuccessFirstTitleResult,
   'first-creator': getMockSuccessFirstCreatorResult,
+  'collection-titles': getMockSuccessWithCollectionTitles,
+  'collection-aggregations': getMockSuccessWithCollectionAggregations,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.7-alpha.3":
-  version "0.2.7-alpha.3"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.7-alpha.3.tgz#d7704ca234fef601962679abb5a37ddbbe187130"
-  integrity sha512-D909qOKzvqcV1QehXFZ5IlWgLjSBulH8muWzUZX8KEU5pIkoKsZ/8a5AHu4zYxKp0Xb3hKXmLoWiYyproH2Tdw==
+"@internetarchive/collection-name-cache@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.7.tgz#038cb7a5e2c6aa0a288671ba9db59c87e3b3d5bb"
+  integrity sha512-GJhz5fjypAS95TpPerA7ELQUI3SB0JkgFcnOEN/tEMqQSy5Pae5BCx16/sQ+GvtSzgCYs8qRdIuXDvDww91xyg==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.7-alpha.1"
+    "@internetarchive/search-service" "^0.4.7"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -198,10 +198,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.7-alpha.1":
-  version "0.4.7-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.7-alpha.1.tgz#8027d74a9d3399d6be6edceeeb32b7129f74a674"
-  integrity sha512-Gcv0mQh1iuaEI4txeBJmJVgI7uyUZATblANQI7LLt0zB6wLb9MLQo6j6aC4ZJaL+R6RNs+vqLL8EpUDkaeMjxA==
+"@internetarchive/search-service@^0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.7.tgz#40147e583e0a619af696043cc557702d212ac64a"
+  integrity sha512-WxLHkjWuLp0729x2ML7QW5ZnQdhkNnye6xQbvtVpJ1mZP9nt3A6cDC9c1+XDSn446YS8vkFSy/+FZRqY2s9NYg==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/analytics-manager/-/analytics-manager-0.1.2.tgz"
   integrity sha512-6hSf5NQZJsTNSmV6q6dUSVZmS/Aq5uE3rzyDFQgETJRVC21jJ7kLiVEcmxVIrmIY4NVMcTodwE3srE0BeTDzNg==
 
-"@internetarchive/collection-name-cache@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.6.tgz#25a5a2cb2d1d4636066e9954514ae3276ca9e608"
-  integrity sha512-ydS56vTKMZF7Hkqv2ggtxzuV7pFkv0fAJcq18x1w72Y7UDa8uITptbVEVdEDLkE1fCqnVl2dmi+7iv0pTjTGiA==
+"@internetarchive/collection-name-cache@^0.2.7-alpha.3":
+  version "0.2.7-alpha.3"
+  resolved "https://registry.yarnpkg.com/@internetarchive/collection-name-cache/-/collection-name-cache-0.2.7-alpha.3.tgz#d7704ca234fef601962679abb5a37ddbbe187130"
+  integrity sha512-D909qOKzvqcV1QehXFZ5IlWgLjSBulH8muWzUZX8KEU5pIkoKsZ/8a5AHu4zYxKp0Xb3hKXmLoWiYyproH2Tdw==
   dependencies:
     "@internetarchive/local-cache" "^0.2.1"
-    "@internetarchive/search-service" "^0.4.6"
+    "@internetarchive/search-service" "^0.4.7-alpha.1"
     lit "^2.0.2"
 
 "@internetarchive/feature-feedback@^0.1.4":
@@ -198,10 +198,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.6.tgz#8c3f441a323a009123b93d0d1404ddb8d3904305"
-  integrity sha512-3BvPg5uHb7oVa92PHIkzsBNm3fbryGF0kDxtl4XH+6LqMM/cL5WfHY647tTT+0k98VUQhJMZTp16+T1zzXIZGw==
+"@internetarchive/search-service@^0.4.7-alpha.1":
+  version "0.4.7-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.7-alpha.1.tgz#8027d74a9d3399d6be6edceeeb32b7129f74a674"
+  integrity sha512-Gcv0mQh1iuaEI4txeBJmJVgI7uyUZATblANQI7LLt0zB6wLb9MLQo6j6aC4ZJaL+R6RNs+vqLL8EpUDkaeMjxA==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Until recently, when we received collections on search hits & aggregations, we would only have the identifier for that collection and would need to make additional fetches to obtain its readable name. However, the PPS is now equipped with the ability to send all needed collection titles as part of the original hits/aggregations response.

This functionality is currently disabled behind a PPS flag, but will be enabled in the near future. In preparation, this PR checks whether the response includes collection titles, and if so it skips the additional step of fetching them. Otherwise, it will continue functioning as before.

When the flag is permanently enabled at the PPS end, we can take this one step further and remove the `collection-name-cache` dependency entirely.