### PR TITLE
WEBDEV-5981 Make date picker full-width in mobile layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@internetarchive/collection-name-cache": "^0.2.7",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
-    "@internetarchive/histogram-date-range": "^1.0.0",
+    "@internetarchive/histogram-date-range": "^1.0.1-alpha.1",
     "@internetarchive/ia-activity-indicator": "^0.0.4",
     "@internetarchive/ia-dropdown": "^1.1.0",
     "@internetarchive/infinite-scroller": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@internetarchive/collection-name-cache": "^0.2.7",
     "@internetarchive/feature-feedback": "^0.1.4",
     "@internetarchive/field-parsers": "^0.1.3",
-    "@internetarchive/histogram-date-range": "^1.0.1-alpha.1",
+    "@internetarchive/histogram-date-range": "^1.1.0",
     "@internetarchive/ia-activity-indicator": "^0.0.4",
     "@internetarchive/ia-dropdown": "^1.1.0",
     "@internetarchive/infinite-scroller": "^0.1.4",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -384,44 +384,75 @@ export class CollectionBrowser
   }
 
   private get collectionBrowserTemplate() {
-    const shouldShowSearching =
-      this.searchResultsLoading || this.totalResults === undefined;
-    const resultsCount = this.totalResults?.toLocaleString();
-    const resultsLabel = this.totalResults === 1 ? 'Result' : 'Results';
-    return html` <div id="left-column-scroll-sentinel"></div>
+    return html`
+      <div id="left-column-scroll-sentinel"></div>
+      ${this.leftColumnTemplate} ${this.rightColumnTemplate}
+    `;
+  }
+
+  private get leftColumnTemplate(): TemplateResult {
+    if (this.mobileView) {
+      return this.mobileLeftColumnTemplate;
+    }
+    return this.desktopLeftColumnTemplate;
+  }
+
+  private get mobileLeftColumnTemplate(): TemplateResult {
+    return html`
       <div
         id="left-column"
         class="column${this.isResizeToMobile ? ' preload' : ''}"
       >
-        <div id="mobile-header-container">
-          ${this.mobileView
-            ? this.mobileFacetsTemplate
-            : html`<h2 id="facets-header" class="sr-only">Filters</h2>`}
-          <div id="results-total">
-            <span id="big-results-count">
-              ${shouldShowSearching ? html`Searching&hellip;` : resultsCount}
-            </span>
-            <span id="big-results-label">
-              ${shouldShowSearching ? nothing : resultsLabel}
-            </span>
-          </div>
-          ${this.mobileView ? nothing : this.clearFiltersBtnTemplate(false)}
-        </div>
-        ${this.mobileView
-          ? nothing
-          : html`<div id="facets-container" aria-labelledby="facets-header">
-              ${this.facetsTemplate}
-              <div id="facets-scroll-sentinel"></div>
-            </div>`}
-        ${this.mobileView ? nothing : html`<div id="facets-bottom-fade"></div>`}
+        ${this.resultsCountTemplate}
+        <div id="facets-header-container">${this.mobileFacetsTemplate}</div>
       </div>
+    `;
+  }
+
+  private get desktopLeftColumnTemplate(): TemplateResult {
+    return html`
+      <div id="left-column" class="column">
+        <div id="facets-header-container">
+          <h2 id="facets-header" class="sr-only">Filters</h2>
+          ${this.resultsCountTemplate} ${this.clearFiltersBtnTemplate(false)}
+        </div>
+        <div id="facets-container" aria-labelledby="facets-header">
+          ${this.facetsTemplate}
+          <div id="facets-scroll-sentinel"></div>
+        </div>
+        <div id="facets-bottom-fade"></div>
+      </div>
+    `;
+  }
+
+  private get resultsCountTemplate(): TemplateResult {
+    const shouldShowSearching =
+      this.searchResultsLoading || this.totalResults === undefined;
+    const resultsCount = this.totalResults?.toLocaleString();
+    const resultsLabel = this.totalResults === 1 ? 'Result' : 'Results';
+
+    return html`
+      <div id="results-total">
+        <span id="big-results-count">
+          ${shouldShowSearching ? html`Searching&hellip;` : resultsCount}
+        </span>
+        <span id="big-results-label">
+          ${shouldShowSearching ? nothing : resultsLabel}
+        </span>
+      </div>
+    `;
+  }
+
+  private get rightColumnTemplate(): TemplateResult {
+    return html`
       <div id="right-column" class="column">
         ${this.sortFilterBarTemplate}
         ${this.displayMode === `list-compact`
           ? this.listHeaderTemplate
           : nothing}
         ${this.infiniteScrollerTemplate}
-      </div>`;
+      </div>
+    `;
   }
 
   private get infiniteScrollerTemplate() {
@@ -1827,6 +1858,10 @@ export class CollectionBrowser
           transition: transform 0.2s ease-out;
         }
 
