### PR TITLE
WEBDEV-5950 Recognize facet parameters that contain numbers within the key's square brackets

### DIFF
--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -216,6 +216,16 @@ export class RestorationStateHandler
     const facetAnds = url.searchParams.getAll('and[]');
     const facetNots = url.searchParams.getAll('not[]');
 
+    // We also need to check for the presence of params like 'and[0]', 'not[1]', etc.
+    // since Facebook automatically converts URLs with [] into those forms.
+    for (const [key, val] of url.searchParams.entries()) {
+      if (/and\[\d+\]/.test(key)) {
+        facetAnds.push(val);
+      } else if (/not\[\d+\]/.test(key)) {
+        facetNots.push(val);
+      }
+    }
+
     // Legacy search allowed `q` and `search` params for the query, so in the interest
     // of backwards-compatibility with old bookmarks, we recognize those here too.
     // (However, they still get upgraded to a `query` param when we persist our state

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -397,6 +397,13 @@ export class RestorationStateHandler
     searchParams.delete('and[]');
     searchParams.delete('not[]');
 
+    // Remove any and/not facet params that contain numbers in their square brackets
+    for (const key of searchParams.keys()) {
+      if (/(and|not)\[\d+\]/.test(key)) {
+        searchParams.delete(key);
+      }
+    }
+
     // Also remove some legacy params that should have been upgraded to the ones above
     searchParams.delete('q');
     searchParams.delete('search');

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -183,6 +183,32 @@ describe('Restoration state handler', () => {
     );
   });
 
+  it('should restore selected facets with numbers in the square brackets', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[12]=subject:"foo"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.subject.foo.state).to.equal(
+      'selected'
+    );
+  });
+
+  it('should restore negative facets with numbers in the square brackets', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?not[12]=year:2018';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    const restorationState = handler.getRestorationState();
+    expect(restorationState.selectedFacets.year['2018'].state).to.equal(
+      'hidden'
+    );
+  });
+
   it('should restore sort from URL (space format)', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });
 

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -296,4 +296,22 @@ describe('Restoration state handler', () => {
     handler.persistState({ selectedFacets: getDefaultSelectedFacets() });
     expect(window.location.search).to.equal('');
   });
+
+  it('round trip load/persist should erase numbers in square brackets', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+
+    const url = new URL(window.location.href);
+    url.search = '?and[0]=subject:"foo"';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    // Load state from the URL and immediately persist it back to the URL
+    const restorationState = handler.getRestorationState();
+    handler.persistState(restorationState);
+
+    // Ensure the new URL includes the "normalized" facet parameter and not the numbered one
+    expect(decodeURIComponent(window.location.search)).to.include(
+      'and[]=subject:"foo"'
+    );
+    expect(new URL(window.location.href).searchParams.get('and[0]')).to.be.null;
+  });
 });


### PR DESCRIPTION
Context: for legacy compatibility reasons, collection-browser uses URL params containing square brackets to encode facet selection/negation, e.g., `and[]=subject:"foo"`. However, when these links are posted to Facebook (and possibly other PHP-based sites), these square brackets get altered to fill them with sequential numeric indices, e.g., `and[0]`, `and[1]`, ...

So a user who visits a search page link from Facebook always gets directed to a search with no facets selected, and a bunch of unrecognized params.

Since there's no indication Facebook is going to stop mangling links like this, we opt to be more lenient in what syntax we accept for these parameters. This PR updates the URL handling to recognize `and[]`/`not[]` parameters even if they have digits within their square brackets, and to correct them to the normalized no-number form when persisting state back to the URL.