### PR TITLE
WEBDEV-5828 Add "Clear all filters" button

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -678,9 +678,14 @@ export class CollectionBrowser
     const buttonText = mobile ? 'Clear all' : 'Clear all filters';
 
     return html`
-      <button class=${buttonClasses} @click=${this.clearFilters}>
-        ${buttonText}
-      </button>
+      <div class="clear-filters-btn-row">
+        ${mobile
+          ? html`<span class="clear-filters-btn-separator">&nbsp;</span>`
+          : nothing}
+        <button class=${buttonClasses} @click=${this.clearFilters}>
+          ${buttonText}
+        </button>
+      </div>
     `;
   }
 
@@ -1954,7 +1959,7 @@ export class CollectionBrowser
         #mobile-header-container {
           display: flex;
           justify-content: space-between;
-          align-items: center;
+          align-items: flex-start;
           flex-wrap: wrap;
           margin: 10px 0;
         }
@@ -1964,18 +1969,37 @@ export class CollectionBrowser
           padding: 0;
         }
 
+        .clear-filters-btn-row {
+          display: inline-block;
+        }
+
+        .desktop .clear-filters-btn-row {
+          width: 100%;
+        }
+
         .clear-filters-btn {
-          display: block;
+          display: inline-block;
           appearance: none;
           margin: 0;
           padding: 0;
           border: 0;
+          background: none;
           color: var(--ia-theme-link-color);
+          font-size: 1.4rem;
+          font-family: inherit;
           cursor: pointer;
         }
 
         .clear-filters-btn:hover {
           text-decoration: underline;
+        }
+
+        .clear-filters-btn-separator {
+          display: inline-block;
+          margin-left: 5px;
+          border-left: 1px solid #2c2c2c;
+          font-size: 1.4rem;
+          line-height: 1.3rem;
         }
 
         #facets-container {
@@ -2013,7 +2037,6 @@ export class CollectionBrowser
         #results-total {
           display: flex;
           align-items: baseline;
-          margin-bottom: 5rem;
         }
 
         .mobile #results-total {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -325,6 +325,22 @@ export class CollectionBrowser
     return false;
   }
 
+  /**
+   * Returns true if there are any currently selected/negated facet buckets,
+   * any selected date range, or any selected letter filters. False otherwise.
+   *
+   * Ignores sorting options.
+   */
+  private get hasActiveFilters(): boolean {
+    return !!(
+      this.hasCheckedFacets ||
+      this.minSelectedDate ||
+      this.maxSelectedDate ||
+      this.selectedTitleFilter ||
+      this.selectedCreatorFilter
+    );
+  }
+
   render() {
     this.setPlaceholderType();
     return html`
@@ -389,6 +405,7 @@ export class CollectionBrowser
               ${shouldShowSearching ? nothing : resultsLabel}
             </span>
           </div>
+          ${this.mobileView ? nothing : this.clearFiltersBtnTemplate(false)}
         </div>
         ${this.mobileView
           ? nothing
@@ -601,6 +618,7 @@ export class CollectionBrowser
         <summary>
           <span class="collapser-icon">${chevronIcon}</span>
           <h2>Filters</h2>
+          ${this.clearFiltersBtnTemplate(true)}
         </summary>
         ${this.facetsTemplate}
       </details>
@@ -638,6 +656,31 @@ export class CollectionBrowser
         .analyticsHandler=${this.analyticsHandler}
       >
       </collection-facets>
+    `;
+  }
+
+  /**
+   * The HTML template for the "Clear all filters" button, or `nothing` if no
+   * filters are currently active.
+   *
+   * @param mobile Whether to style/shorten the button for mobile view
+   */
+  private clearFiltersBtnTemplate(
+    mobile: boolean
+  ): TemplateResult | typeof nothing {
+    if (!this.hasActiveFilters) return nothing;
+
+    const buttonClasses = classMap({
+      'clear-filters-btn': true,
+      mobile,
+    });
+
+    const buttonText = mobile ? 'Clear all' : 'Clear all filters';
+
+    return html`
+      <button class=${buttonClasses} @click=${this.clearFilters}>
+        ${buttonText}
+      </button>
     `;
   }
 
@@ -1908,16 +1951,40 @@ export class CollectionBrowser
           background: transparent;
         }
 
+        #mobile-header-container {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          flex-wrap: wrap;
+          margin: 10px 0;
+        }
+
         .mobile #left-column {
           width: 100%;
           padding: 0;
         }
 
-        #mobile-header-container {
-          display: flex;
-          justify-content: space-between;
-          align-items: flex-start;
-          margin: 10px 0;
+        .clear-filters-btn {
+          display: block;
+          appearance: none;
+          margin: 0;
+          padding: 0;
+          border: 0;
+          color: var(--ia-theme-link-color);
+          cursor: pointer;
+        }
+
+        .clear-filters-btn:hover {
+          text-decoration: underline;
+        }
+
+        #facets-container {
+          position: relative;
+          max-height: 0;
+          transition: max-height 0.2s ease-in-out;
+          z-index: 1;
+          margin-top: 5rem;
+          padding-bottom: 2rem;
         }
 
         .desktop #mobile-header-container {


### PR DESCRIPTION
Adds a button above the facets (in both desktop and mobile view) that clears all active filters -- including facets, date ranges, and title/creator letter filters. The button does not change the active sort setting.