### PR TITLE
WEBDEV-6292 Adjust sort bar slots/props to accommodate inline search bar

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -376,10 +376,20 @@ export class AppRoot extends LitElement {
               <input
                 type="checkbox"
                 id="enable-sortbar-left-slot"
-                @click=${this.sortBarSlotCheckboxChanged}
+                @click=${this.sortBarLeftSlotCheckboxChanged}
               />
               <label for="enable-sortbar-left-slot"
                 >Show sortbar left slot</label
+              >
+            </div>
+            <div class="checkbox-control">
+              <input
+                type="checkbox"
+                id="enable-sortbar-right-slot"
+                @click=${this.sortBarRightSlotCheckboxChanged}
+              />
+              <label for="enable-sortbar-right-slot"
+                >Show sortbar right slot</label
               >
             </div>
             <div class="checkbox-control">
@@ -733,25 +743,50 @@ export class AppRoot extends LitElement {
   }
 
   /**
-   * Handler for when the dev panel's "Show facet top slot" checkbox is changed.
+   * Handler for when the dev panel's "Show sort bar top left slot" checkbox is changed.
    */
-  private sortBarSlotCheckboxChanged(e: Event) {
+  private sortBarLeftSlotCheckboxChanged(e: Event) {
     const target = e.target as HTMLInputElement;
 
-    const div = document.createElement('div');
-    div.style.setProperty('border', '1px solid #000');
-    div.textContent = 'Btn';
-    div.style.setProperty('height', '3rem');
-    div.style.setProperty('width', '3rem');
-    div.style.backgroundColor = '#00000';
-    div.setAttribute('slot', 'sort-options-left');
-
     if (target.checked) {
+      const div = document.createElement('div');
+      div.style.setProperty('border', '1px solid #000');
+      div.textContent = 'Btn';
+      div.style.setProperty('height', '3rem');
+      div.style.setProperty('width', '3rem');
+      div.style.backgroundColor = '#000';
+      div.setAttribute('slot', 'sort-options-left');
+
       this.collectionBrowser.appendChild(div);
     } else {
-      this.collectionBrowser.removeChild(
-        this.collectionBrowser.lastElementChild as Element
+      const slottedEl = this.collectionBrowser.querySelector(
+        '[slot="sort-options-left"]'
       );
+      if (slottedEl) this.collectionBrowser.removeChild(slottedEl);
+    }
+  }
+
+  /**
+   * Handler for when the dev panel's "Show sort bar top right slot" checkbox is changed.
+   */
+  private sortBarRightSlotCheckboxChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+
+    if (target.checked) {
+      const div = document.createElement('div');
+      div.style.setProperty('border', '1px solid #000');
+      div.textContent = 'Search bar';
+      div.style.setProperty('height', '3rem');
+      div.style.setProperty('width', '15rem');
+      div.style.backgroundColor = '#000';
+      div.setAttribute('slot', 'sort-options-right');
+
+      this.collectionBrowser.appendChild(div);
+    } else {
+      const slottedEl = this.collectionBrowser.querySelector(
+        '[slot="sort-options-right"]'
+      );
+      if (slottedEl) this.collectionBrowser.removeChild(slottedEl);
     }
   }
 
@@ -807,21 +842,22 @@ export class AppRoot extends LitElement {
   private replaceSortOptionsChanged(e: Event) {
     const target = e.target as HTMLInputElement;
 
-    const p = document.createElement('p');
-    p.style.setProperty('border', '1px solid #000');
-    p.textContent = 'New stuff as a child.';
-    p.style.setProperty('height', '20px');
-    p.style.backgroundColor = '#00000';
-    p.setAttribute('slot', 'sort-options');
-
     if (target.checked) {
-      this.collectionBrowser.enableSortOptionsSlot = true;
+      const p = document.createElement('p');
+      p.style.setProperty('border', '1px solid #000');
+      p.textContent = 'New stuff as a child.';
+      p.style.setProperty('height', '20px');
+      p.style.backgroundColor = '#000';
+      p.setAttribute('slot', 'sort-options');
+
       this.collectionBrowser.appendChild(p);
+      this.collectionBrowser.enableSortOptionsSlot = true;
     } else {
-      this.collectionBrowser.enableSortOptionsSlot = false;
-      this.collectionBrowser.removeChild(
-        this.collectionBrowser.lastElementChild as Element
+      const slottedEl = this.collectionBrowser.querySelector(
+        '[slot="sort-options"]'
       );
+      if (slottedEl) this.collectionBrowser.removeChild(slottedEl);
+      this.collectionBrowser.enableSortOptionsSlot = false;
     }
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -136,6 +136,8 @@ export class CollectionBrowser
 
   @property({ type: Boolean }) suppressSortBar = false;
 
+  @property({ type: Boolean }) suppressDisplayModes = false;
+
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 
   @property({ type: String }) collectionPagePath: string = '/details/';
@@ -628,6 +630,7 @@ export class CollectionBrowser
         .prefixFilterCountMap=${this.dataSource.prefixFilterCountMap}
         .resizeObserver=${this.resizeObserver}
         .enableSortOptionsSlot=${this.enableSortOptionsSlot}
+        .suppressDisplayModes=${this.suppressDisplayModes}
         @sortChanged=${this.userChangedSort}
         @displayModeChanged=${this.displayModeChanged}
         @titleLetterChanged=${this.titleLetterSelected}
@@ -1185,6 +1188,7 @@ export class CollectionBrowser
   connectedCallback(): void {
     super.connectedCallback?.();
     this.setupStateRestorationObserver();
+    this.setupResizeObserver();
   }
 
   disconnectedCallback(): void {
@@ -1338,7 +1342,7 @@ export class CollectionBrowser
   }
 
   private setupResizeObserver() {
-    if (!this.resizeObserver) return;
+    if (!this.resizeObserver || !this.contentContainer) return;
     this.resizeObserver.addObserver({
       target: this.contentContainer,
       handler: this,

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -635,6 +635,7 @@ export class CollectionBrowser
       >
         <slot name="sort-options-left" slot="sort-options-left"></slot>
         <slot name="sort-options" slot="sort-options"></slot>
+        <slot name="sort-options-right" slot="sort-options-right"></slot>
       </sort-filter-bar>
     `;
   }

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -160,6 +160,7 @@ export class SortFilterBar
                 `
               : html`<slot name="sort-options"></slot>`}
           </div>
+          <slot name="sort-options-right"></slot>
 
           <div id="display-style-selector">${this.displayOptionTemplate}</div>
         </section>

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -73,6 +73,10 @@ export class SortFilterBar
   @property({ type: Boolean, reflect: true }) enableSortOptionsSlot: boolean =
     false;
 
+  /** Whether to suppress showing the three display mode options on the right of the bar (default `false`) */
+  @property({ type: Boolean, reflect: true })
+  suppressDisplayModes: boolean = false;
+
   /** Maps of result counts for letters on the alphabet bar, for each letter filter type */
   @property({ type: Object }) prefixFilterCountMap?: Record<
     PrefixFilterType,
@@ -162,7 +166,11 @@ export class SortFilterBar
           </div>
           <slot name="sort-options-right"></slot>
 
-          <div id="display-style-selector">${this.displayOptionTemplate}</div>
+          ${this.suppressDisplayModes
+            ? nothing
+            : html`<div id="display-style-selector">
+                ${this.displayOptionTemplate}
+              </div>`}
         </section>
 
         ${this.dropdownBackdropVisible ? this.dropdownBackdrop : nothing}


### PR DESCRIPTION
Adds a slot for the right side of the sort options, and adds a property to suppress rendering the display mode options. Both of these are to allow a search bar to be slotted in which can be expanded to the full width of the bar on mobile as needed.