### PR TITLE
Collection page tiles should still show date line when default sorting by a date

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -103,6 +103,8 @@ export class CollectionBrowser
 
   @property({ type: Object }) sortParam: SortParam | null = null;
 
+  @property({ type: Object }) defaultSortParam: SortParam | null = null;
+
   @property({ type: String }) selectedSort: SortField = SortField.default;
 
   @property({ type: String }) selectedTitleFilter: string | null = null;
@@ -995,6 +997,7 @@ export class CollectionBrowser
           .tileDisplayMode=${'list-header'}
           .resizeObserver=${this.resizeObserver}
           .sortParam=${this.sortParam}
+          .defaultSortParam=${this.defaultSortParam}
           .mobileBreakpoint=${this.mobileBreakpoint}
           .loggedIn=${this.loggedIn}
         >
@@ -2091,15 +2094,10 @@ export class CollectionBrowser
     if (sortField && sortField !== SortField.default) {
       this.defaultSortField = sortField;
       this.defaultSortDirection = dir as SortDirection;
-
-      if (!this.sortParam) {
-        this.sortParam = {
-          field: this.defaultSortField,
-          direction: this.defaultSortDirection,
-        };
-        this.selectedSort = this.defaultSortField;
-        this.sortDirection = this.defaultSortDirection;
-      }
+      this.defaultSortParam = {
+        field: this.defaultSortField,
+        direction: this.defaultSortDirection,
+      };
     }
   }
 
@@ -2353,6 +2351,7 @@ export class CollectionBrowser
         .resizeObserver=${this.resizeObserver}
         .collectionNameCache=${this.collectionNameCache}
         .sortParam=${this.sortParam}
+        .defaultSortParam=${this.defaultSortParam}
         .creatorFilter=${this.selectedCreatorFilter}
         .mobileBreakpoint=${this.mobileBreakpoint}
         .loggedIn=${this.loggedIn}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2091,6 +2091,15 @@ export class CollectionBrowser
     if (sortField && sortField !== SortField.default) {
       this.defaultSortField = sortField;
       this.defaultSortDirection = dir as SortDirection;
+
+      if (!this.sortParam) {
+        this.sortParam = {
+          field: this.defaultSortField,
+          direction: this.defaultSortDirection,
+        };
+        this.selectedSort = this.defaultSortField;
+        this.sortDirection = this.defaultSortDirection;
+      }
     }
   }
 

--- a/src/tiles/base-tile-component.ts
+++ b/src/tiles/base-tile-component.ts
@@ -19,6 +19,8 @@ export abstract class BaseTileComponent extends LitElement {
 
   @property({ type: Object }) sortParam: SortParam | null = null;
 
+  @property({ type: Object }) defaultSortParam: SortParam | null = null;
+
   @property({ type: String }) creatorFilter?: string;
 
   @property({ type: Number }) mobileBreakpoint?: number;

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -105,12 +105,13 @@ export class TileDispatcher
   }
 
   private get headerTemplate() {
-    const { currentWidth, sortParam, mobileBreakpoint } = this;
+    const { currentWidth, sortParam, defaultSortParam, mobileBreakpoint } =
+      this;
     return html`
       <tile-list-compact-header
         class="header"
         .currentWidth=${currentWidth}
-        .sortParam=${sortParam}
+        .sortParam=${sortParam || defaultSortParam}
         .mobileBreakpoint=${mobileBreakpoint}
       >
       </tile-list-compact-header>
@@ -280,6 +281,7 @@ export class TileDispatcher
       sortParam,
       creatorFilter,
       mobileBreakpoint,
+      defaultSortParam,
     } = this;
 
     if (!model) return nothing;
@@ -334,7 +336,7 @@ export class TileDispatcher
               .currentHeight=${this.currentHeight}
               .collectionNameCache=${this.collectionNameCache}
               .baseImageUrl=${this.baseImageUrl}
-              .sortParam=${sortParam}
+              .sortParam=${sortParam || defaultSortParam}
               .creatorFilter=${creatorFilter}
               .loggedIn=${this.loggedIn}
               .isManageView=${this.isManageView}
@@ -350,7 +352,7 @@ export class TileDispatcher
           .currentWidth=${currentWidth}
           .currentHeight=${currentHeight}
           .baseNavigationUrl=${baseNavigationUrl}
-          .sortParam=${sortParam}
+          .sortParam=${sortParam || defaultSortParam}
           .creatorFilter=${creatorFilter}
           .mobileBreakpoint=${mobileBreakpoint}
           .baseImageUrl=${this.baseImageUrl}
@@ -365,7 +367,7 @@ export class TileDispatcher
           .currentWidth=${currentWidth}
           .currentHeight=${currentHeight}
           .baseNavigationUrl=${baseNavigationUrl}
-          .sortParam=${sortParam}
+          .sortParam=${sortParam || defaultSortParam}
           .creatorFilter=${creatorFilter}
           .mobileBreakpoint=${mobileBreakpoint}
           .baseImageUrl=${this.baseImageUrl}


### PR DESCRIPTION
### Issue:

When sorting by a type of date explicitly, the result tiles correctly show the corresponding date value in place of the creator line correctly and tiles should display the `defaultSort` if it's available within collection search

### Testing:

- load the demo app and search for `inlibrary` as collection query
- Date published is set as sortField param and the `published` text is displayed in the item-tile
- notice that the url didn't change with `?sort=` query param

<img width="1510" alt="Screenshot 2023-08-30 at 20 54 32" src="https://github.com/internetarchive/iaux-collection-browser/assets/1281581/4a018c42-53c8-4eba-b144-eb43f0e612a8">

