### PR TITLE
WEBDEV-6637 Ensure sort bar dropdowns update on default sort change

### DIFF
--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -31,7 +31,7 @@ export interface RestorationState {
 }
 
 export interface RestorationStateHandlerInterface {
-  persistState(state: RestorationState): void;
+  persistState(state: RestorationState, forceReplace?: boolean): void;
   getRestorationState(): RestorationState;
 }
 
@@ -50,9 +50,9 @@ export class RestorationStateHandler
     this.context = options.context;
   }
 
-  persistState(state: RestorationState): void {
+  persistState(state: RestorationState, forceReplace = false): void {
     if (state.displayMode) this.persistViewStateToCookies(state.displayMode);
-    this.persistQueryStateToUrl(state);
+    this.persistQueryStateToUrl(state, forceReplace);
   }
 
   getRestorationState(): RestorationState {
@@ -85,7 +85,10 @@ export class RestorationStateHandler
     return 'list-compact';
   }
 
-  private persistQueryStateToUrl(state: RestorationState) {
+  private persistQueryStateToUrl(
+    state: RestorationState,
+    forceReplace = false
+  ) {
     const url = new URL(window.location.href);
     const oldParams = new URLSearchParams(url.searchParams);
     const newParams = this.removeRecognizedParams(url.searchParams);
@@ -176,7 +179,9 @@ export class RestorationStateHandler
     //  - If the state has changed, we push a new history entry.
     //  - If only the page number has changed, we replace the current history entry.
     //  - If the state hasn't changed, then do nothing.
-    let historyMethod: 'pushState' | 'replaceState' = 'pushState';
+    let historyMethod: 'pushState' | 'replaceState' = forceReplace
+      ? 'replaceState'
+      : 'pushState';
     const nonQueryParamsMatch = this.paramsMatch(oldParams, newParams, [
       'sin',
       'sort',

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -168,7 +168,13 @@ export class SortFilterBar
 
   willUpdate(changed: PropertyValues) {
     if (changed.has('selectedSort') || changed.has('defaultSortField')) {
-      if (this.sortDirection === null) {
+      // If the sort is changed from its default without a direction set,
+      // we adopt the default sort direction for that sort type.
+      if (
+        this.selectedSort &&
+        this.selectedSort !== SortField.default &&
+        this.sortDirection === null
+      ) {
         const sortOption = SORT_OPTIONS[this.finalizedSortField];
         this.sortDirection = sortOption.defaultSortDirection;
       }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -167,7 +167,7 @@ export class SortFilterBar
   }
 
   willUpdate(changed: PropertyValues) {
-    if (changed.has('selectedSort')) {
+    if (changed.has('selectedSort') || changed.has('defaultSortField')) {
       if (this.sortDirection === null) {
         const sortOption = SORT_OPTIONS[this.finalizedSortField];
         this.sortDirection = sortOption.defaultSortDirection;


### PR DESCRIPTION
Fixes a bug introduced in #343 where changing the `defaultSortField` alone would incorrectly leave any previous view/date dropdown selection untouched if using the defaults. The correct behavior is to update the dropdown selection when _either_ the selected sort _or_ its default changes.