### PR TITLE
WEBDEV-6237 Sort `fav-*` collections by Date Favorited

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -948,6 +948,10 @@ export class CollectionBrowser
       );
     }
 
+    if (changed.has('withinCollection')) {
+      this.clearFilters({ sort: true });
+    }
+
     if (
       changed.has('baseQuery') ||
       changed.has('searchType') ||

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -564,6 +564,7 @@ export class CollectionBrowser
         .selectedSort=${this.selectedSort}
         .sortDirection=${this.sortDirection}
         .showRelevance=${this.isRelevanceSortAvailable}
+        .showDateFavorited=${this.withinCollection?.startsWith('fav-')}
         .displayMode=${this.displayMode}
         .selectedTitleFilter=${this.selectedTitleFilter}
         .selectedCreatorFilter=${this.selectedCreatorFilter}
@@ -1841,7 +1842,9 @@ export class CollectionBrowser
   /**
    * Applies any default sort option for the current collection, by checking
    * for one in the collection's metadata. If none is found, defaults to sorting
-   * descending by weekly views.
+   * descending by:
+   *  - Date Favorited for fav-* collections
+   *  - Weekly views for all other collections
    */
   private applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo) {
     if (this.baseQuery) {
@@ -1852,11 +1855,22 @@ export class CollectionBrowser
       return;
     }
 
-    const defaultSort: string =
-      collectionInfo?.public_metadata?.['sort-by'] ?? '-week';
+    // Favorite collections sort on Date Favorited by default.
+    // Other collections fall back to sorting on weekly views.
+    const baseDefaultSort: string =
+      collectionInfo?.public_metadata?.identifier?.startsWith('fav-')
+        ? '-favoritedate'
+        : '-week';
+
+    // The collection metadata may override the default sorting with something else
+    const metadataSort: string | undefined =
+      collectionInfo?.public_metadata?.['sort-by'];
+
+    // Prefer the metadata-specified sort if one exists
+    const defaultSortToApply = metadataSort ?? baseDefaultSort;
 
     // Account for both -field and field:dir formats
-    let [field, dir] = defaultSort.split(':');
+    let [field, dir] = defaultSortToApply.split(':');
     if (field.startsWith('-')) {
       field = field.slice(1);
       dir = 'desc';

--- a/src/models.ts
+++ b/src/models.ts
@@ -65,6 +65,7 @@ export enum SortField {
   'datearchived' = 'datearchived',
   'datereviewed' = 'datereviewed',
   'dateadded' = 'dateadded',
+  'datefavorited' = 'datefavorited',
   'creator' = 'creator',
 }
 
@@ -127,6 +128,7 @@ export const SORT_OPTIONS: Record<SortField, SortOption> = {
   // For collection pages _without a query_, the default is usually weekly views, but this can be
   // overridden by the collection's `sort-by` metadata entry. If a query _is_ specified, then the
   // default is again relevance sort.
+  // For fav-* collections only, the default is instead sorting by date favorited.
   [SortField.default]: {
     field: SortField.default,
     defaultSortDirection: null,
@@ -240,6 +242,17 @@ export const SORT_OPTIONS: Record<SortField, SortOption> = {
     searchServiceKey: 'addeddate',
     displayName: 'Date added',
     urlNames: ['addeddate'],
+  },
+  [SortField.datefavorited]: {
+    field: SortField.datefavorited,
+    defaultSortDirection: 'desc',
+    canSetDirection: false,
+    shownInSortBar: true, // But only when viewing fav-* collections
+    shownInURL: false,
+    handledBySearchService: false,
+    searchServiceKey: 'favoritedate',
+    displayName: 'Date favorited',
+    urlNames: ['favoritedate'],
   },
   [SortField.creator]: {
     field: SortField.creator,

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -738,6 +738,7 @@ export class SortFilterBar
    */
   private get dateOptionSelected(): boolean {
     const dateSortFields: SortField[] = [
+      SortField.datefavorited,
       SortField.datearchived,
       SortField.date,
       SortField.datereviewed,

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -65,6 +65,9 @@ export class SortFilterBar
   /** Whether to show the Relevance sort option (default `true`) */
   @property({ type: Boolean }) showRelevance: boolean = true;
 
+  /** Whether to show the Date Favorited sort option instead of Date Published/Archived/Reviewed (default `false`) */
+  @property({ type: Boolean }) showDateFavorited: boolean = false;
+
   /** Maps of result counts for letters on the alphabet bar, for each letter filter type */
   @property({ type: Object }) prefixFilterCountMap?: Record<
     PrefixFilterType,
@@ -356,7 +359,10 @@ export class SortFilterBar
   private get mobileSortSelectorTemplate() {
     const displayedOptions = Object.values(SORT_OPTIONS)
       .filter(opt => opt.shownInSortBar)
-      .filter(opt => this.showRelevance || opt.field !== SortField.relevance);
+      .filter(opt => this.showRelevance || opt.field !== SortField.relevance)
+      .filter(
+        opt => this.showDateFavorited || opt.field !== SortField.datefavorited
+      );
 
     return html`
       <div
@@ -536,6 +542,9 @@ export class SortFilterBar
       id: 'date-dropdown',
       selected: this.dateOptionSelected,
       dropdownOptions: [
+        ...(this.showDateFavorited
+          ? [this.getDropdownOption(SortField.datefavorited)]
+          : []),
         this.getDropdownOption(SortField.date),
         this.getDropdownOption(SortField.datearchived),
         this.getDropdownOption(SortField.datereviewed),
@@ -552,7 +561,7 @@ export class SortFilterBar
         if (!this.dateDropdown.open && !this.dateOptionSelected) {
           e.stopPropagation();
           this.clearAlphaBarFilters();
-          this.setSelectedSort(SortField.date);
+          this.setSelectedSort(this.defaultDateSortField);
         }
       },
     });
@@ -756,6 +765,14 @@ export class SortFilterBar
   }
 
   /**
+   * The default field for the date sort dropdown.
+   * This is Date Favorited when that option is available, or Date Published otherwise.
+   */
+  private get defaultDateSortField(): SortField {
+    return this.showDateFavorited ? SortField.datefavorited : SortField.date;
+  }
+
+  /**
    * The display name of the current date field
    *
    * @readonly
@@ -764,7 +781,7 @@ export class SortFilterBar
    * @memberof SortFilterBar
    */
   private get dateSortField(): string {
-    const defaultDateSort = SORT_OPTIONS[SortField.date];
+    const defaultDateSort = SORT_OPTIONS[this.defaultDateSortField];
     const currentDateSort = this.dateOptionSelected
       ? SORT_OPTIONS[this.finalizedSortField] ?? defaultDateSort
       : defaultDateSort;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1065,6 +1065,31 @@ describe('Collection Browser', () => {
     expect(sortBar.sortDirection).to.be.null;
   });
 
+  it('uses date favorited sort as default when targeting fav- collection', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+      ></collection-browser>`
+    );
+
+    el.withinCollection = 'fav-sort';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await el.updateComplete;
+    await aTimeout(50);
+
+    const sortBar = el.shadowRoot?.querySelector(
+      'sort-filter-bar'
+    ) as SortFilterBar;
+    expect(sortBar).to.exist;
+    expect(sortBar.defaultSortField).to.equal(SortField.datefavorited);
+    expect(sortBar.defaultSortDirection).to.equal('desc');
+    expect(sortBar.selectedSort).to.equal(SortField.default);
+    expect(sortBar.sortDirection).to.be.null;
+  });
+
   it('scrolls to page', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -682,6 +682,52 @@ export const getMockSuccessWithConciseDefaultSort: () => Result<
   },
 });
 
+export const getMockSuccessWithDefaultFavSort: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      kind: 'hits',
+      clientParameters: {
+        user_query: 'fav-sort',
+        sort: [],
+      },
+      backendRequests: {
+        primary: {
+          kind: 'hits',
+          finalized_parameters: {
+            user_query: 'fav-sort',
+            sort: [],
+          },
+        },
+      },
+    },
+    rawResponse: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new ItemHit({
+          fields: {
+            identifier: 'foo',
+            title: 'Foo',
+          },
+        }),
+      ],
+      collectionExtraInfo: {
+        public_metadata: {
+          identifier: 'fav-foo',
+        },
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
 export const getMockErrorResult: () => Result<
   SearchResponse,
   SearchServiceError

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -24,6 +24,7 @@ import {
   getMockSuccessExtraQuotedHref,
   getMockSuccessWithDefaultSort,
   getMockSuccessWithConciseDefaultSort,
+  getMockSuccessWithDefaultFavSort,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -43,6 +44,7 @@ const responses: Record<
   'extra-quoted-href': getMockSuccessExtraQuotedHref,
   'default-sort': getMockSuccessWithDefaultSort,
   'default-sort-concise': getMockSuccessWithConciseDefaultSort,
+  'fav-sort': getMockSuccessWithDefaultFavSort,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,
 };


### PR DESCRIPTION
Favorite collections should be sorted by Date Favorited by default. This option was not previously available, so this PR adds it and ensures it is applied as the default when browsing a `fav-*` collection.