### PR TITLE
v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Includes a patch to "unwrap" tile hrefs that have been erroneously wrapped in quotes twice.