### PR TITLE
Fixed resizeObserver issue when you are on ?tab=loans

### DIFF
--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -216,6 +216,9 @@ export class SortFilterBar
   private disconnectResizeObserver(
     resizeObserver: SharedResizeObserverInterface
   ) {
+    // return if element not defined
+    if (!this.sortSelectorContainer || !this.desktopSortContainer) return;
+
     resizeObserver.removeObserver({
       target: this.sortSelectorContainer,
       handler: this,
@@ -229,6 +232,10 @@ export class SortFilterBar
 
   private setupResizeObserver() {
     if (!this.resizeObserver) return;
+
+    // return if element not defined
+    if (!this.sortSelectorContainer || !this.desktopSortContainer) return;
+
     this.resizeObserver.addObserver({
       target: this.sortSelectorContainer,
       handler: this,


### PR DESCRIPTION
Currently we are using slot for loans tab sort-bar from offshoot. There are resizeObserver was using on universal sort filter-bar elements which is not present when loans tab. So applied check to make sure the element are there before .addObserver.

This fix is part of https://webarchive.jira.com/browse/WEBDEV-6481 ticket. This issue should be fixed when we added slot for loans tab sort filter-bar.