### PR TITLE
Dispatch event to switch on ?tab=about tab when resultCount is 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.13.0-alpha2",
+  "version": "1.13.0-alpha3",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.13.0",
+  "version": "1.13.0-alpha2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1125,12 +1125,8 @@ export class CollectionBrowser
     );
   }
 
-  private emitTabChanged(tabId: string) {
-    this.dispatchEvent(
-      new CustomEvent<String>('tabChanged', {
-        detail: tabId,
-      })
-    );
+  private emitEmptyResults() {
+    this.dispatchEvent(new Event('emptyResults'));
   }
 
   private disconnectResizeObserver(
@@ -1812,9 +1808,9 @@ export class CollectionBrowser
 
     this.totalResults = success.response.totalResults;
 
-    // switch tab to ?tab=about if this.totalResults is 0
+    // display event to offshoot when result count is zero.
     if (this.totalResults === 0) {
-      this.emitTabChanged('about');
+      this.emitEmptyResults();
     }
 
     if (this.withinCollection) {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1125,6 +1125,14 @@ export class CollectionBrowser
     );
   }
 
+  private emitTabChanged(tabId: string) {
+    this.dispatchEvent(
+      new CustomEvent<String>('tabChanged', {
+        detail: tabId,
+      })
+    );
+  }
+
   private disconnectResizeObserver(
     resizeObserver: SharedResizeObserverInterface
   ) {
@@ -1803,6 +1811,11 @@ export class CollectionBrowser
     }
 
     this.totalResults = success.response.totalResults;
+
+    // switch tab to ?tab=about if this.totalResults is 0
+    if (this.totalResults === 0) {
+      this.emitTabChanged('about');
+    }
 
     if (this.withinCollection) {
       this.collectionInfo = success.response.collectionExtraInfo;


### PR DESCRIPTION
dispatch an event to collection-page if resultcount is zero. The event will be listened at offshoot and switch to ?tab=about to show about page of collection.