### PR TITLE
Add prop to suppress facets pane & associated requests

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -309,6 +309,15 @@ export class AppRoot extends LitElement {
             <div class="checkbox-control">
               <input
                 type="checkbox"
+                id="enable-facets"
+                checked
+                @click=${this.facetsChanged}
+              />
+              <label for="enable-facets">Enable facets</label>
+            </div>
+            <div class="checkbox-control">
+              <input
+                type="checkbox"
                 id="enable-management"
                 @click=${this.manageModeCheckboxChanged}
               />
@@ -559,6 +568,11 @@ export class AppRoot extends LitElement {
       this.collectionBrowser.minSelectedDate = undefined;
       this.collectionBrowser.maxSelectedDate = undefined;
     }
+  }
+
+  private facetsChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.collectionBrowser.suppressFacets = !target.checked;
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -9,6 +9,7 @@ import {
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { msg } from '@lit/localize';
 
 import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
 import type {
@@ -130,6 +131,8 @@ export class CollectionBrowser
   @property({ type: Boolean }) suppressPlaceholders = false;
 
   @property({ type: Boolean }) suppressResultCount = false;
+
+  @property({ type: Boolean }) suppressFacets = false;
 
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 
@@ -954,6 +957,13 @@ export class CollectionBrowser
    * The template for the facets component alone, without any surrounding wrappers.
    */
   private get facetsTemplate() {
+    if (this.suppressFacets)
+      return html`
+        <p class="facets-message">
+          ${msg('Facets are temporarily unavailable.')}
+        </p>
+      `;
+
     return html`
       <collection-facets
         @facetsChanged=${this.facetsChanged}
@@ -1480,7 +1490,10 @@ export class CollectionBrowser
     });
 
     // Fire the initial page and facets requests
-    await Promise.all([this.doInitialPageFetch(), this.fetchFacets()]);
+    await Promise.all([
+      this.doInitialPageFetch(),
+      this.suppressFacets ? null : this.fetchFacets(),
+    ]);
 
     // Resolve the `initialSearchComplete` promise for this search
     this._initialSearchCompleteResolver(true);
@@ -2580,6 +2593,11 @@ export class CollectionBrowser
         }
         #facets-bottom-fade.hidden {
           height: 0;
+        }
+
+        .facets-message {
+          text-align: center;
+          font-size: 1.2rem;
         }
 
         .desktop #left-column-scroll-sentinel {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -957,12 +957,13 @@ export class CollectionBrowser
    * The template for the facets component alone, without any surrounding wrappers.
    */
   private get facetsTemplate() {
-    if (this.suppressFacets)
+    if (this.suppressFacets) {
       return html`
         <p class="facets-message">
           ${msg('Facets are temporarily unavailable.')}
         </p>
       `;
+    }
 
     return html`
       <collection-facets

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2597,8 +2597,7 @@ export class CollectionBrowser
         }
 
         .facets-message {
-          text-align: center;
-          font-size: 1.2rem;
+          font-size: 1.4rem;
         }
 
         .desktop #left-column-scroll-sentinel {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1495,6 +1495,24 @@ describe('Collection Browser', () => {
     expect(el.maxSelectedDate).not.to.exist;
   });
 
+  it('shows temporarily unavailable message when facets suppressed', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService} suppressFacets>
+      </collection-browser>`
+    );
+
+    el.baseQuery = 'foo';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    const facetsMsg = el.shadowRoot?.querySelector('.facets-message');
+    expect(facetsMsg).to.exist;
+    expect(facetsMsg?.textContent?.trim()).to.equal(
+      'Facets are temporarily unavailable.'
+    );
+  });
+
   it('shows manage bar interface instead of sort bar when in manage view', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(


### PR DESCRIPTION
Adds a `suppressFacets` property to collection-browser to allow quick disabling of the facets pane and its associated PPS requests.