### PR TITLE
Fix an infinite scroller call that requires full reload, not just visible cell refresh

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1060,7 +1060,7 @@ export class CollectionBrowser
       changed.has('baseImageUrl') ||
       changed.has('loggedIn')
     ) {
-      this.infiniteScroller?.refreshAllVisibleCells();
+      this.infiniteScroller?.reload();
     }
 
     if (

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1211,8 +1211,7 @@ describe('Collection Browser', () => {
     await el.updateComplete;
 
     const infiniteScroller = el.shadowRoot?.querySelector('infinite-scroller');
-    (infiniteScroller as InfiniteScroller).refreshAllVisibleCells =
-      infiniteScrollerRefreshSpy;
+    (infiniteScroller as InfiniteScroller).reload = infiniteScrollerRefreshSpy;
     expect(infiniteScrollerRefreshSpy.called).to.be.false;
     expect(infiniteScrollerRefreshSpy.callCount).to.equal(0);
 


### PR DESCRIPTION
When the display mode changes, we require a full reload of the infinite scroller's cell contents, not just a refresh of the visible cell buffer. This undoes a slightly overzealous change in #278.