### PR TITLE
WEBDEV-6171 Handle unrecognized sort options

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -139,7 +139,8 @@ export const SORT_OPTIONS: Record<SortField, SortOption> = {
   },
   // Unrecognized sort is the case where the user has specified a sort in the URL, but it is not
   // one of the options listed in this map. We still want these unrecognized sorts to be applied
-  // when searching, but they are not displayed in the sort bar.
+  // when searching, but they are not displayed in the sort bar and we do not actively manage
+  // their URL param beyond flipping the direction as needed.
   [SortField.unrecognized]: {
     field: SortField.unrecognized,
     defaultSortDirection: null,


### PR DESCRIPTION
Currently, one cannot set a sort option via URL if it does not appear in the sort bar -- collection browser clobbers these. So valid sorts like `avg_rating` are inaccessible. However, these were allowed on the legacy search page, and consequently there exist old links and possibly old bookmarks that include these now-unrecognized sort params.

To ensure these sort options continue to be available (even if not surfaced in the UI), this PR allows unrecognized sort options to be specified in the URL and passed as-is to the backend, which already has handling to determine whether they are valid.

Moreover, this PR includes a refactoring pass to clean up how various properties of sort options are handled internally, centralizing them into a single config instead of having several individual maps for different properties.