### PR TITLE
WEBDEV-6705 Fire analytics when mobile facets toggled

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -890,9 +890,16 @@ export class CollectionBrowser
    * including the collapsible container (with header) and the facets themselves.
    */
   private get mobileFacetsTemplate(): TemplateResult {
-    const toggleFacetsVisible = () => {
+    const toggleFacetsVisible = (e: Event) => {
       this.isResizeToMobile = false;
       this.mobileFacetsVisible = !this.mobileFacetsVisible;
+
+      const target = e.target as HTMLDetailsElement;
+      this.analyticsHandler?.sendEvent({
+        category: this.searchContext,
+        action: analyticsActions.mobileFacetsToggled,
+        label: target.open ? 'open' : 'closed',
+      });
     };
 
     return html`
@@ -903,7 +910,7 @@ export class CollectionBrowser
       >
         <summary>
           <span class="collapser-icon">${chevronIcon}</span>
-          <h2>Filters</h2>
+          <h2>${msg('Filters')}</h2>
           ${this.clearFiltersBtnTemplate(true)}
         </summary>
         ${this.facetsTemplate}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -903,11 +903,7 @@ export class CollectionBrowser
     };
 
     return html`
-      <details
-        id="mobile-filter-collapse"
-        @click=${toggleFacetsVisible}
-        @keyup=${toggleFacetsVisible}
-      >
+      <details id="mobile-filter-collapse" @toggle=${toggleFacetsVisible}>
         <summary>
           <span class="collapser-icon">${chevronIcon}</span>
           <h2>${msg('Filters')}</h2>

--- a/src/utils/analytics-events.ts
+++ b/src/utils/analytics-events.ts
@@ -14,6 +14,7 @@ export enum analyticsActions {
   facetDeselected = 'facetDeselected',
   facetNegativeSelected = 'facetNegativeSelected',
   facetNegativeDeselected = 'facetNegativeDeselected',
+  mobileFacetsToggled = 'mobileFacetsToggled',
   partOfCollectionClicked = 'partOfCollectionClicked',
   histogramChanged = 'histogramChanged',
   histogramChangedFromModal = 'histogramChangedFromModal',


### PR DESCRIPTION
Adds an analytics event that fires whenever the mobile facets accordion is opened or closed.