### PR TITLE
WEBDEV-6386 Refactor facets to extract individual facet row component

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1722,27 +1722,26 @@ export class CollectionBrowser
   }
 
   facetClickHandler({
-    detail: { key, state: facetState, negative },
+    detail: { facetType, bucket, negative },
   }: CustomEvent<FacetEventDetails>): void {
+    let action: analyticsActions;
     if (negative) {
-      this.analyticsHandler?.sendEvent({
-        category: this.searchContext,
-        action:
-          facetState !== 'none'
-            ? analyticsActions.facetNegativeSelected
-            : analyticsActions.facetNegativeDeselected,
-        label: key,
-      });
+      action =
+        bucket.state !== 'none'
+          ? analyticsActions.facetNegativeSelected
+          : analyticsActions.facetNegativeDeselected;
     } else {
-      this.analyticsHandler?.sendEvent({
-        category: this.searchContext,
-        action:
-          facetState !== 'none'
-            ? analyticsActions.facetSelected
-            : analyticsActions.facetDeselected,
-        label: key,
-      });
+      action =
+        bucket.state !== 'none'
+          ? analyticsActions.facetSelected
+          : analyticsActions.facetDeselected;
     }
+
+    this.analyticsHandler?.sendEvent({
+      category: this.searchContext,
+      action,
+      label: facetType,
+    });
   }
 
   private async fetchFacets() {

--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -143,7 +143,7 @@ export class FacetRow extends LitElement {
 
     const target = e.target as HTMLInputElement;
     const { checked } = target;
-    bucket.state = this.getFacetState(checked, negative);
+    bucket.state = FacetRow.getFacetState(checked, negative);
 
     this.dispatchFacetClickEvent({
       facetType,
@@ -169,7 +169,7 @@ export class FacetRow extends LitElement {
   /**
    * Returns the composed facet state corresponding to a positive or negative facet's checked state
    */
-  private getFacetState(checked: boolean, negative: boolean): FacetState {
+  static getFacetState(checked: boolean, negative: boolean): FacetState {
     let state: FacetState;
     if (checked) {
       state = negative ? 'hidden' : 'selected';

--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -1,0 +1,271 @@
+import {
+  css,
+  html,
+  LitElement,
+  TemplateResult,
+  CSSResultGroup,
+  nothing,
+} from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import type { CollectionNameCacheInterface } from '@internetarchive/collection-name-cache';
+import eyeIcon from '../assets/img/icons/eye';
+import eyeClosedIcon from '../assets/img/icons/eye-closed';
+import type {
+  FacetOption,
+  FacetBucket,
+  FacetEventDetails,
+  FacetState,
+} from '../models';
+
+@customElement('facet-row')
+export class FacetRow extends LitElement {
+  //
+  // UI STATE
+  //
+
+  /** The name of the facet group to which this facet belongs (e.g., "mediatype") */
+  @property({ type: String }) facetType?: FacetOption;
+
+  /** The facet bucket containing details about the state, count, and key for this row */
+  @property({ type: Object }) bucket?: FacetBucket;
+
+  /** The collection name cache for converting collection identifiers to titles */
+  @property({ type: Object })
+  collectionNameCache?: CollectionNameCacheInterface;
+
+  //
+  // COMPONENT LIFECYCLE METHODS
+  //
+
+  render() {
+    return html`${this.facetRowTemplate}`;
+  }
+
+  //
+  // TEMPLATE GETTERS
+  //
+
+  /**
+   * Template for the full facet row, including the positive/negative checks,
+   * the display name, and the count.
+   */
+  private get facetRowTemplate(): TemplateResult | typeof nothing {
+    const { bucket, facetType } = this;
+    if (!bucket || !facetType) return nothing;
+
+    const showOnlyCheckboxId = `${facetType}:${bucket.key}-show-only`;
+    const negativeCheckboxId = `${facetType}:${bucket.key}-negative`;
+
+    // For collections, we need to asynchronously load the collection name
+    // so we use the `async-collection-name` widget.
+    // For other facet types, we just have a static value to use.
+    const bucketTextDisplay =
+      facetType !== 'collection'
+        ? html`${bucket.displayText ?? bucket.key}`
+        : html`<a href="/details/${bucket.key}">
+            <async-collection-name
+              .collectionNameCache=${this.collectionNameCache}
+              .identifier=${bucket.key}
+              placeholder="-"
+            ></async-collection-name>
+          </a> `;
+
+    const facetHidden = bucket.state === 'hidden';
+    const facetSelected = bucket.state === 'selected';
+
+    const titleText = `${facetType}: ${bucket.displayText ?? bucket.key}`;
+    const onlyShowText = facetSelected
+      ? `Show all ${facetType}s`
+      : `Only show ${titleText}`;
+    const hideText = `Hide ${titleText}`;
+    const unhideText = `Unhide ${titleText}`;
+    const showHideText = facetHidden ? unhideText : hideText;
+    const ariaLabel = `${titleText}, ${bucket.count} results`;
+
+    return html`
+      <div class="facet-row-container">
+        <div class="facet-checkboxes">
+          <input
+            type="checkbox"
+            .name=${facetType}
+            .value=${bucket.key}
+            @click=${(e: Event) => {
+              this.facetClicked(e, false);
+            }}
+            .checked=${facetSelected}
+            class="select-facet-checkbox"
+            title=${onlyShowText}
+            id=${showOnlyCheckboxId}
+          />
+          <input
+            type="checkbox"
+            id=${negativeCheckboxId}
+            .name=${facetType}
+            .value=${bucket.key}
+            @click=${(e: Event) => {
+              this.facetClicked(e, true);
+            }}
+            .checked=${facetHidden}
+            class="hide-facet-checkbox"
+          />
+          <label
+            for=${negativeCheckboxId}
+            class="hide-facet-icon${facetHidden ? ' active' : ''}"
+            title=${showHideText}
+          >
+            <span class="eye">${eyeIcon}</span>
+            <span class="eye-closed">${eyeClosedIcon}</span>
+          </label>
+        </div>
+        <label
+          for=${showOnlyCheckboxId}
+          class="facet-info-display"
+          title=${onlyShowText}
+          aria-label=${ariaLabel}
+        >
+          <div class="facet-title">${bucketTextDisplay}</div>
+          <div class="facet-count">${bucket.count.toLocaleString()}</div>
+        </label>
+      </div>
+    `;
+  }
+
+  //
+  // EVENT HANDLERS & DISPATCHERS
+  //
+
+  /**
+   * Handler for whenever this facet is clicked & its state changes
+   */
+  private facetClicked(e: Event, negative: boolean) {
+    const { bucket, facetType } = this;
+    if (!bucket || !facetType) return;
+
+    const target = e.target as HTMLInputElement;
+    const { checked } = target;
+    bucket.state = this.getFacetState(checked, negative);
+
+    this.dispatchFacetClickEvent({
+      facetType,
+      bucket,
+      negative,
+    });
+  }
+
+  /**
+   * Emits a `facetClick` event with details about this facet & its current state
+   */
+  private dispatchFacetClickEvent(detail: FacetEventDetails) {
+    const event = new CustomEvent<FacetEventDetails>('facetClick', {
+      detail,
+    });
+    this.dispatchEvent(event);
+  }
+
+  //
+  // OTHER METHODS
+  //
+
+  /**
+   * Returns the composed facet state corresponding to a positive or negative facet's checked state
+   */
+  private getFacetState(checked: boolean, negative: boolean): FacetState {
+    let state: FacetState;
+    if (checked) {
+      state = negative ? 'hidden' : 'selected';
+    } else {
+      state = 'none';
+    }
+    return state;
+  }
+
+  //
+  // STYLES
+  //
+
+  static get styles(): CSSResultGroup {
+    return css`
+      async-collection-name {
+        display: contents;
+      }
+      .facet-checkboxes {
+        margin: 0 5px 0 0;
+        display: flex;
+        height: 15px;
+      }
+      .facet-checkboxes input:first-child {
+        margin-right: 5px;
+      }
+      .facet-checkboxes input {
+        height: 15px;
+        width: 15px;
+        margin: 0;
+      }
+      .facet-row-container {
+        display: flex;
+        font-weight: 500;
+        font-size: 1.2rem;
+        margin: 2.5px auto;
+        height: auto;
+        border-top: var(--facet-row-border-top, 1px solid transparent);
+        border-bottom: var(--facet-row-border-bottom, 1px solid transparent);
+        overflow: hidden;
+      }
+      .facet-info-display {
+        display: flex;
+        flex: 1 1 0%;
+        cursor: pointer;
+        flex-wrap: wrap;
+      }
+      .facet-title {
+        word-break: break-word;
+        display: inline-block;
+        flex: 1 1 0%;
+      }
+      .facet-count {
+        text-align: right;
+      }
+      .select-facet-checkbox {
+        cursor: pointer;
+        display: inline-block;
+      }
+      .hide-facet-checkbox {
+        display: none;
+      }
+      .hide-facet-icon {
+        width: 15px;
+        height: 15px;
+        cursor: pointer;
+        opacity: 0.3;
+        display: inline-block;
+      }
+      .hide-facet-icon:hover,
+      .active {
+        opacity: 1;
+      }
+      .hide-facet-icon:hover .eye,
+      .hide-facet-icon .eye-closed {
+        display: none;
+      }
+      .hide-facet-icon:hover .eye-closed,
+      .hide-facet-icon.active .eye-closed {
+        display: inline;
+      }
+      .hide-facet-icon.active .eye {
+        display: none;
+      }
+      .sorting-icon {
+        cursor: pointer;
+      }
+
+      a:link,
+      a:visited {
+        text-decoration: none;
+        color: var(--ia-theme-link-color, #4b64ff);
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    `;
+  }
+}

--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -184,6 +184,9 @@ export class FacetRow extends LitElement {
   //
 
   static get styles(): CSSResultGroup {
+    const facetRowBorderTop = css`var(--facet-row-border-top, 1px solid transparent)`;
+    const facetRowBorderBottom = css`var(--facet-row-border-bottom, 1px solid transparent)`;
+
     return css`
       async-collection-name {
         display: contents;
@@ -207,8 +210,8 @@ export class FacetRow extends LitElement {
         font-size: 1.2rem;
         margin: 2.5px auto;
         height: auto;
-        border-top: var(--facet-row-border-top, 1px solid transparent);
-        border-bottom: var(--facet-row-border-bottom, 1px solid transparent);
+        border-top: ${facetRowBorderTop};
+        border-bottom: ${facetRowBorderBottom};
         overflow: hidden;
       }
       .facet-info-display {

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -30,18 +30,14 @@ export class FacetsTemplate extends LitElement {
   collectionNameCache?: CollectionNameCacheInterface;
 
   private facetClicked(e: CustomEvent<FacetEventDetails>) {
-    const { facetType, bucket, negative } = e.detail;
+    const { bucket, negative } = e.detail;
     if (bucket.state === 'none') {
       this.facetUnchecked(bucket);
     } else {
       this.facetChecked(bucket, negative);
     }
 
-    this.dispatchFacetClickEvent({
-      facetType,
-      bucket,
-      negative,
-    });
+    this.dispatchFacetClickEvent(e.detail);
   }
 
   private facetChecked(bucket: FacetBucket, negative: boolean) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -295,6 +295,9 @@ export const prefixFilterAggregationKeys: Record<PrefixFilterType, string> = {
   creator: 'firstCreator',
 };
 
+/**
+ * Union of the facet types that are available in the sidebar.
+ */
 export type FacetOption =
   | 'subject'
   | 'lending'
@@ -322,9 +325,22 @@ export interface FacetGroup {
   buckets: FacetBucket[];
 }
 
+/**
+ * Information about a user interaction event on a facet.
+ */
 export type FacetEventDetails = {
-  key: FacetOption;
-  state: FacetState;
+  /**
+   * The type of facet that was interacted with (e.g., 'mediatype', 'language', ...).
+   */
+  facetType: FacetOption;
+  /**
+   * The bucket corresponding to the facet that was interacted with, including the
+   * updated state of the facet after the interaction.
+   */
+  bucket: FacetBucket;
+  /**
+   * Whether the interaction occurred on a negative facet.
+   */
   negative: boolean;
 };
 

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -177,7 +177,15 @@ describe('Collection Browser', () => {
 
     el.facetClickHandler(
       new CustomEvent('facetClick', {
-        detail: { key: 'mediatype', state: 'selected', negative: false },
+        detail: {
+          facetType: 'mediatype',
+          bucket: {
+            key: '',
+            state: 'selected',
+            count: 123,
+          },
+          negative: false,
+        },
       })
     );
     expect(mockAnalyticsHandler.callCategory).to.equal('search-service');
@@ -186,7 +194,15 @@ describe('Collection Browser', () => {
 
     el.facetClickHandler(
       new CustomEvent('facetClick', {
-        detail: { key: 'mediatype', state: 'none', negative: false },
+        detail: {
+          facetType: 'mediatype',
+          bucket: {
+            key: '',
+            state: 'none',
+            count: 123,
+          },
+          negative: false,
+        },
       })
     );
     expect(el.selectedFacets).to.equal(mockedSelectedFacets);
@@ -219,7 +235,15 @@ describe('Collection Browser', () => {
 
     el.facetClickHandler(
       new CustomEvent('facetClick', {
-        detail: { key: 'mediatype', state: 'hidden', negative: true },
+        detail: {
+          facetType: 'mediatype',
+          bucket: {
+            key: '',
+            state: 'hidden',
+            count: 123,
+          },
+          negative: true,
+        },
       })
     );
     expect(mockAnalyticsHandler.callCategory).to.equal('beta-search-service');
@@ -228,7 +252,15 @@ describe('Collection Browser', () => {
 
     el.facetClickHandler(
       new CustomEvent('facetClick', {
-        detail: { key: 'mediatype', state: 'none', negative: true },
+        detail: {
+          facetType: 'mediatype',
+          bucket: {
+            key: '',
+            state: 'none',
+            count: 123,
+          },
+          negative: true,
+        },
       })
     );
     expect(el.selectedFacets).to.equal(mockedSelectedFacets);

--- a/test/collection-facets/facet-row.test.ts
+++ b/test/collection-facets/facet-row.test.ts
@@ -1,0 +1,352 @@
+import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
+import { html } from 'lit';
+import type { FacetRow } from '../../src/collection-facets/facet-row';
+import '../../src/collection-facets/facet-row';
+import type { FacetState } from '../../src/models';
+import { MockCollectionNameCache } from '../mocks/mock-collection-name-cache';
+
+describe('Facet row', () => {
+  it('renders nothing if no bucket provided', async () => {
+    const el = await fixture<FacetRow>(
+      html`<facet-row .facetGroupKey=${'subject'}></facet-row>`
+    );
+
+    expect(el.shadowRoot?.querySelector('.facet-row-container')).not.to.exist;
+  });
+
+  it('renders nothing if no facet type provided', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row .bucket=${bucket}></facet-row>`
+    );
+
+    expect(el.shadowRoot?.querySelector('.facet-row-container')).not.to.exist;
+  });
+
+  it('renders provided bucket as facet row', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+      ></facet-row>`
+    );
+
+    expect(el.shadowRoot?.querySelector('.facet-row-container')).to.exist;
+    expect(
+      el.shadowRoot?.querySelectorAll('input[type="checkbox"]')
+    ).to.have.length(2);
+    expect(el.shadowRoot?.querySelectorAll('label')).to.have.length(2);
+
+    expect(el.shadowRoot?.textContent?.trim()).to.match(/^foo\s*5$/);
+  });
+
+  it('renders locale-appropriate facet count', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 54321,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+      ></facet-row>`
+    );
+
+    const facetCount = el.shadowRoot?.querySelector('.facet-count');
+    expect(facetCount?.textContent).to.equal('54,321');
+  });
+
+  it('renders selected facets with checked checkbox', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'selected' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+      ></facet-row>`
+    );
+
+    // "Positive" checkbox is checked; "Negative" checkbox is not checked
+    const selectCheckbox = el.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    const hideCheckbox = el.shadowRoot?.querySelector(
+      '.hide-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(selectCheckbox?.checked).to.be.true;
+    expect(hideCheckbox?.checked).to.be.false;
+
+    // Eye icon is not in its active state
+    expect(
+      el.shadowRoot?.querySelector('.hide-facet-icon')
+    ).to.exist.and.satisfy(
+      (icon: HTMLElement) => !icon.classList.contains('active')
+    );
+  });
+
+  it('renders hidden facets with closed eye icon', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'hidden' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+      ></facet-row>`
+    );
+
+    // "Positive" checkbox is not checked; "Negative" checkbox is checked
+    const selectCheckbox = el.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    const hideCheckbox = el.shadowRoot?.querySelector(
+      '.hide-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(selectCheckbox?.checked).to.be.false;
+    expect(hideCheckbox?.checked).to.be.true;
+
+    // Eye icon is in its "active" state
+    expect(
+      el.shadowRoot?.querySelector('.hide-facet-icon')
+    ).to.exist.and.satisfy((icon: HTMLElement) =>
+      icon.classList.contains('active')
+    );
+  });
+
+  it('renders collection facets as links', async () => {
+    const collectionNameCache = new MockCollectionNameCache();
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'collection'}
+        .bucket=${bucket}
+        .collectionNameCache=${collectionNameCache}
+      ></facet-row>`
+    );
+
+    const collectionName = el.shadowRoot?.querySelector(
+      'async-collection-name'
+    );
+    expect(collectionName?.parentElement).to.be.instanceOf(HTMLAnchorElement);
+    expect(collectionName?.parentElement?.getAttribute('href')).to.equal(
+      '/details/foo'
+    );
+  });
+
+  it('does not render non-collection facets as links', async () => {
+    const collectionNameCache = new MockCollectionNameCache();
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        .collectionNameCache=${collectionNameCache}
+      ></facet-row>`
+    );
+
+    expect(el.shadowRoot?.querySelector('a:link')).not.to.exist;
+  });
+
+  it('emits event when facet checkbox is clicked', async () => {
+    const facetClickSpy = sinon.spy();
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        @facetClick=${facetClickSpy}
+      ></facet-row>`
+    );
+
+    const positiveFacetCheck = el.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(positiveFacetCheck).to.exist;
+    positiveFacetCheck.click();
+
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'selected',
+      negative: false,
+      count: 5,
+    });
+  });
+
+  it('emits event when facet checkbox is unchecked', async () => {
+    const facetClickSpy = sinon.spy();
+    const bucket = {
+      key: 'foo',
+      state: 'selected' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        @facetClick=${facetClickSpy}
+      ></facet-row>`
+    );
+
+    const positiveFacetCheck = el.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(positiveFacetCheck).to.exist;
+    positiveFacetCheck.click();
+
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'none',
+      negative: false,
+      count: 5,
+    });
+  });
+
+  it('emits event when facet negative icon is clicked', async () => {
+    const facetClickSpy = sinon.spy();
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        @facetClick=${facetClickSpy}
+      ></facet-row>`
+    );
+
+    const negativeFacetIcon = el.shadowRoot?.querySelector(
+      '.hide-facet-icon'
+    ) as HTMLLabelElement;
+    expect(negativeFacetIcon).to.exist;
+    negativeFacetIcon.click();
+
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'hidden',
+      negative: true,
+      count: 5,
+    });
+  });
+
+  it('emits event when facet negative icon is unchecked', async () => {
+    const facetClickSpy = sinon.spy();
+    const bucket = {
+      key: 'foo',
+      state: 'hidden' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        @facetClick=${facetClickSpy}
+      ></facet-row>`
+    );
+
+    const negativeFacetIcon = el.shadowRoot?.querySelector(
+      '.hide-facet-icon'
+    ) as HTMLLabelElement;
+    expect(negativeFacetIcon).to.exist;
+    negativeFacetIcon.click();
+
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'none',
+      negative: true,
+      count: 5,
+    });
+  });
+
+  it('selects/deselects facet when label is clicked', async () => {
+    const facetClickSpy = sinon.spy();
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetGroupKey=${'subject'}
+        .bucket=${bucket}
+        @facetClick=${facetClickSpy}
+      ></facet-row>`
+    );
+
+    const facetLabel = el.shadowRoot?.querySelector(
+      '.facet-info-display'
+    ) as HTMLLabelElement;
+    expect(facetLabel).to.exist;
+
+    // Select facet by clicking label
+    facetLabel.click();
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'selected',
+      negative: false,
+      count: 5,
+    });
+
+    // Deselect facet by clicking label
+    facetLabel.click();
+    expect(facetClickSpy.callCount).to.equal(2);
+    expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
+      key: 'subject',
+      value: 'foo',
+      state: 'none',
+      negative: false,
+      count: 5,
+    });
+  });
+});

--- a/test/collection-facets/facet-row.test.ts
+++ b/test/collection-facets/facet-row.test.ts
@@ -9,7 +9,7 @@ import { MockCollectionNameCache } from '../mocks/mock-collection-name-cache';
 describe('Facet row', () => {
   it('renders nothing if no bucket provided', async () => {
     const el = await fixture<FacetRow>(
-      html`<facet-row .facetGroupKey=${'subject'}></facet-row>`
+      html`<facet-row .facetType=${'subject'}></facet-row>`
     );
 
     expect(el.shadowRoot?.querySelector('.facet-row-container')).not.to.exist;
@@ -37,10 +37,7 @@ describe('Facet row', () => {
     };
 
     const el = await fixture<FacetRow>(
-      html`<facet-row
-        .facetGroupKey=${'subject'}
-        .bucket=${bucket}
-      ></facet-row>`
+      html`<facet-row .facetType=${'subject'} .bucket=${bucket}></facet-row>`
     );
 
     expect(el.shadowRoot?.querySelector('.facet-row-container')).to.exist;
@@ -60,10 +57,7 @@ describe('Facet row', () => {
     };
 
     const el = await fixture<FacetRow>(
-      html`<facet-row
-        .facetGroupKey=${'subject'}
-        .bucket=${bucket}
-      ></facet-row>`
+      html`<facet-row .facetType=${'subject'} .bucket=${bucket}></facet-row>`
     );
 
     const facetCount = el.shadowRoot?.querySelector('.facet-count');
@@ -78,10 +72,7 @@ describe('Facet row', () => {
     };
 
     const el = await fixture<FacetRow>(
-      html`<facet-row
-        .facetGroupKey=${'subject'}
-        .bucket=${bucket}
-      ></facet-row>`
+      html`<facet-row .facetType=${'subject'} .bucket=${bucket}></facet-row>`
     );
 
     // "Positive" checkbox is checked; "Negative" checkbox is not checked
@@ -110,10 +101,7 @@ describe('Facet row', () => {
     };
 
     const el = await fixture<FacetRow>(
-      html`<facet-row
-        .facetGroupKey=${'subject'}
-        .bucket=${bucket}
-      ></facet-row>`
+      html`<facet-row .facetType=${'subject'} .bucket=${bucket}></facet-row>`
     );
 
     // "Positive" checkbox is not checked; "Negative" checkbox is checked
@@ -144,7 +132,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'collection'}
+        .facetType=${'collection'}
         .bucket=${bucket}
         .collectionNameCache=${collectionNameCache}
       ></facet-row>`
@@ -169,7 +157,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         .collectionNameCache=${collectionNameCache}
       ></facet-row>`
@@ -188,7 +176,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         @facetClick=${facetClickSpy}
       ></facet-row>`
@@ -202,11 +190,9 @@ describe('Facet row', () => {
 
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'selected',
+      facetType: 'subject',
+      bucket,
       negative: false,
-      count: 5,
     });
   });
 
