### PR TITLE
WEBDEV-6209 Fix More facets within a collection

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -751,6 +751,7 @@ export class CollectionBrowser
         @facetsChanged=${this.facetsChanged}
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
         .collectionPagePath=${this.collectionPagePath}
+        .withinCollection=${this.withinCollection}
         .searchService=${this.searchService}
         .featureFeedbackService=${this.featureFeedbackService}
         .recaptchaManager=${this.recaptchaManager}

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -90,6 +90,8 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Object }) filterMap?: FilterMap;
 
+  @property({ type: String }) withinCollection?: string;
+
   @property({ type: String }) collectionPagePath: string = '/details/';
 
   @property({ type: Object, attribute: false })
@@ -587,6 +589,7 @@ export class CollectionFacets extends LitElement {
         .facetAggregationKey=${facetAggrKey}
         .query=${this.query}
         .filterMap=${this.filterMap}
+        .withinCollection=${this.withinCollection}
         .modalManager=${this.modalManager}
         .searchService=${this.searchService}
         .searchType=${this.searchType}

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -58,6 +58,8 @@ export class MoreFacetsContent extends LitElement {
 
   @property({ type: String }) searchType?: SearchType;
 
+  @property({ type: String }) withinCollection?: string;
+
   @property({ type: Object })
   collectionNameCache?: CollectionNameCacheInterface;
 
@@ -132,15 +134,20 @@ export class MoreFacetsContent extends LitElement {
    */
   async updateSpecificFacets(): Promise<void> {
     const trimmedQuery = this.query?.trim();
-    if (!trimmedQuery) return;
+    if (!trimmedQuery && !this.withinCollection) return;
 
     const aggregations = {
       simpleParams: [this.facetAggregationKey as string],
     };
     const aggregationsSize = 65535; // todo - do we want to have all the records at once?
 
+    const collectionParams = this.withinCollection
+      ? { pageType: 'collection_details', pageTarget: this.withinCollection }
+      : null;
+
     const params: SearchParams = {
-      query: trimmedQuery,
+      ...collectionParams,
+      query: trimmedQuery || '',
       filters: this.filterMap,
       aggregations,
       aggregationsSize,

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -86,6 +86,41 @@ describe('More facets content', () => {
     expect(searchService.searchParams?.query).to.equal('title:hello');
   });
 
+  it('queries for more facets using search service within a collection (no query)', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<MoreFacetsContent>(
+      html`<more-facets-content
+        .searchService=${searchService}
+        .withinCollection=${'foobar'}
+      ></more-facets-content>`
+    );
+
+    el.facetKey = 'subject';
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.query).to.be.empty;
+    expect(searchService.searchParams?.pageTarget).to.equal('foobar');
+  });
+
+  it('queries for more facets using search service within a collection (with query)', async () => {
+    const searchService = new MockSearchService();
+
+    const el = await fixture<MoreFacetsContent>(
+      html`<more-facets-content
+        .searchService=${searchService}
+        .withinCollection=${'foobar'}
+      ></more-facets-content>`
+    );
+
+    el.facetKey = 'subject';
+    el.query = 'title:hello';
+    await el.updateComplete;
+
+    expect(searchService.searchParams?.query).to.equal('title:hello');
+    expect(searchService.searchParams?.pageTarget).to.equal('foobar');
+  });
+
   it('filter raw selectedFacets object', async () => {
     const searchService = new MockSearchService();
 


### PR DESCRIPTION
Currently, the More facet links are broken when searching within a collection (the dialog just hangs). This PR ensures the More facets search query uses the correct `page_type` and `page_target` params, fixing the issue.