### PR TITLE
WEBDEV-5576 Batch first two pages of results into a single request

### DIFF
--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -393,7 +393,7 @@ describe('Collection Browser', () => {
     await el.updateComplete;
 
     // This shouldn't throw an error
-    expect(el.fetchPage(2)).to.exist;
+    expect(el.fetchPage(3)).to.exist;
 
     // Should continue showing the empty placeholder
     expect(el.shadowRoot?.querySelector('empty-placeholder')).to.exist;
@@ -652,7 +652,7 @@ describe('Collection Browser', () => {
     el.sortParam = { field: 'foo', direction: 'asc' };
     await el.updateComplete;
 
-    await el.fetchPage(2);
+    await el.fetchPage(3);
 
     // If there is no change to the query or sort param during the fetch, the results
     // should be read.


### PR DESCRIPTION
Currently we make two separate page requests (for pages 1 and 2 of the results) on every query change, due to how the infinite scroller preloads a page ahead of the current one for smoother scrolling. However, it would be much easier on the search backend if these two pages were loaded together, rather than making two separate requests for them.

This PR allows initial page requests like these to be batched together and ensures that our initial page load only makes a single request for search results -- for **two** pages worth on that initial request. This only applies to the initial load of pages 1 and 2, _not_ to subsequent page loads.