@@ -220,7 +206,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         @facetClick=${facetClickSpy}
       ></facet-row>`
@@ -234,11 +220,9 @@ describe('Facet row', () => {
 
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'none',
+      facetType: 'subject',
+      bucket,
       negative: false,
-      count: 5,
     });
   });
 
@@ -252,7 +236,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         @facetClick=${facetClickSpy}
       ></facet-row>`
@@ -266,11 +250,9 @@ describe('Facet row', () => {
 
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'hidden',
+      facetType: 'subject',
+      bucket,
       negative: true,
-      count: 5,
     });
   });
 
@@ -284,7 +266,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         @facetClick=${facetClickSpy}
       ></facet-row>`
@@ -298,11 +280,9 @@ describe('Facet row', () => {
 
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'none',
+      facetType: 'subject',
+      bucket,
       negative: true,
-      count: 5,
     });
   });
 
@@ -316,7 +296,7 @@ describe('Facet row', () => {
 
     const el = await fixture<FacetRow>(
       html`<facet-row
-        .facetGroupKey=${'subject'}
+        .facetType=${'subject'}
         .bucket=${bucket}
         @facetClick=${facetClickSpy}
       ></facet-row>`
@@ -331,22 +311,18 @@ describe('Facet row', () => {
     facetLabel.click();
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'selected',
+      facetType: 'subject',
+      bucket,
       negative: false,
-      count: 5,
     });
 
     // Deselect facet by clicking label
     facetLabel.click();
     expect(facetClickSpy.callCount).to.equal(2);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
-      key: 'subject',
-      value: 'foo',
-      state: 'none',
+      facetType: 'subject',
+      bucket,
       negative: false,
-      count: 5,
     });
   });
 });

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -4,8 +4,9 @@ import { html } from 'lit';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 import '../../src/collection-facets/facets-template';
 import type { FacetRow } from '../../src/collection-facets/facet-row';
+import type { FacetGroup } from '../../src/models';
 
-const facetGroup = {
+const facetGroup: FacetGroup = {
   title: 'Media Type',
   key: 'mediatype',
   buckets: [
@@ -67,12 +68,12 @@ describe('Render facets', () => {
 
   it('emits facet click and change events when a facet is selected/deselected', async () => {
     const facetClickSpy = sinon.spy();
-    const facetsChangeSpy = sinon.spy();
+    const facetChangeSpy = sinon.spy();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${facetGroup}
         @facetClick=${facetClickSpy}
-        @selectedFacetsChanged=${facetsChangeSpy}
+        @selectedFacetsChanged=${facetChangeSpy}
       ></facets-template>`
     );
 
