### PR TITLE
WEBDEV-5813 Mediatype icon links should open in the same tab

### DIFF
--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -127,7 +127,7 @@ export class TileList extends LitElement {
   // Data templates
   private get iconRightTemplate() {
     return html`
-      <a id="icon-right" href=${this.mediatypeURL} target="_blank">
+      <a id="icon-right" href=${this.mediatypeURL}>
         <mediatype-icon
           .mediatype=${this.model?.mediatype}
           .collections=${this.model?.collections}


### PR DESCRIPTION
Currently, clicking the mediatype icon on a list view tile opens that mediatype's collection in a new tab. This PR just makes it open in the same tab for consistency with all the other links on the page.