### PR TITLE
WEBDEV-6637 Ensure sort dropdown selections are sticky and correctly reflect active defaults

### DIFF
--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -167,6 +167,12 @@ export class SortFilterBar
   }
 
   willUpdate(changed: PropertyValues) {
+    console.log(
+      'sort bar updated:\n',
+      [...changed.entries()]
+        .map(([k, v]) => `${String(k)}: ${v} -> ${this[k as keyof this]}`)
+        .join('\n')
+    );
     if (changed.has('selectedSort')) {
       if (this.sortDirection === null) {
         const sortOption = SORT_OPTIONS[this.finalizedSortField];
@@ -182,7 +188,10 @@ export class SortFilterBar
 
     // If we change which dropdown options are available, ensure the correct default becomes selected.
     // Currently, Date Favorited is the only dropdown option whose presence/absence can change.
-    if (changed.has('showDateFavorited')) {
+    if (
+      changed.has('showDateFavorited') &&
+      changed.get('showDateFavorited') !== this.showDateFavorited
+    ) {
       this.lastSelectedDateSort = this.defaultDateSortField;
     }
   }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -166,20 +166,30 @@ export class SortFilterBar
     `;
   }
 
-  updated(changed: PropertyValues) {
-    if (changed.has('displayMode')) {
-      this.displayModeChanged();
-    }
+  willUpdate(changed: PropertyValues) {
+    if (changed.has('selectedSort')) {
+      if (this.sortDirection === null) {
+        const sortOption = SORT_OPTIONS[this.finalizedSortField];
+        this.sortDirection = sortOption.defaultSortDirection;
+      }
 
-    if (changed.has('selectedSort') && this.sortDirection === null) {
-      const sortOption = SORT_OPTIONS[this.finalizedSortField];
-      this.sortDirection = sortOption.defaultSortDirection;
+      if (this.viewOptionSelected) {
+        this.lastSelectedViewSort = this.finalizedSortField;
+      } else if (this.dateOptionSelected) {
+        this.lastSelectedDateSort = this.finalizedSortField;
+      }
     }
 
     // If we change which dropdown options are available, ensure the correct default becomes selected.
     // Currently, Date Favorited is the only dropdown option whose presence/absence can change.
     if (changed.has('showDateFavorited')) {
       this.lastSelectedDateSort = this.defaultDateSortField;
+    }
+  }
+
+  updated(changed: PropertyValues) {
+    if (changed.has('displayMode')) {
+      this.displayModeChanged();
     }
 
     if (changed.has('selectedTitleFilter') && this.selectedTitleFilter) {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -557,7 +557,7 @@ export class SortFilterBar
         this.getDropdownOption(SortField.weeklyview),
         this.getDropdownOption(SortField.alltimeview),
       ],
-      selectedOption: this.viewOptionSelected ? this.selectedSort : '',
+      selectedOption: this.viewOptionSelected ? this.finalizedSortField : '',
       onOptionSelected: this.dropdownOptionSelected,
       onDropdownClick: () => {
         this.dateDropdown.open = false;
@@ -589,7 +589,7 @@ export class SortFilterBar
         this.getDropdownOption(SortField.datereviewed),
         this.getDropdownOption(SortField.dateadded),
       ],
-      selectedOption: this.dateOptionSelected ? this.selectedSort : '',
+      selectedOption: this.dateOptionSelected ? this.finalizedSortField : '',
       onOptionSelected: this.dropdownOptionSelected,
       onDropdownClick: () => {
         this.viewsDropdown.open = false;

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -167,12 +167,6 @@ export class SortFilterBar
   }
 
   willUpdate(changed: PropertyValues) {
-    console.log(
-      'sort bar updated:\n',
-      [...changed.entries()]
-        .map(([k, v]) => `${String(k)}: ${v} -> ${this[k as keyof this]}`)
-        .join('\n')
-    );
     if (changed.has('selectedSort')) {
       if (this.sortDirection === null) {
         const sortOption = SORT_OPTIONS[this.finalizedSortField];

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -10,23 +10,22 @@ import type { SortField } from '../../src/models';
 import '../../src/sort-filter-bar/sort-filter-bar';
 
 describe('Sort selector default buttons', async () => {
-  const el = await fixture<SortFilterBar>(html`
-    <sort-filter-bar> </sort-filter-bar>
-  `);
-  const sortSelectorContainer = el.shadowRoot?.querySelector(
-    '#sort-selector-container'
-  );
-  const desktopSortSelector = sortSelectorContainer?.querySelector(
-    '#desktop-sort-selector'
-  );
+  let el: SortFilterBar;
+  let sortSelectorContainer: HTMLElement | null | undefined;
+  let desktopSortSelector: HTMLElement | null | undefined;
 
   beforeEach(async () => {
-    el.resizeObserver = new SharedResizeObserver();
-    await el.updateComplete;
-  });
+    el = await fixture<SortFilterBar>(html`
+      <sort-filter-bar></sort-filter-bar>
+    `);
+    sortSelectorContainer = el.shadowRoot?.querySelector(
+      '#sort-selector-container'
+    );
+    desktopSortSelector = sortSelectorContainer?.querySelector(
+      '#desktop-sort-selector'
+    );
 
-  afterEach(async () => {
-    el.resizeObserver = undefined;
+    el.resizeObserver = new SharedResizeObserver();
     await el.updateComplete;
   });
 
@@ -160,6 +159,10 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('handles click event on relevance selector', async () => {
+    el.showRelevance = true;
+    el.selectedSort = 'title' as SortField;
+    await el.updateComplete;
+
     const defaultSortSelector = desktopSortSelector?.children
       .item(0)
       ?.querySelector('button');


### PR DESCRIPTION
This PR tweaks the sort selection dropdowns for Views/Dates so that:
1. After making a dropdown selection, changing the sort to something outside of that dropdown will leave the last selected option visible (i.e., "sticky" selection), instead of resetting the dropdown to its default state.
2. When no dropdown selection has been made yet (so the default option is visible on the dropdown label), opening the dropdown menu will correctly show that default option as the selected menu item. (Without this fix, the menu is opening in an indeterminate state with nothing selected.)