@@ -86,23 +87,23 @@ describe('Render facets', () => {
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(1);
-    expect(facetsChangeSpy.callCount).to.equal(1);
+    expect(facetChangeSpy.callCount).to.equal(1);
     expect(facetRow.bucket?.state).to.equal('selected');
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(2);
-    expect(facetsChangeSpy.callCount).to.equal(2);
+    expect(facetChangeSpy.callCount).to.equal(2);
     expect(facetRow.bucket?.state).to.equal('none');
   });
 
   it('emits facet click and change events when a facet is negated/un-negated', async () => {
     const facetClickSpy = sinon.spy();
-    const facetsChangeSpy = sinon.spy();
+    const facetChangeSpy = sinon.spy();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${facetGroup}
         @facetClick=${facetClickSpy}
-        @selectedFacetsChanged=${facetsChangeSpy}
+        @selectedFacetsChanged=${facetChangeSpy}
       ></facets-template>`
     );
 
@@ -116,12 +117,49 @@ describe('Render facets', () => {
 
     facetNegateCheck.click();
     expect(facetClickSpy.callCount).to.equal(1);
-    expect(facetsChangeSpy.callCount).to.equal(1);
+    expect(facetChangeSpy.callCount).to.equal(1);
     expect(facetRow.bucket?.state).to.equal('hidden');
 
     facetNegateCheck.click();
     expect(facetClickSpy.callCount).to.equal(2);
-    expect(facetsChangeSpy.callCount).to.equal(2);
+    expect(facetChangeSpy.callCount).to.equal(2);
     expect(facetRow.bucket?.state).to.equal('none');
+  });
+
+  it('emits facet click and change events when a pre-selected facet is deselected', async () => {
+    const facetClickSpy = sinon.spy();
+    const facetChangeSpy = sinon.spy();
+    const facetGroupWithSelection = { ...facetGroup };
+    facetGroupWithSelection.buckets = [
+      { ...facetGroup.buckets[0], state: 'selected' },
+      ...facetGroup.buckets.slice(1),
+    ];
+
+    const el = await fixture<FacetsTemplate>(
+      html`<facets-template
+        .facetGroup=${facetGroupWithSelection}
+        @facetClick=${facetClickSpy}
+        @selectedFacetsChanged=${facetChangeSpy}
+      ></facets-template>`
+    );
+
+    const facetRow = el.shadowRoot?.querySelector('facet-row') as FacetRow;
+    expect(facetRow).to.exist;
+
+    const facetSelectCheck = facetRow.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(facetSelectCheck).to.exist;
+    expect(facetSelectCheck.checked).to.be.true;
+
+    facetSelectCheck.click();
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetChangeSpy.callCount).to.equal(1);
+    expect(facetRow.bucket?.state).to.equal('none');
+
+    facetSelectCheck.click();
+    expect(facetClickSpy.callCount).to.equal(2);
+    expect(facetChangeSpy.callCount).to.equal(2);
+    expect(facetRow.bucket?.state).to.equal('selected');
   });
 });

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture } from '@open-wc/testing';
+import sinon from 'sinon';
 import { html } from 'lit';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 import '../../src/collection-facets/facets-template';
@@ -33,7 +34,6 @@ describe('Render facets', () => {
         .renderOn=${'page'}
       ></facets-template>`
     );
-    await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.facets-on-page')).to.exist;
   });
