### PR TITLE
WEBDEV-6256 Show more appropriate error message when collection fails to load

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -425,7 +425,8 @@ export class CollectionBrowser
     }
 
     if (this.queryErrorMessage) {
-      this.placeholderType = 'query-error';
+      this.placeholderType =
+        !hasQuery && isCollection ? 'collection-error' : 'query-error';
     }
   }
 

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -48,9 +48,9 @@ export class EmptyPlaceholder extends LitElement {
       Tips for constructing search queries.
     </a> `);
 
-  private static readonly MESSAGE_COLLECTION_ERROR = msg(html` The search engine
-    encountered an error fetching details for this collection. If the problem
-    persists, please let us know at
+  private static readonly MESSAGE_COLLECTION_ERROR = msg(html`The search engine
+    encountered an error while loading this collection. If the problem persists,
+    please let us know at
     <a href="mailto:info@archive.org">info@archive.org</a>.`);
 
   private static readonly QUERY_ERROR_DETAILS_MESSAGE = msg('Error details:');

--- a/src/empty-placeholder.ts
+++ b/src/empty-placeholder.ts
@@ -18,6 +18,7 @@ export type PlaceholderType =
   | 'empty-collection'
   | 'no-results'
   | 'query-error'
+  | 'collection-error'
   | null;
 @customElement('empty-placeholder')
 export class EmptyPlaceholder extends LitElement {
@@ -47,6 +48,11 @@ export class EmptyPlaceholder extends LitElement {
       Tips for constructing search queries.
     </a> `);
 
+  private static readonly MESSAGE_COLLECTION_ERROR = msg(html` The search engine
+    encountered an error fetching details for this collection. If the problem
+    persists, please let us know at
+    <a href="mailto:info@archive.org">info@archive.org</a>.`);
+
   private static readonly QUERY_ERROR_DETAILS_MESSAGE = msg('Error details:');
 
   @property({ type: String }) placeholderType: PlaceholderType = null;
@@ -73,6 +79,7 @@ export class EmptyPlaceholder extends LitElement {
           ['empty-collection', () => this.emptyCollectionTemplate],
           ['no-results', () => this.noResultsTemplate],
           ['query-error', () => this.queryErrorTemplate],
+          ['collection-error', () => this.collectionErrorTemplate],
         ])}
       </div>
     `;
@@ -106,6 +113,16 @@ export class EmptyPlaceholder extends LitElement {
   private get queryErrorTemplate(): TemplateResult {
     return html`
       <h2 class="title">${EmptyPlaceholder.MESSAGE_QUERY_ERROR}</h2>
+      <div>${nullResultIcon}</div>
+      <p class="error-details">
+        ${EmptyPlaceholder.QUERY_ERROR_DETAILS_MESSAGE} ${this.detailMessage}
+      </p>
+    `;
+  }
+
+  private get collectionErrorTemplate(): TemplateResult {
+    return html`
+      <h2 class="title">${EmptyPlaceholder.MESSAGE_COLLECTION_ERROR}</h2>
       <div>${nullResultIcon}</div>
       <p class="error-details">
         ${EmptyPlaceholder.QUERY_ERROR_DETAILS_MESSAGE} ${this.detailMessage}

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -561,6 +561,29 @@ describe('Collection Browser', () => {
     expect(errorDetails.textContent).to.contain('foo');
   });
 
+  it('shows error message when error response received for a collection', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+      ></collection-browser>`
+    );
+
+    el.withinCollection = 'error';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    const errorPlaceholder = el.shadowRoot?.querySelector(
+      'empty-placeholder'
+    ) as EmptyPlaceholder;
+    const errorDetails = errorPlaceholder?.shadowRoot?.querySelector(
+      '.error-details'
+    ) as HTMLParagraphElement;
+
+    expect(errorDetails).to.exist;
+    expect(errorDetails.textContent).to.contain('foo');
+  });
+
   it('reports malformed response errors to Sentry', async () => {
     const sentrySpy = sinon.spy();
     (window as any).Sentry = { captureMessage: sentrySpy };

--- a/test/empty-placeholder.test.ts
+++ b/test/empty-placeholder.test.ts
@@ -14,11 +14,9 @@ describe('Empty Placeholder', () => {
     el.placeholderType = 'empty-query';
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.empty-query')).to.exist;
-
-    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+    const placeholderElem = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholderElem).to.exist;
+    expect(placeholderElem).to.have.class('empty-query');
   });
 
   it('should render with empty-collection placeholder', async () => {
@@ -29,11 +27,9 @@ describe('Empty Placeholder', () => {
     el.placeholderType = 'empty-collection';
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.empty-collection')).to.exist;
-
-    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+    const placeholderElem = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholderElem).to.exist;
+    expect(placeholderElem).to.have.class('empty-collection');
   });
 
   it('should render with no-results placeholder', async () => {
@@ -44,11 +40,9 @@ describe('Empty Placeholder', () => {
     el.placeholderType = 'no-results';
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.no-results')).to.exist;
-
-    expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+    const placeholderElem = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholderElem).to.exist;
+    expect(placeholderElem).to.have.class('no-results');
   });
 
   it('should render with query-error placeholder', async () => {
@@ -59,11 +53,22 @@ describe('Empty Placeholder', () => {
     el.placeholderType = 'query-error';
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.query-error')).to.exist;
+    const placeholderElem = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholderElem).to.exist;
+    expect(placeholderElem).to.have.class('query-error');
+  });
 
-    expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
-    expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
+  it('should render with collection-error placeholder', async () => {
+    const el = await fixture<EmptyPlaceholder>(
+      html`<empty-placeholder></empty-placeholder>`
+    );
+
+    el.placeholderType = 'collection-error';
+    await el.updateComplete;
+
+    const placeholderElem = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholderElem).to.exist;
+    expect(placeholderElem).to.have.class('collection-error');
   });
 
   it('should not render any empty placeholder', async () => {
@@ -74,9 +79,11 @@ describe('Empty Placeholder', () => {
     el.placeholderType = null;
     await el.updateComplete;
 
+    expect(el.shadowRoot?.querySelector('.placeholder')).to.not.exist;
     expect(el.shadowRoot?.querySelector('.empty-query')).to.not.exist;
     expect(el.shadowRoot?.querySelector('.empty-collection')).to.not.exist;
     expect(el.shadowRoot?.querySelector('.no-results')).to.not.exist;
     expect(el.shadowRoot?.querySelector('.query-error')).to.not.exist;
+    expect(el.shadowRoot?.querySelector('.collection-error')).to.not.exist;
   });
 });


### PR DESCRIPTION
Currently when the PPS request for a collection encounters an error, we are at best displaying an error message that implies something is wrong with the query (even when there isn't one), or at worst showing the "collection not found" state.

This PR adds a new placeholder option that should be somewhat more user-friendly, noting that the search engine couldn't load the collection details and linking to our support channel in case the problem persists.