+        #mobile-filter-collapse {
+          width: 100%;
+        }
+
         #mobile-filter-collapse > summary {
           cursor: pointer;
           list-style: none;
@@ -1957,14 +1992,14 @@ export class CollectionBrowser
           background: transparent;
         }
 
-        #mobile-header-container {
+        #facets-header-container {
           display: flex;
           justify-content: space-between;
           align-items: flex-start;
           margin: 10px 0;
         }
 
-        .desktop #mobile-header-container {
+        .desktop #facets-header-container {
           padding-top: 2rem;
           flex-wrap: wrap;
         }
@@ -2037,6 +2072,7 @@ export class CollectionBrowser
         }
 
         .mobile #results-total {
+          float: right;
           margin-bottom: 0;
           margin-right: 5px;
         }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -385,6 +385,9 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Top-level template for rendering the left (facets) and right (results) columns.
+   */
   private get collectionBrowserTemplate() {
     return html`
       <div id="left-column-scroll-sentinel"></div>
@@ -392,6 +395,10 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for either the mobile or desktop version of the left column, depending
+   * on current component state.
+   */
   private get leftColumnTemplate(): TemplateResult {
     if (this.mobileView) {
       return this.mobileLeftColumnTemplate;
@@ -399,6 +406,11 @@ export class CollectionBrowser
     return this.desktopLeftColumnTemplate;
   }
 
+  /**
+   * Template for the mobile version of the "left column" (which in this case, appears
+   * *above* the search results rather than beside them), for rendering the
+   * accordion-style facets.
+   */
   private get mobileLeftColumnTemplate(): TemplateResult {
     return html`
       <div
@@ -411,6 +423,9 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for the desktop version of the left column, displaying the facets sidebar.
+   */
   private get desktopLeftColumnTemplate(): TemplateResult {
     return html`
       <div id="left-column" class="column">
@@ -427,6 +442,10 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for the "X Results" count at the top of the search results.
+   * Changes to the "Searching..." label if the search results are still loading.
+   */
   private get resultsCountTemplate(): TemplateResult {
     const shouldShowSearching =
       this.searchResultsLoading || this.totalResults === undefined;
@@ -445,6 +464,10 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for the right column of the collection browser, where the result
+   * tiles and sort/filter bar are shown.
+   */
   private get rightColumnTemplate(): TemplateResult {
     return html`
       <div id="right-column" class="column">

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -181,6 +181,8 @@ export class CollectionBrowser
 
   @state() private mobileFacetsVisible = false;
 
+  @state() private contentWidth?: number;
+
   @state() private placeholderType: PlaceholderType = null;
 
   @state() private prefixFilterCountMap: Partial<
@@ -678,6 +680,7 @@ export class CollectionBrowser
         .collectionNameCache=${this.collectionNameCache}
         .showHistogramDatePicker=${this.showHistogramDatePicker}
         .allowExpandingDatePicker=${!this.mobileView}
+        .contentWidth=${this.contentWidth}
         .query=${this.baseQuery}
         .filterMap=${this.filterMap}
         .modalManager=${this.modalManager}
@@ -900,7 +903,8 @@ export class CollectionBrowser
   handleResize(entry: ResizeObserverEntry): void {
     const previousView = this.mobileView;
     if (entry.target === this.contentContainer) {
-      this.mobileView = entry.contentRect.width < this.mobileBreakpoint;
+      this.contentWidth = entry.contentRect.width;
+      this.mobileView = this.contentWidth < this.mobileBreakpoint;
       // If changing from desktop to mobile disable transition
       if (this.mobileView && !previousView) {
         this.isResizeToMobile = true;

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -229,10 +229,6 @@ export class CollectionFacets extends LitElement {
       : nothing;
   }
 
-  private get currentYearsHistogramAggregation(): Aggregation | undefined {
-    return this.aggregations?.year_histogram;
-  }
-
   private get histogramTemplate() {
     const { fullYearsHistogramAggregation } = this;
     return this.fullYearAggregationLoading

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -80,6 +80,8 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Boolean }) collapsableFacets = false;
 
+  @property({ type: Number }) contentWidth?: number;
+
   @property({ type: Boolean }) showHistogramDatePicker = false;
 
   @property({ type: Boolean }) allowExpandingDatePicker = false;
@@ -241,7 +243,9 @@ export class CollectionFacets extends LitElement {
             .maxSelectedDate=${this.maxSelectedDate}
             .updateDelay=${100}
             missingDataMessage="..."
-            .width=${180}
+            .width=${this.collapsableFacets && this.contentWidth
+              ? this.contentWidth
+              : 180}
             .bins=${fullYearsHistogramAggregation?.buckets as number[]}
             @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
           ></histogram-date-range>

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,10 +108,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-0.1.3.tgz"
   integrity sha512-gN7ivwHWlf8V7fD3VakQ4NtddSou5i3A3TqbIo8EKF+XTxJXaXpNBmzkZEGf2oMVK8rHvrabFxZKVEy9qG7Omw==
 
-"@internetarchive/histogram-date-range@^1.0.1-alpha.1":
-  version "1.0.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.0.1-alpha.1.tgz#6464a90689e8eb41ae5d3c3e728e166760199f1b"
-  integrity sha512-6JIigQXyJcs6vbQvicOKT1VytlCRn5S+OoEyRvYL6JkxQvvzVKS4cgU7tWbrDilx6MS+4sNcsbsCWRyweL6cmA==
+"@internetarchive/histogram-date-range@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.1.0.tgz#d6f5ff58e23ad97efff7623952342b60819f8e75"
+  integrity sha512-iuFA4GZYnsoD3dVkQswqFsLnxBrJlpRFcbcOnHHw05ynRs/s0Xc7rTwDVMljc2heLFUUFtYIf4icVXyUoUJKXg==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.4"
     dayjs "^1.10.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,10 +108,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-0.1.3.tgz"
   integrity sha512-gN7ivwHWlf8V7fD3VakQ4NtddSou5i3A3TqbIo8EKF+XTxJXaXpNBmzkZEGf2oMVK8rHvrabFxZKVEy9qG7Omw==
 
-"@internetarchive/histogram-date-range@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.0.0.tgz#3e8b7651abf372d1a472e8fa29966c1177dbcc42"
-  integrity sha512-3pXMt0FjT3RWGV4y0g8ngej28l6BKf6oFmJMlnDMjEaiP1T40ZMSVoQoVS1yJwkgpINimBatUgx7PKUCM0HeOA==
+"@internetarchive/histogram-date-range@^1.0.1-alpha.1":
+  version "1.0.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.0.1-alpha.1.tgz#6464a90689e8eb41ae5d3c3e728e166760199f1b"
+  integrity sha512-6JIigQXyJcs6vbQvicOKT1VytlCRn5S+OoEyRvYL6JkxQvvzVKS4cgU7tWbrDilx6MS+4sNcsbsCWRyweL6cmA==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.4"
     dayjs "^1.10.7"


### PR DESCRIPTION
At mobile widths, the date picker only takes up a fraction of the available space, making it small and hard to read.

While in desktop view we solved this by allowing it to expand into a larger modal, in the mobile layout it is possible to make the date picker wider all the time, no modal required. This PR allows it to fill the entire container width available to it in mobile view.

This also entails upgrading `histogram-date-range` component version, as the previous version has a bug causing it not to fully render updates to the component's `width`/`height` properties.