@@ -45,7 +45,6 @@ describe('Render facets', () => {
         .renderOn=${'modal'}
       ></facets-template>`
     );
-    await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.facets-on-modal')).to.exist;
   });
@@ -54,7 +53,6 @@ describe('Render facets', () => {
     const el = await fixture<FacetsTemplate>(
       html`<facets-template .facetGroup=${facetGroup}></facets-template>`
     );
-    await el.updateComplete;
 
     const facetRows = el.shadowRoot?.querySelectorAll('facet-row');
     expect(facetRows?.length).to.equal(facetGroup.buckets.length);
@@ -65,5 +63,65 @@ describe('Render facets', () => {
       expect(facetRow.bucket).to.equal(facetGroup.buckets[i]);
       expect(facetRow.facetType).to.equal(facetGroup.key);
     });
+  });
+
+  it('emits facet click and change events when a facet is selected/deselected', async () => {
+    const facetClickSpy = sinon.spy();
+    const facetsChangeSpy = sinon.spy();
+    const el = await fixture<FacetsTemplate>(
+      html`<facets-template
+        .facetGroup=${facetGroup}
+        @facetClick=${facetClickSpy}
+        @selectedFacetsChanged=${facetsChangeSpy}
+      ></facets-template>`
+    );
+
+    const facetRow = el.shadowRoot?.querySelector('facet-row') as FacetRow;
+    expect(facetRow).to.exist;
+
+    const facetSelectCheck = facetRow.shadowRoot?.querySelector(
+      '.select-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(facetSelectCheck).to.exist;
+
+    facetSelectCheck.click();
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetsChangeSpy.callCount).to.equal(1);
+    expect(facetRow.bucket?.state).to.equal('selected');
+
+    facetSelectCheck.click();
+    expect(facetClickSpy.callCount).to.equal(2);
+    expect(facetsChangeSpy.callCount).to.equal(2);
+    expect(facetRow.bucket?.state).to.equal('none');
+  });
+
+  it('emits facet click and change events when a facet is negated/un-negated', async () => {
+    const facetClickSpy = sinon.spy();
+    const facetsChangeSpy = sinon.spy();
+    const el = await fixture<FacetsTemplate>(
+      html`<facets-template
+        .facetGroup=${facetGroup}
+        @facetClick=${facetClickSpy}
+        @selectedFacetsChanged=${facetsChangeSpy}
+      ></facets-template>`
+    );
+
+    const facetRow = el.shadowRoot?.querySelector('facet-row') as FacetRow;
+    expect(facetRow).to.exist;
+
+    const facetNegateCheck = facetRow.shadowRoot?.querySelector(
+      '.hide-facet-checkbox'
+    ) as HTMLInputElement;
+    expect(facetNegateCheck).to.exist;
+
+    facetNegateCheck.click();
+    expect(facetClickSpy.callCount).to.equal(1);
+    expect(facetsChangeSpy.callCount).to.equal(1);
+    expect(facetRow.bucket?.state).to.equal('hidden');
+
+    facetNegateCheck.click();
+    expect(facetClickSpy.callCount).to.equal(2);
+    expect(facetsChangeSpy.callCount).to.equal(2);
+    expect(facetRow.bucket?.state).to.equal('none');
   });
 });

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -1,9 +1,8 @@
 import { expect, fixture } from '@open-wc/testing';
-import sinon from 'sinon';
 import { html } from 'lit';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 import '../../src/collection-facets/facets-template';
-import { getDefaultSelectedFacets, FacetEventDetails } from '../../src/models';
+import type { FacetRow } from '../../src/collection-facets/facet-row';
 
 const facetGroup = {
   title: 'Media Type',
@@ -24,7 +23,7 @@ describe('Render facets', () => {
     );
     await el.updateComplete;
 
-    expect(el.shadowRoot?.querySelector('.facet-row')).to.exist;
+    expect(el.shadowRoot?.querySelector('facet-row')).to.exist;
   });
 
   it('facets render on page', async () => {
@@ -51,153 +50,20 @@ describe('Render facets', () => {
     expect(el.shadowRoot?.querySelector('.facets-on-modal')).to.exist;
   });
 
-  it('find facet-title and facet-count for particular facet group', async () => {
+  it('applies correct bucket values to facet row', async () => {
     const el = await fixture<FacetsTemplate>(
       html`<facets-template .facetGroup=${facetGroup}></facets-template>`
     );
     await el.updateComplete;
 
-    const facetInfo = el.shadowRoot?.querySelector('.facet-info-display');
-    expect(facetInfo?.querySelector('.facet-title')?.textContent).to.equal(
-      'audio'
-    );
-    expect(
-      facetInfo?.querySelector('.facet-count')?.textContent?.trim()
-    ).to.equal('1,001');
-  });
+    const facetRows = el.shadowRoot?.querySelectorAll('facet-row');
+    expect(facetRows?.length).to.equal(facetGroup.buckets.length);
 
-  it('find the hidden facet item', async () => {
-    const selectedFacets = { ...facetGroup };
-    selectedFacets.buckets[2].state = 'hidden'; // hide 'texts' mediatype
-
-    const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${facetGroup}
-        .selectedFacets=${selectedFacets}
-      ></facets-template>`
-    );
-    await el.updateComplete;
-
-    const hiddenFacet = el.shadowRoot?.querySelectorAll('.hide-facet-icon')[0];
-
-    // check title attribute for 'texts' mediatype
-    expect(hiddenFacet?.getAttribute('title')).equal('Unhide mediatype: texts');
-  });
-
-  it('find the selected facet item', async () => {
-    const selectedFacets = { ...facetGroup };
-    selectedFacets.buckets[1].state = 'selected'; // select 'movies' mediatype
-
-    const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${facetGroup}
-        .selectedFacets=${selectedFacets}
-      ></facets-template>`
-    );
-    await el.updateComplete;
-
-    const selectedFacet =
-      el.shadowRoot?.querySelectorAll('.hide-facet-icon')[0];
-
-    // check title attribute for 'movies' mediatype
-    expect(selectedFacet?.getAttribute('title')).equal(
-      'Hide mediatype: movies'
-    );
-  });
-
-  it('emits facetClick events for normal facets', async () => {
-    const facetClickSpy = sinon.spy();
-    const mediatypeGroup = {
-      title: 'Media Type',
-      key: 'mediatype',
-      buckets: [
-        { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
-      ],
-    };
-    const selectedFacets = getDefaultSelectedFacets();
-    const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${mediatypeGroup}
-        .selectedFacets=${selectedFacets}
-        @facetClick=${facetClickSpy}
-      ></facets-template>`
-    );
-
-    const checkbox = el.shadowRoot?.querySelector(
-      '.select-facet-checkbox'
-    ) as HTMLInputElement;
-    expect(checkbox).to.exist;
-
-    // Select it
-    checkbox.click();
-    await el.updateComplete;
-    expect(facetClickSpy.callCount).to.equal(1);
-
-    const selectEvent = facetClickSpy
-      .args[0][0] as CustomEvent<FacetEventDetails>;
-    expect(selectEvent).to.exist;
-    expect(selectEvent?.detail?.key).to.equal('mediatype');
-    expect(selectEvent?.detail?.state).to.equal('selected');
-    expect(selectEvent?.detail?.negative).to.be.false;
-
-    // Unselect it
-    checkbox.click();
-    await el.updateComplete;
-    expect(facetClickSpy.callCount).to.equal(2);
-
-    const unselectEvent = facetClickSpy
-      .args[1][0] as CustomEvent<FacetEventDetails>;
-    expect(unselectEvent).to.exist;
-    expect(unselectEvent?.detail?.key).to.equal('mediatype');
-    expect(unselectEvent?.detail?.state).to.equal('none');
-    expect(unselectEvent?.detail?.negative).to.be.false;
-  });
-
-  it('emits facetClick events for negative facets', async () => {
-    const facetClickSpy = sinon.spy();
-    const mediatypeGroup = {
-      title: 'Media Type',
-      key: 'mediatype',
-      buckets: [
-        { displayText: 'audio', key: 'audio', count: 42, state: 'none' },
-      ],
-    };
-    const selectedFacets = getDefaultSelectedFacets();
-    const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${mediatypeGroup}
-        .selectedFacets=${selectedFacets}
-        @facetClick=${facetClickSpy}
-      ></facets-template>`
-    );
-
-    const checkbox = el.shadowRoot?.querySelector(
-      '.hide-facet-checkbox'
-    ) as HTMLInputElement;
-    expect(checkbox).to.exist;
-
-    // Select it
-    checkbox.click();
-    await el.updateComplete;
-    expect(facetClickSpy.callCount).to.equal(1);
-
-    const selectEvent = facetClickSpy
-      .args[0][0] as CustomEvent<FacetEventDetails>;
-    expect(selectEvent).to.exist;
-    expect(selectEvent?.detail?.key).to.equal('mediatype');
-    expect(selectEvent?.detail?.state).to.equal('hidden');
-    expect(selectEvent?.detail?.negative).to.be.true;
-
-    // Unselect it
-    checkbox.click();
-    await el.updateComplete;
-    expect(facetClickSpy.callCount).to.equal(2);
-
-    const unselectEvent = facetClickSpy
-      .args[1][0] as CustomEvent<FacetEventDetails>;
-    expect(unselectEvent).to.exist;
-    expect(unselectEvent?.detail?.key).to.equal('mediatype');
-    expect(unselectEvent?.detail?.state).to.equal('none');
-    expect(unselectEvent?.detail?.negative).to.be.true;
+    facetRows?.forEach((elmt, i) => {
+      const facetRow = elmt as FacetRow;
+      expect(facetRow).to.exist;
+      expect(facetRow.bucket).to.equal(facetGroup.buckets[i]);
+      expect(facetRow.facetType).to.equal(facetGroup.key);
+    });
   });
 });


### PR DESCRIPTION
Currently our lowest-level facet component renders an entire _group_ of facets, making some of the facet logic and state management more complex than it needs to be. In order to simplify efforts to tweak facet behavior going forward, this PR extracts a new component to represent an individual facet row, providing a cleaner separation between the responsibilities of that single facet vs. those of the facet group as a whole. It also fleshes out our tests for a few facet behavior corners that were lacking test coverage before.