### PR TITLE
Share modal sizing

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -501,6 +501,9 @@ export class CollectionFacets extends LitElement {
     this.modalManager?.showModal({
       config,
       customModalContent,
+      userClosedModalCallback: () => {
+        this.modalManager?.classList.remove('more-search-facets');
+      },
     });
   }
 


### PR DESCRIPTION
Lingering class attribute when opening 'more' on facets - causing sizing discrepancy for share modal