### PR TITLE
WEBDEV-6122 Collapse double-wrapped quotes in tile href

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1786,7 +1786,7 @@ export class CollectionBrowser
         dateReviewed: result.reviewdate?.value,
         description: result.description?.values.join('\n'),
         favCount: result.num_favorites?.value ?? 0,
-        href: result.__href__?.value,
+        href: this.collapseRepeatedQuotes(result.__href__?.value),
         identifier: result.identifier,
         issue: result.issue?.value,
         itemCount: result.item_count?.value ?? 0,
@@ -1809,6 +1809,20 @@ export class CollectionBrowser
     if (needsReload) {
       this.infiniteScroller?.reload();
     }
+  }
+
+  /**
+   * Returns the input string, but removing one set of quotes from all instances of
+   * ""clauses wrapped in two sets of quotes"". This assumes the quotes are already
+   * URL-encoded.
+   *
+   * This should be a temporary measure to address the fact that the __href__ field
+   * sometimes acquires extra quotation marks during query rewriting. Once there is a
+   * full Lucene parser in place that handles quoted queries correctly, this can likely
+   * be removed.
+   */
+  private collapseRepeatedQuotes(str?: string): string | undefined {
+    return str?.replace(/%22%22(?!%22%22)(.+?)%22%22/g, '%22$1%22');
   }
 
   /** Fetches the aggregation buckets for the given prefix filter type. */

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -945,7 +945,6 @@ describe('Collection Browser', () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
-        .log=${true}
         .searchService=${searchService}
       ></collection-browser>`
     );
@@ -959,6 +958,34 @@ describe('Collection Browser', () => {
     expect(spy.callCount).to.equal(2);
     expect(spy.firstCall.firstArg?.detail?.loading).to.equal(true);
     expect(spy.secondCall.firstArg?.detail?.loading).to.equal(false);
+  });
+
+  it('collapses extra set of quotes around href field', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+      ></collection-browser>`
+    );
+
+    el.baseQuery = 'extra-quoted-href';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await el.updateComplete;
+    await nextTick();
+
+    const infiniteScroller = el.shadowRoot?.querySelector('infinite-scroller');
+    expect(infiniteScroller).to.exist;
+
+    const firstResult =
+      infiniteScroller!.shadowRoot?.querySelector('tile-dispatcher');
+    expect(firstResult).to.exist;
+
+    // Original href q param starts/ends with %22%22, but should be collapsed to %22 before render
+    expect(
+      firstResult!.shadowRoot?.querySelector('a[href]')?.getAttribute('href')
+    ).to.equal('/details/foo?q=%22quoted+query%22');
   });
 
   it('scrolls to page', async () => {

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -4,6 +4,7 @@ import {
   ItemHit,
   SearchResponse,
   SearchServiceError,
+  TextHit,
 } from '@internetarchive/search-service';
 import { SearchServiceErrorType } from '@internetarchive/search-service/dist/src/search-service-error';
 
@@ -464,6 +465,42 @@ export const getMockSuccessMultiLineDescription: () => Result<
             identifier: 'foo',
             collection: ['foo', 'bar'],
             description: ['line1', 'line2'],
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
+export const getMockSuccessExtraQuotedHref: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'extra-quoted-href',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'extra-quoted-href',
+        sort: [],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new TextHit({
+          fields: {
+            identifier: 'foo',
+            title: 'Foo',
+            __href__: '/details/foo?q=%22%22quoted+query%22%22',
           },
         }),
       ],

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -21,6 +21,7 @@ import {
   getMockMalformedResult,
   getMockSuccessWithCollectionTitles,
   getMockSuccessWithCollectionAggregations,
+  getMockSuccessExtraQuotedHref,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -37,6 +38,7 @@ const responses: Record<
   'first-creator': getMockSuccessFirstCreatorResult,
   'collection-titles': getMockSuccessWithCollectionTitles,
   'collection-aggregations': getMockSuccessWithCollectionAggregations,
+  'extra-quoted-href': getMockSuccessExtraQuotedHref,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,
 };


### PR DESCRIPTION
When the backend provides a tile `__href__` field for FTS queries, its values sometimes have erroneous ""doubly quoted"" clauses which cause subsequent search-within to fail. While there are more fundamental backend fixes in the works to address the source of those extra quotes, this PR provides a temporary fix to prevent them from affecting the rendered tile links.