### PR TITLE
WEBDEV-5910 Accept `withinCollection` prop with no query, for collection pages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 export { CollectionBrowser } from './src/collection-browser';
 export { SortFilterBar } from './src/sort-filter-bar/sort-filter-bar';
-export { CollectionDisplayMode } from './src/models';
+export { CollectionDisplayMode, SortField } from './src/models';
 export { CollectionBrowserLoadingTile } from './src/tiles/collection-browser-loading-tile';
 export { CollectionTile } from './src/tiles/grid/collection-tile';
 export { AccountTile } from './src/tiles/grid/account-tile';

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -95,9 +95,7 @@ export class AppRoot extends LitElement {
     this.searchQuery = this.baseQueryField.value;
     this.collectionBrowser.searchType = this.searchType;
 
-    if ((this.currentPage ?? 1) > 1) {
-      this.collectionBrowser.goToPage(this.currentPage ?? 1);
-    }
+    this.goToCurrentPage();
   }
 
   private collectionChanged(e: Event) {
@@ -105,8 +103,13 @@ export class AppRoot extends LitElement {
     this.withinCollection = this.baseCollectionField.value;
     this.collectionBrowser.withinCollection = this.withinCollection;
 
-    if ((this.currentPage ?? 1) > 1) {
-      this.collectionBrowser.goToPage(this.currentPage ?? 1);
+    this.goToCurrentPage();
+  }
+
+  private goToCurrentPage() {
+    const page = this.currentPage ?? 1;
+    if (page > 1) {
+      this.collectionBrowser.goToPage(page);
     }
   }
 

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -39,6 +39,8 @@ export class AppRoot extends LitElement {
 
   @state() private searchQuery?: string;
 
+  @state() private withinCollection?: string;
+
   @state() private cellWidth: number = 18;
 
   @state() private cellHeight: number = 29;
@@ -54,6 +56,9 @@ export class AppRoot extends LitElement {
   @property({ type: Object, reflect: false }) latestAction?: AnalyticsEvent;
 
   @query('#base-query-field') private baseQueryField!: HTMLInputElement;
+
+  @query('#base-collection-field')
+  private baseCollectionField!: HTMLInputElement;
 
   @query('#page-number-input') private pageNumberInput!: HTMLInputElement;
 
@@ -89,6 +94,16 @@ export class AppRoot extends LitElement {
     e.preventDefault();
     this.searchQuery = this.baseQueryField.value;
     this.collectionBrowser.searchType = this.searchType;
+
+    if ((this.currentPage ?? 1) > 1) {
+      this.collectionBrowser.goToPage(this.currentPage ?? 1);
+    }
+  }
+
+  private collectionChanged(e: Event) {
+    e.preventDefault();
+    this.withinCollection = this.baseCollectionField.value;
+    this.collectionBrowser.withinCollection = this.withinCollection;
 
     if ((this.currentPage ?? 1) > 1) {
       this.collectionBrowser.goToPage(this.currentPage ?? 1);
@@ -139,6 +154,17 @@ export class AppRoot extends LitElement {
               <label for="page-number-input"> Page: </label>
               <input type="number" value="1" id="page-number-input" />
               <input type="submit" value="Go" />
+            </form>
+          </div>
+          <div>
+            <form @submit=${this.collectionChanged}>
+              <label for="base-collection-field"> Within collection: </label>
+              <input
+                type="text"
+                id="base-collection-field"
+                .value=${this.withinCollection ?? ''}
+              />
+              <input type="submit" value="Search" />
             </form>
           </div>
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2013,6 +2013,10 @@ export class CollectionBrowser
           display: flex;
         }
 
+        empty-placeholder {
+          margin-top: var(--placeholderMarginTop, 0);
+        }
+
         .collapser-icon {
           display: inline-block;
         }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -90,6 +90,8 @@ export class CollectionBrowser
 
   @property({ type: String }) searchType: SearchType = SearchType.METADATA;
 
+  @property({ type: String }) withinCollection?: string;
+
   @property({ type: String }) baseQuery?: string;
 
   @property({ type: String }) displayMode?: CollectionDisplayMode;
@@ -1480,14 +1482,19 @@ export class CollectionBrowser
 
   private async fetchFacets() {
     const trimmedQuery = this.baseQuery?.trim();
-    if (!trimmedQuery) return;
+    if (!trimmedQuery && !this.withinCollection) return;
     if (!this.searchService) return;
 
     const { facetFetchQueryKey } = this;
 
+    const collectionParams = this.withinCollection
+      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
+      : null;
+
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
-      query: trimmedQuery,
+      ...collectionParams,
+      query: trimmedQuery || '',
       rows: 0,
       filters: this.filterMap,
       // Fetch a few extra buckets beyond the 6 we show, in case some get suppressed
@@ -1609,7 +1616,7 @@ export class CollectionBrowser
    */
   async fetchPage(pageNumber: number, numInitialPages = 1) {
     const trimmedQuery = this.baseQuery?.trim();
-    if (!trimmedQuery) return;
+    if (!trimmedQuery && !this.withinCollection) return;
     if (!this.searchService) return;
 
     // if we already have data, don't fetch again
@@ -1632,9 +1639,14 @@ export class CollectionBrowser
     }
     this.pageFetchesInProgress[pageFetchQueryKey] = pageFetches;
 
+    const collectionParams = this.withinCollection
+      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
+      : null;
+
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
-      query: trimmedQuery,
+      ...collectionParams,
+      query: trimmedQuery || '',
       page: pageNumber,
       rows: numRows,
       sort: sortParams,
@@ -1830,12 +1842,18 @@ export class CollectionBrowser
     filterType: PrefixFilterType
   ): Promise<Bucket[]> {
     const trimmedQuery = this.baseQuery?.trim();
-    if (!trimmedQuery) return [];
+    if (!trimmedQuery && !this.withinCollection) return [];
 
     const filterAggregationKey = prefixFilterAggregationKeys[filterType];
     const sortParams = this.sortParam ? [this.sortParam] : [];
+
+    const collectionParams = this.withinCollection
+      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
+      : null;
+
     const params: SearchParams = {
-      query: trimmedQuery,
+      ...collectionParams,
+      query: trimmedQuery || '',
       rows: 0,
       filters: this.filterMap,
       // Only fetch the firstTitle or firstCreator aggregation

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -384,7 +384,7 @@ export class CollectionBrowser
 
   private setPlaceholderType() {
     this.placeholderType = null;
-    if (!this.baseQuery?.trim()) {
+    if (!this.baseQuery?.trim() && !this.withinCollection) {
       this.placeholderType = 'empty-query';
     } else if (
       !this.searchResultsLoading &&
@@ -911,7 +911,8 @@ export class CollectionBrowser
       changed.has('maxSelectedDate') ||
       changed.has('sortParam') ||
       changed.has('selectedFacets') ||
-      changed.has('searchService')
+      changed.has('searchService') ||
+      changed.has('withinCollection')
     ) {
       this.handleQueryChange();
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1351,8 +1351,7 @@ export class CollectionBrowser
 
   /** The full query, including year facets and date range clauses */
   private get fullQuery(): string | undefined {
-    if (!this.baseQuery) return undefined;
-    let fullQuery = this.baseQuery.trim();
+    let fullQuery = this.baseQuery?.trim() ?? '';
 
     const { facetQuery, dateRangeQueryClause, sortFilterQueries } = this;
 
@@ -1591,6 +1590,7 @@ export class CollectionBrowser
    * The query key is a string that uniquely identifies the current search.
    * It consists of:
    *  - The current base query
+   *  - The current collection
    *  - The current search type
    *  - Any currently-applied facets
    *  - Any currently-applied date range
@@ -1603,7 +1603,7 @@ export class CollectionBrowser
   private get pageFetchQueryKey(): string {
     const sortField = this.sortParam?.field ?? 'none';
     const sortDirection = this.sortParam?.direction ?? 'none';
-    return `${this.fullQuery}-${this.searchType}-${sortField}-${sortDirection}`;
+    return `${this.fullQuery}-${this.withinCollection}-${this.searchType}-${sortField}-${sortDirection}`;
   }
 
   /**
@@ -1611,7 +1611,7 @@ export class CollectionBrowser
    * are not relevant in determining aggregation queries.
    */
   private get facetFetchQueryKey(): string {
-    return `${this.fullQuery}-${this.searchType}`;
+    return `${this.fullQuery}-${this.withinCollection}-${this.searchType}`;
   }
 
   // this maps the query to the pages being fetched for that query

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1724,10 +1724,12 @@ export class CollectionBrowser
     // When we reach the end of the data, we can set the infinite scroller's
     // item count to the real total number of results (rather than the
     // temporary estimates based on pages rendered so far).
-    if (results.length < this.pageSize) {
+    const resultCountDiscrepancy = numRows - results.length;
+    if (resultCountDiscrepancy > 0) {
       this.endOfDataReached = true;
       if (this.infiniteScroller) {
-        this.infiniteScroller.itemCount = this.totalResults;
+        this.infiniteScroller.itemCount =
+          this.estimatedTileCount - resultCountDiscrepancy;
       }
     }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -953,7 +953,8 @@ export class CollectionBrowser
     const previousView = this.mobileView;
     if (entry.target === this.contentContainer) {
       this.contentWidth = entry.contentRect.width;
-      this.mobileView = this.contentWidth < this.mobileBreakpoint;
+      this.mobileView =
+        this.contentWidth > 0 && this.contentWidth < this.mobileBreakpoint;
       // If changing from desktop to mobile disable transition
       if (this.mobileView && !previousView) {
         this.isResizeToMobile = true;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2056,6 +2056,7 @@ export class CollectionBrowser
           border-right: 1px solid rgb(232, 232, 232);
           padding-left: 1rem;
           padding-right: 1rem;
+          margin-top: var(--rightColumnMarginTop, 0);
           background: #fff;
         }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -120,6 +120,8 @@ export class CollectionBrowser
 
   @property({ type: Boolean }) showHistogramDatePicker = false;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   /** describes where this component is being used */
   @property({ type: String, reflect: true }) searchContext: string =
     analyticsCategories.default;
@@ -714,6 +716,7 @@ export class CollectionBrowser
       <collection-facets
         @facetsChanged=${this.facetsChanged}
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
+        .collectionPagePath=${this.collectionPagePath}
         .searchService=${this.searchService}
         .featureFeedbackService=${this.featureFeedbackService}
         .recaptchaManager=${this.recaptchaManager}
@@ -1953,6 +1956,7 @@ export class CollectionBrowser
 
     return html`
       <tile-dispatcher
+        .collectionPagePath=${this.collectionPagePath}
         .baseNavigationUrl=${this.baseNavigationUrl}
         .baseImageUrl=${this.baseImageUrl}
         .model=${model}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1488,13 +1488,9 @@ export class CollectionBrowser
 
     const { facetFetchQueryKey } = this;
 
-    const collectionParams = this.withinCollection
-      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
-      : null;
-
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
-      ...collectionParams,
+      ...this.collectionParams,
       query: trimmedQuery || '',
       rows: 0,
       filters: this.filterMap,
@@ -1578,6 +1574,19 @@ export class CollectionBrowser
   }
 
   /**
+   * Additional params to pass to the search service if targeting a collection page,
+   * or null otherwise.
+   */
+  private get collectionParams(): {
+    pageType: string;
+    pageTarget: string;
+  } | null {
+    return this.withinCollection
+      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
+      : null;
+  }
+
+  /**
    * The query key is a string that uniquely identifies the current search.
    * It consists of:
    *  - The current base query
@@ -1640,13 +1649,9 @@ export class CollectionBrowser
     }
     this.pageFetchesInProgress[pageFetchQueryKey] = pageFetches;
 
-    const collectionParams = this.withinCollection
-      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
-      : null;
-
     const sortParams = this.sortParam ? [this.sortParam] : [];
     const params: SearchParams = {
-      ...collectionParams,
+      ...this.collectionParams,
       query: trimmedQuery || '',
       page: pageNumber,
       rows: numRows,
@@ -1848,12 +1853,8 @@ export class CollectionBrowser
     const filterAggregationKey = prefixFilterAggregationKeys[filterType];
     const sortParams = this.sortParam ? [this.sortParam] : [];
 
-    const collectionParams = this.withinCollection
-      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
-      : null;
-
     const params: SearchParams = {
-      ...collectionParams,
+      ...this.collectionParams,
       query: trimmedQuery || '',
       rows: 0,
       filters: this.filterMap,

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -90,6 +90,8 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object }) filterMap?: FilterMap;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   @property({ type: Object, attribute: false })
   modalManager?: ModalManagerInterface;
 
@@ -626,6 +628,7 @@ export class CollectionFacets extends LitElement {
   private getFacetTemplate(facetGroup: FacetGroup): TemplateResult {
     return html`
       <facets-template
+        .collectionPagePath=${this.collectionPagePath}
         .facetGroup=${facetGroup}
         .selectedFacets=${this.selectedFacets}
         .renderOn=${'page'}

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -22,6 +22,8 @@ export class FacetsTemplate extends LitElement {
 
   @property({ type: String }) renderOn?: string;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   @property({ type: Object })
   collectionNameCache?: CollectionNameCacheInterface;
 
@@ -146,7 +148,7 @@ export class FacetsTemplate extends LitElement {
             const bucketTextDisplay =
               facetGroup.key !== 'collection'
                 ? html`${bucket.displayText ?? bucket.key}`
-                : html`<a href="/details/${bucket.key}">
+                : html`<a href="${this.collectionPagePath}${bucket.key}">
                     <async-collection-name
                       .collectionNameCache=${this.collectionNameCache}
                       .identifier=${bucket.key}

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -8,20 +8,52 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { choose } from 'lit/directives/choose.js';
+import { msg } from '@lit/localize';
 
 import emptyQueryIcon from './assets/img/icons/empty-query';
 import nullResultIcon from './assets/img/icons/null-result';
 
 export type PlaceholderType =
   | 'empty-query'
-  | 'null-result'
+  | 'empty-collection'
+  | 'no-results'
   | 'query-error'
   | null;
 @customElement('empty-placeholder')
 export class EmptyPlaceholder extends LitElement {
+  private static readonly MESSAGE_EMPTY_QUERY = msg(
+    'To begin searching, enter a search term in the box above and hit "Go".'
+  );
+
+  private static readonly MESSAGE_NO_SEARCH_RESULTS = msg(
+    'Your search did not match any items in the Archive. ' +
+      'Try different keywords or a more general search.'
+  );
+
+  private static readonly MESSAGE_NO_COLLECTION_RESULTS = msg(
+    'Your search did not match any items in this collection. ' +
+      'Try different keywords or a more general search.'
+  );
+
+  private static readonly MESSAGE_NO_VIEWABLE_MEMBERS = msg(
+    'This collection contains no viewable items.'
+  );
+
+  private static readonly MESSAGE_QUERY_ERROR = msg(html`The search engine
+    encountered an error, which might be related to your search query.
+    <a
+      href="https://help.archive.org/help/search-building-powerful-complex-queries/"
+    >
+      Tips for constructing search queries.
+    </a> `);
+
+  private static readonly QUERY_ERROR_DETAILS_MESSAGE = msg('Error details:');
+
   @property({ type: String }) placeholderType: PlaceholderType = null;
 
   @property({ type: Boolean }) isMobileView?: false;
+
+  @property({ type: Boolean }) isCollection?: false;
 
   @property({ type: String }) detailMessage?: string = '';
 
@@ -38,7 +70,8 @@ export class EmptyPlaceholder extends LitElement {
       >
         ${choose(this.placeholderType, [
           ['empty-query', () => this.emptyQueryTemplate],
-          ['null-result', () => this.nullResultTemplate],
+          ['empty-collection', () => this.emptyCollectionTemplate],
+          ['no-results', () => this.noResultsTemplate],
           ['query-error', () => this.queryErrorTemplate],
         ])}
       </div>
@@ -47,18 +80,24 @@ export class EmptyPlaceholder extends LitElement {
 
   private get emptyQueryTemplate(): TemplateResult {
     return html`
-      <h2 class="title">
-        To begin searching, enter a search term in the box above and hit "Go".
-      </h2>
+      <h2 class="title">${EmptyPlaceholder.MESSAGE_EMPTY_QUERY}</h2>
       <div>${emptyQueryIcon}</div>
     `;
   }
 
-  private get nullResultTemplate(): TemplateResult {
+  private get emptyCollectionTemplate(): TemplateResult {
+    return html`
+      <h2 class="title">${EmptyPlaceholder.MESSAGE_NO_VIEWABLE_MEMBERS}</h2>
+      <div>${nullResultIcon}</div>
+    `;
+  }
+
+  private get noResultsTemplate(): TemplateResult {
     return html`
       <h2 class="title">
-        Your search did not match any items in the Archive. Try different
-        keywords or a more general search.
+        ${this.isCollection
+          ? EmptyPlaceholder.MESSAGE_NO_COLLECTION_RESULTS
+          : EmptyPlaceholder.MESSAGE_NO_SEARCH_RESULTS}
       </h2>
       <div>${nullResultIcon}</div>
     `;
@@ -66,17 +105,11 @@ export class EmptyPlaceholder extends LitElement {
 
   private get queryErrorTemplate(): TemplateResult {
     return html`
-      <h2 class="title">
-        The search engine encountered an error, which might be related to your
-        search query.
-        <a
-          href="https://help.archive.org/help/search-building-powerful-complex-queries/"
-        >
-          Tips for constructing search queries.
-        </a>
-      </h2>
+      <h2 class="title">${EmptyPlaceholder.MESSAGE_QUERY_ERROR}</h2>
       <div>${nullResultIcon}</div>
-      <p class="error-details">Error details: ${this.detailMessage}</p>
+      <p class="error-details">
+        ${EmptyPlaceholder.QUERY_ERROR_DETAILS_MESSAGE} ${this.detailMessage}
+      </p>
     `;
   }
 

--- a/src/sort-filter-bar/alpha-bar.ts
+++ b/src/sort-filter-bar/alpha-bar.ts
@@ -210,7 +210,7 @@ export class AlphaBar extends LitElement {
       border: none;
       border-radius: 4px;
       font-family: inherit;
-      font-size: inherit;
+      font-size: 1.2rem;
       cursor: pointer;
     }
 

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import DOMPurify from 'dompurify';
 import type { SortParam } from '@internetarchive/search-service';
@@ -65,17 +65,19 @@ export class TileListCompact extends LitElement {
     `;
   }
 
-  private get href(): string {
+  private get href(): string | typeof nothing {
+    if (!this.model?.identifier || this.baseNavigationUrl == null)
+      return nothing;
+
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
-    if (this.model?.href) {
-      return `${this.baseNavigationUrl}${this.model?.href}`;
+    if (this.model.href) {
+      return `${this.baseNavigationUrl}${this.model.href}`;
     }
 
     const isCollection = this.model?.mediatype === 'collection';
-    return `${this.baseNavigationUrl}${
-      isCollection ? this.collectionPagePath : '/details/'
-    }${this.model?.identifier}`;
+    const basePath = isCollection ? this.collectionPagePath : '/details/';
+    return `${this.baseNavigationUrl}${basePath}${this.model.identifier}`;
   }
 
   /*

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -30,6 +30,8 @@ export class TileListCompact extends LitElement {
 
   @property({ type: Boolean }) loggedIn = false;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   render() {
     return html`
       <div id="list-line" class="${this.classSize}">
@@ -66,9 +68,14 @@ export class TileListCompact extends LitElement {
   private get href(): string {
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
-    return this.model?.href
-      ? `${this.baseNavigationUrl}${this.model.href}`
-      : `${this.baseNavigationUrl}/details/${this.model?.identifier}`;
+    if (this.model?.href) {
+      return `${this.baseNavigationUrl}${this.model?.href}`;
+    }
+
+    const isCollection = this.model?.mediatype === 'collection';
+    return `${this.baseNavigationUrl}${
+      isCollection ? this.collectionPagePath : '/details/'
+    }${this.model?.identifier}`;
   }
 
   /*

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -96,11 +96,15 @@ export class TileList extends LitElement {
     if (!this.model) return nothing;
 
     const isCollection = this.model.mediatype === 'collection';
-    return html`<a
-      href="${this.baseNavigationUrl}${isCollection
-        ? this.collectionPagePath
-        : '/details/'}${encodeURI(this.model.identifier)}"
-    >
+    const hrefBasePath = isCollection ? this.collectionPagePath : '/details/';
+    const href =
+      this.model.identifier && this.baseNavigationUrl != null
+        ? `${this.baseNavigationUrl}${hrefBasePath}${encodeURI(
+            this.model.identifier
+          )}`
+        : nothing;
+
+    return html`<a href=${href}>
       <image-block
         .model=${this.model}
         .baseImageUrl=${this.baseImageUrl}

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -49,6 +49,8 @@ export class TileList extends LitElement {
 
   @property({ type: Boolean }) loggedIn = false;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   render() {
     return html`
       <div id="list-line" class="${this.classSize}">
@@ -93,10 +95,11 @@ export class TileList extends LitElement {
   private get imageBlockTemplate() {
     if (!this.model) return nothing;
 
+    const isCollection = this.model.mediatype === 'collection';
     return html`<a
-      href="${this.baseNavigationUrl}/details/${encodeURI(
-        this.model.identifier
-      )}"
+      href="${this.baseNavigationUrl}${isCollection
+        ? this.collectionPagePath
+        : '/details/'}${encodeURI(this.model.identifier)}"
     >
       <image-block
         .model=${this.model}
@@ -148,7 +151,11 @@ export class TileList extends LitElement {
       ? html`<a href="${this.baseNavigationUrl}${this.model.href}"
           >${this.model.title ?? this.model.identifier}</a
         >`
-      : this.detailsLink(this.model.identifier, this.model.title);
+      : this.detailsLink(
+          this.model.identifier,
+          this.model.title,
+          this.model.mediatype === 'collection'
+        );
   }
 
   private get itemLineTemplate() {
@@ -341,12 +348,18 @@ export class TileList extends LitElement {
     /* eslint-enable lit/no-invalid-html */
   }
 
-  private detailsLink(identifier: string, text?: string): TemplateResult {
+  private detailsLink(
+    identifier: string,
+    text?: string,
+    collection = false
+  ): TemplateResult {
     const linkText = text ?? identifier;
     // No whitespace after closing tag
     // identifiers (all ASCII in their creation) should be safe to use in href, but sanitize anyway
     return html`<a
-      href="${this.baseNavigationUrl}/details/${encodeURI(identifier)}"
+      href="${this.baseNavigationUrl}${collection
+        ? this.collectionPagePath
+        : '/details/'}${encodeURI(identifier)}"
       >${DOMPurify.sanitize(linkText)}</a
     >`;
   }
@@ -364,7 +377,7 @@ export class TileList extends LitElement {
       case 'account':
         return nothing;
       default:
-        return `${this.baseNavigationUrl}/details/${encodeURI(
+        return `${this.baseNavigationUrl}${this.collectionPagePath}${encodeURI(
           this.model.mediatype
         )}`;
     }
@@ -398,7 +411,7 @@ export class TileList extends LitElement {
         promises.push(
           this.collectionNameCache?.collectionNameFor(collection).then(name => {
             newCollectionLinks.push(
-              this.detailsLink(collection, name ?? collection)
+              this.detailsLink(collection, name ?? collection, true)
             );
           })
         );

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -124,7 +124,7 @@ export class TileDispatcher
   private get linkTileTemplate() {
     return html`
       <a
-        href="${this.linkTileHref}"
+        href=${this.linkTileHref}
         aria-label=${this.model?.title ?? 'Untitled item'}
         title=${this.shouldPrepareHoverPane
           ? nothing // Don't show title tooltips when we have the tile info popups
@@ -139,17 +139,19 @@ export class TileDispatcher
     `;
   }
 
-  private get linkTileHref() {
+  private get linkTileHref(): string | typeof nothing {
+    if (!this.model?.identifier || this.baseNavigationUrl == null)
+      return nothing;
+
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
-    if (this.model?.href) {
-      return `${this.baseNavigationUrl}${this.model?.href}`;
+    if (this.model.href) {
+      return `${this.baseNavigationUrl}${this.model.href}`;
     }
 
-    const isCollection = this.model?.mediatype === 'collection';
-    return `${this.baseNavigationUrl}${
-      isCollection ? this.collectionPagePath : '/details/'
-    }${this.model?.identifier}`;
+    const isCollection = this.model.mediatype === 'collection';
+    const basePath = isCollection ? this.collectionPagePath : '/details/';
+    return `${this.baseNavigationUrl}${basePath}${this.model.identifier}`;
   }
 
   /**

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -56,6 +56,8 @@ export class TileDispatcher
   /** Whether this tile should include a hover pane at all (for applicable tile modes) */
   @property({ type: Boolean }) enableHoverPane = false;
 
+  @property({ type: String }) collectionPagePath: string = '/details/';
+
   private hoverPaneController?: HoverPaneControllerInterface;
 
   @query('#container')
@@ -140,9 +142,14 @@ export class TileDispatcher
   private get linkTileHref() {
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
-    return this.model?.href
-      ? `${this.baseNavigationUrl}${this.model?.href}`
-      : `${this.baseNavigationUrl}/details/${this.model?.identifier}`;
+    if (this.model?.href) {
+      return `${this.baseNavigationUrl}${this.model?.href}`;
+    }
+
+    const isCollection = this.model?.mediatype === 'collection';
+    return `${this.baseNavigationUrl}${
+      isCollection ? this.collectionPagePath : '/details/'
+    }${this.model?.identifier}`;
   }
 
   /**
@@ -266,6 +273,7 @@ export class TileDispatcher
       case 'list-compact':
         return html`<tile-list-compact
           .model=${model}
+          .collectionPagePath=${this.collectionPagePath}
           .currentWidth=${currentWidth}
           .currentHeight=${currentHeight}
           .baseNavigationUrl=${baseNavigationUrl}
@@ -278,6 +286,7 @@ export class TileDispatcher
       case 'list-detail':
         return html`<tile-list
           .model=${model}
+          .collectionPagePath=${this.collectionPagePath}
           .collectionNameCache=${this.collectionNameCache}
           .currentWidth=${currentWidth}
           .currentHeight=${currentHeight}

--- a/test/empty-placeholder.test.ts
+++ b/test/empty-placeholder.test.ts
@@ -15,21 +15,55 @@ describe('Empty Placeholder', () => {
     await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.empty-query')).to.exist;
-    expect(el.shadowRoot?.querySelector('.null-result')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('infinite-scroller')).to.not.exist;
+
+    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
   });
 
-  it('should render with null-result placeholder', async () => {
+  it('should render with empty-collection placeholder', async () => {
     const el = await fixture<EmptyPlaceholder>(
       html`<empty-placeholder></empty-placeholder>`
     );
 
-    el.placeholderType = 'null-result';
+    el.placeholderType = 'empty-collection';
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.null-result')).to.exist;
+    expect(el.shadowRoot?.querySelector('.empty-collection')).to.exist;
+
+    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
     expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('collection-facets')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+  });
+
+  it('should render with no-results placeholder', async () => {
+    const el = await fixture<EmptyPlaceholder>(
+      html`<empty-placeholder></empty-placeholder>`
+    );
+
+    el.placeholderType = 'no-results';
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('.no-results')).to.exist;
+
+    expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+  });
+
+  it('should render with query-error placeholder', async () => {
+    const el = await fixture<EmptyPlaceholder>(
+      html`<empty-placeholder></empty-placeholder>`
+    );
+
+    el.placeholderType = 'query-error';
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('.query-error')).to.exist;
+
+    expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
   });
 
   it('should not render any empty placeholder', async () => {
@@ -41,7 +75,8 @@ describe('Empty Placeholder', () => {
     await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.null-result')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('collection-facets')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
   });
 });

--- a/test/tiles/grid/item-tile.test.ts
+++ b/test/tiles/grid/item-tile.test.ts
@@ -158,10 +158,10 @@ describe('Item Tile', () => {
 
   it('should render published date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<ItemTile>(html`
@@ -181,10 +181,10 @@ describe('Item Tile', () => {
 
   it('should render added date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<ItemTile>(html`
@@ -202,10 +202,10 @@ describe('Item Tile', () => {
 
   it('should render archived date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<ItemTile>(html`
@@ -225,10 +225,10 @@ describe('Item Tile', () => {
 
   it('should render reviewed date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<ItemTile>(html`

--- a/test/tiles/list/tile-list-compact.test.ts
+++ b/test/tiles/list/tile-list-compact.test.ts
@@ -41,7 +41,7 @@ describe('List Tile Compact', () => {
     const el = await fixture<TileListCompact>(html`
       <tile-list-compact
         .baseNavigationUrl=${''}
-        .model=${{ title: 'foo', href: '/foo/bar' }}
+        .model=${{ identifier: 'id', title: 'foo', href: '/foo/bar' }}
       ></tile-list-compact>
     `);
 
@@ -78,10 +78,10 @@ describe('List Tile Compact', () => {
 
   it('should render published date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -99,10 +99,10 @@ describe('List Tile Compact', () => {
 
   it('should render added date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -120,10 +120,10 @@ describe('List Tile Compact', () => {
 
   it('should render archived date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileListCompact>(html`
@@ -141,10 +141,10 @@ describe('List Tile Compact', () => {
 
   it('should render reviewed date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileListCompact>(html`

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -138,10 +138,10 @@ describe('List Tile', () => {
 
   it('should render published date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileList>(html`
@@ -159,10 +159,10 @@ describe('List Tile', () => {
 
   it('should render added date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileList>(html`
@@ -180,10 +180,10 @@ describe('List Tile', () => {
 
   it('should render archived date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileList>(html`
@@ -201,10 +201,10 @@ describe('List Tile', () => {
 
   it('should render reviewed date when sorting by it', async () => {
     const model: Partial<TileModel> = {
-      dateAdded: new Date('2010-01-02'),
-      dateArchived: new Date('2011-01-02'),
-      datePublished: new Date('2012-01-02'),
-      dateReviewed: new Date('2013-01-02'),
+      dateAdded: new Date(2010, 0, 2),
+      dateArchived: new Date(2011, 0, 2),
+      datePublished: new Date(2012, 0, 2),
+      dateReviewed: new Date(2013, 0, 2),
     };
 
     const el = await fixture<TileList>(html`

--- a/test/utils/format-date.test.ts
+++ b/test/utils/format-date.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@open-wc/testing';
 import { formatDate } from '../../src/utils/format-date';
 
-const testDate = new Date(Date.UTC(2020, 11, 9));
+const testDate = new Date(2020, 11, 9);
 
 describe('formatDate', () => {
   it('returns blank when undefined date', () => {


### PR DESCRIPTION
To enable use on collection pages, the collection browser must be able to display the contents of a collection without any additional query set. The search service already allows this via `pageType=collection_details` with a valid `pageTarget` set to the collection identifier.

This PR adds the `withinCollection` prop to accept the collection identifier, passing it to the search service with the correct page type, and functioning correctly with an empty query in the presence of this additional prop.