### PR TITLE
WEBDEV-6176 Set default sort option from collection metadata

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1780,7 +1780,7 @@ export class CollectionBrowser
 
     if (this.withinCollection) {
       this.collectionInfo = success.response.collectionExtraInfo;
-      
+
       // For collections, we want the UI to respect the default sort option
       // which can be specified in metadata, or otherwise assumed to be week:desc
       this.applyDefaultCollectionSort(success.response.collectionExtraInfo);

--- a/src/models.ts
+++ b/src/models.ts
@@ -55,6 +55,7 @@ export type CollectionBrowserContext = 'collection' | 'search';
  * The sort fields shown in the sort filter bar
  */
 export enum SortField {
+  'default' = 'default',
   'relevance' = 'relevance',
   'alltimeview' = 'alltimeview',
   'weeklyview' = 'weeklyview',
@@ -87,6 +88,7 @@ export type URLSortField = MetadataSortField | 'title' | 'creator';
 export const SortFieldDisplayName: {
   [key in SortField]: string;
 } = {
+  default: '', // Use the default sorting option for the current page context, if none has been selected
   relevance: 'Relevance',
   alltimeview: 'All-time views',
   weeklyview: 'Weekly views',
@@ -101,6 +103,7 @@ export const SortFieldDisplayName: {
 export const DefaultSortDirection: {
   [key in SortField]: SortDirection;
 } = {
+  default: 'desc',
   relevance: 'desc', // Can't actually change the sort direction for relevance
   alltimeview: 'desc',
   weeklyview: 'desc',
@@ -118,6 +121,7 @@ export const DefaultSortDirection: {
 export const SortFieldToMetadataField: {
   [key in SortField]: MetadataSortField | null;
 } = {
+  default: null,
   relevance: null,
   alltimeview: 'downloads',
   weeklyview: 'week',

--- a/src/models.ts
+++ b/src/models.ts
@@ -101,10 +101,10 @@ export const SortFieldDisplayName: {
 };
 
 export const DefaultSortDirection: {
-  [key in SortField]: SortDirection;
+  [key in SortField]: SortDirection | null;
 } = {
-  default: 'desc',
-  relevance: 'desc', // Can't actually change the sort direction for relevance
+  default: null,
+  relevance: null, // Can't actually change the sort direction for relevance
   alltimeview: 'desc',
   weeklyview: 'desc',
   title: 'asc',

--- a/src/models.ts
+++ b/src/models.ts
@@ -104,7 +104,7 @@ export const DefaultSortDirection: {
   [key in SortField]: SortDirection | null;
 } = {
   default: null,
-  relevance: null, // Can't actually change the sort direction for relevance
+  relevance: null, // Sort direction is disabled entirely for relevance sort (user can't click the button)
   alltimeview: 'desc',
   weeklyview: 'desc',
   title: 'asc',

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -306,9 +306,9 @@ export class SortFilterBar
         class=${this.mobileSelectorVisible ? 'hidden' : 'visible'}
       >
         <ul id="desktop-sort-selector">
-          <li>
-            ${this.showRelevance
-              ? this.getSortDisplayOption(SortField.relevance, {
+          ${this.showRelevance
+            ? html`<li>
+                ${this.getSortDisplayOption(SortField.relevance, {
                   onClick: () => {
                     this.dropdownBackdropVisible = false;
                     if (this.finalizedSortField !== SortField.relevance) {
@@ -316,9 +316,9 @@ export class SortFilterBar
                       this.setSelectedSort(SortField.relevance);
                     }
                   },
-                })
-              : nothing}
-          </li>
+                })}
+              </li>`
+            : nothing}
           <li>${this.viewsDropdownTemplate}</li>
           <li>
             ${this.getSortDisplayOption(SortField.title, {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -147,23 +147,13 @@ export class SortFilterBar
     `;
   }
 
-  // willUpdate(changed: PropertyValues<this>): void {
-  //   if (changed.has('defaultSortField') && !this.selectedSort) {
-  //     this.selectedSort = this.defaultSortField;
-  //   }
-
-  //   if (changed.has('defaultSortDirection') && !this.sortDirection) {
-  //     this.sortDirection = this.defaultSortDirection;
-  //   }
-  // }
-
   updated(changed: PropertyValues) {
     if (changed.has('displayMode')) {
       this.displayModeChanged();
     }
 
     if (changed.has('selectedSort') && this.sortDirection === null) {
-      this.sortDirection = DefaultSortDirection[this.selectedSort];
+      this.sortDirection = DefaultSortDirection[this.finalizedSortField];
     }
 
     if (changed.has('selectedTitleFilter') && this.selectedTitleFilter) {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -197,7 +197,7 @@ export class TileList extends BaseTileComponent {
         ${this.labelTemplate(msg('By'))}
         ${join(
           map(this.model.creators, id => this.searchLink('creator', id)),
-          html`, `
+          ', '
         )}
       </div>
     `;
@@ -262,7 +262,7 @@ export class TileList extends BaseTileComponent {
         ${this.labelTemplate(msg('Topics'))}
         ${join(
           map(this.model.subjects, id => this.searchLink('subject', id)),
-          html`, `
+          ', '
         )}
       </div>
     `;
@@ -275,7 +275,7 @@ export class TileList extends BaseTileComponent {
     return html`
       <div id="collections" class="metadata">
         ${this.labelTemplate(msg('Collections'))}
-        ${join(this.collectionLinks, html`, `)}
+        ${join(this.collectionLinks, ', ')}
       </div>
     `;
   }
@@ -542,6 +542,10 @@ export class TileList extends BaseTileComponent {
         -webkit-line-clamp: 3;
         overflow: hidden;
         overflow-wrap: anywhere;
+      }
+
+      #collections > a {
+        display: inline-block;
       }
 
       #icon {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -93,7 +93,7 @@ describe('Collection Browser', () => {
     el.clearFilters({ sort: true }); // Sort is reset too due to the option
 
     expect(el.selectedFacets).to.deep.equal(getDefaultSelectedFacets());
-    expect(el.selectedSort).to.equal('relevance');
+    expect(el.selectedSort).to.equal(SortField.default);
     expect(el.sortDirection).to.be.null;
     expect(el.sortParam).to.be.null;
     expect(el.selectedCreatorFilter).to.be.null;
@@ -763,7 +763,7 @@ describe('Collection Browser', () => {
       </collection-browser>`
     );
 
-    expect(el.selectedSort).to.equal(SortField.relevance);
+    expect(el.selectedSort).to.equal(SortField.default);
 
     el.baseQuery = 'foo';
     await el.updateComplete;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -993,12 +993,62 @@ describe('Collection Browser', () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
-        .withinCollection=${'foo'}
         .searchService=${searchService}
         .baseNavigationUrl=${''}
       ></collection-browser>`
     );
 
+    el.withinCollection = 'default-sort';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await el.updateComplete;
+    await aTimeout(50);
+
+    const sortBar = el.shadowRoot?.querySelector(
+      'sort-filter-bar'
+    ) as SortFilterBar;
+    expect(sortBar).to.exist;
+    expect(sortBar.defaultSortField).to.equal(SortField.title);
+    expect(sortBar.defaultSortDirection).to.equal('asc');
+    expect(sortBar.selectedSort).to.equal(SortField.default);
+    expect(sortBar.sortDirection).to.be.null;
+  });
+
+  it('sets default sort from collection metadata in "-field" format', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+      ></collection-browser>`
+    );
+
+    el.withinCollection = 'default-sort-concise';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await el.updateComplete;
+    await aTimeout(50);
+
+    const sortBar = el.shadowRoot?.querySelector(
+      'sort-filter-bar'
+    ) as SortFilterBar;
+    expect(sortBar).to.exist;
+    expect(sortBar.defaultSortField).to.equal(SortField.dateadded);
+    expect(sortBar.defaultSortDirection).to.equal('desc');
+    expect(sortBar.selectedSort).to.equal(SortField.default);
+    expect(sortBar.sortDirection).to.be.null;
+  });
+
+  it('uses relevance sort as default when a query is set', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+      ></collection-browser>`
+    );
+
+    el.withinCollection = 'default-sort';
     el.baseQuery = 'default-sort';
     await el.updateComplete;
     await el.initialSearchComplete;
@@ -1009,8 +1059,8 @@ describe('Collection Browser', () => {
       'sort-filter-bar'
     ) as SortFilterBar;
     expect(sortBar).to.exist;
-    expect(sortBar.defaultSortField).to.equal('title');
-    expect(sortBar.defaultSortDirection).to.equal('asc');
+    expect(sortBar.defaultSortField).to.equal(SortField.relevance);
+    expect(sortBar.defaultSortDirection).to.be.null;
     expect(sortBar.selectedSort).to.equal(SortField.default);
     expect(sortBar.sortDirection).to.be.null;
   });

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -20,6 +20,7 @@ import { analyticsCategories } from '../src/utils/analytics-events';
 import type { TileDispatcher } from '../src/tiles/tile-dispatcher';
 import type { CollectionFacets } from '../src/collection-facets';
 import type { EmptyPlaceholder } from '../src/empty-placeholder';
+import type { SortFilterBar } from '../src/sort-filter-bar/sort-filter-bar';
 
 /**
  * Wait for the next tick of the event loop.
@@ -986,6 +987,32 @@ describe('Collection Browser', () => {
     expect(
       firstResult!.shadowRoot?.querySelector('a[href]')?.getAttribute('href')
     ).to.equal('/details/foo?q=%22quoted+query%22');
+  });
+
+  it('sets default sort from collection metadata', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .withinCollection=${'foo'}
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+      ></collection-browser>`
+    );
+
+    el.baseQuery = 'default-sort';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await el.updateComplete;
+    await aTimeout(50);
+
+    const sortBar = el.shadowRoot?.querySelector(
+      'sort-filter-bar'
+    ) as SortFilterBar;
+    expect(sortBar).to.exist;
+    expect(sortBar.defaultSortField).to.equal('title');
+    expect(sortBar.defaultSortDirection).to.equal('asc');
+    expect(sortBar.selectedSort).to.equal(SortField.default);
+    expect(sortBar.sortDirection).to.be.null;
   });
 
   it('scrolls to page', async () => {

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -590,6 +590,46 @@ export const getMockSuccessExtraQuotedHref: () => Result<
   },
 });
 
+export const getMockSuccessWithDefaultSort: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'default-sort',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'default-sort',
+        sort: ['titleSorter', 'identifier'],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            title: 'Foo',
+          },
+        }),
+      ],
+      collectionExtraInfo: {
+        public_metadata: {
+          sort_by: 'titleSorter',
+        },
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
 export const getMockErrorResult: () => Result<
   SearchResponse,
   SearchServiceError

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -619,7 +619,47 @@ export const getMockSuccessWithDefaultSort: () => Result<
       ],
       collectionExtraInfo: {
         public_metadata: {
-          sort_by: 'titleSorter',
+          'sort-by': 'titleSorter',
+        },
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
+export const getMockSuccessWithConciseDefaultSort: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      clientParameters: {
+        user_query: 'default-sort-concise',
+        sort: [],
+      },
+      finalizedParameters: {
+        user_query: 'default-sort-concise',
+        sort: ['addeddate:desc', 'identifier'],
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            title: 'Foo',
+          },
+        }),
+      ],
+      collectionExtraInfo: {
+        public_metadata: {
+          'sort-by': '-addeddate',
         },
       },
     },

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -596,13 +596,19 @@ export const getMockSuccessWithDefaultSort: () => Result<
 > = () => ({
   success: {
     request: {
+      kind: 'hits',
       clientParameters: {
         user_query: 'default-sort',
         sort: [],
       },
-      finalizedParameters: {
-        user_query: 'default-sort',
-        sort: ['titleSorter', 'identifier'],
+      backendRequests: {
+        primary: {
+          kind: 'hits',
+          finalized_parameters: {
+            user_query: 'default-sort',
+            sort: ['titleSorter', 'identifier'],
+          },
+        },
       },
     },
     rawResponse: {},
@@ -636,13 +642,19 @@ export const getMockSuccessWithConciseDefaultSort: () => Result<
 > = () => ({
   success: {
     request: {
+      kind: 'hits',
       clientParameters: {
         user_query: 'default-sort-concise',
         sort: [],
       },
-      finalizedParameters: {
-        user_query: 'default-sort-concise',
-        sort: ['addeddate:desc', 'identifier'],
+      backendRequests: {
+        primary: {
+          kind: 'hits',
+          finalized_parameters: {
+            user_query: 'default-sort-concise',
+            sort: ['addeddate:desc', 'identifier'],
+          },
+        },
       },
     },
     rawResponse: {},

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -23,6 +23,7 @@ import {
   getMockSuccessWithCollectionAggregations,
   getMockSuccessExtraQuotedHref,
   getMockSuccessWithDefaultSort,
+  getMockSuccessWithConciseDefaultSort,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -41,6 +42,7 @@ const responses: Record<
   'collection-aggregations': getMockSuccessWithCollectionAggregations,
   'extra-quoted-href': getMockSuccessExtraQuotedHref,
   'default-sort': getMockSuccessWithDefaultSort,
+  'default-sort-concise': getMockSuccessWithConciseDefaultSort,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,
 };
@@ -80,8 +82,10 @@ export class MockSearchService implements SearchServiceInterface {
       });
     }
 
+    const responseKey =
+      (this.searchParams.query || this.searchParams.pageTarget) ?? '';
     const resultFn: () => Result<SearchResponse, SearchServiceError> =
-      responses[this.searchParams.query] ?? getMockSuccessMultipleResults;
+      responses[responseKey] ?? getMockSuccessMultipleResults;
     let result = resultFn();
 
     // with-sort query has special handling

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -22,6 +22,7 @@ import {
   getMockSuccessWithCollectionTitles,
   getMockSuccessWithCollectionAggregations,
   getMockSuccessExtraQuotedHref,
+  getMockSuccessWithDefaultSort,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -39,6 +40,7 @@ const responses: Record<
   'collection-titles': getMockSuccessWithCollectionTitles,
   'collection-aggregations': getMockSuccessWithCollectionAggregations,
   'extra-quoted-href': getMockSuccessExtraQuotedHref,
+  'default-sort': getMockSuccessWithDefaultSort,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,
 };


### PR DESCRIPTION
On collection pages, there may be a default sort applied to the results independent of the user's sort selection. For instance, most collections have a default sort of `week:desc` (this can be modified in collection metadata).

Accordingly, when browsing collection members, this default sort should be represented accurately in the sort bar UI. This PR slightly refactors how sort fields are handled, adding a `default` SortField enum member which indicates deferral to the current defaults (`relevance` if viewing a search results page, or the current collection's default if viewing a collection page).