### PR TITLE
v1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Includes fix to show first creator matching the current filter on grid/compact tiles, instead of first creator overall.