### PR TITLE
WEBDEV-6697 Extract session context from search service responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/ia-dropdown": "^1.3.8",
     "@internetarchive/infinite-scroller": "1.0.1",
     "@internetarchive/modal-manager": "^0.2.8",
-    "@internetarchive/search-service": "^1.3.1",
+    "@internetarchive/search-service": "1.3.2-alpha.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/ia-dropdown": "^1.3.8",
     "@internetarchive/infinite-scroller": "1.0.1",
     "@internetarchive/modal-manager": "^0.2.8",
-    "@internetarchive/search-service": "1.3.2-alpha.1",
+    "@internetarchive/search-service": "^1.3.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -4,6 +4,7 @@ import type {
   CollectionExtraInfo,
   AccountExtraInfo,
   PageElementMap,
+  SearchResponseSessionContext,
 } from '@internetarchive/search-service';
 import type { ReactiveController } from 'lit';
 import type {
@@ -98,6 +99,11 @@ export interface CollectionBrowserDataSourceInterface
    * used to populate the profile header.
    */
   readonly accountExtraInfo?: AccountExtraInfo;
+
+  /**
+   * Context about the user session that produced the search response, from the PPS.
+   */
+  readonly sessionContext?: SearchResponseSessionContext;
 
   /**
    * The set of requested page elements for profile pages, if applicable. These represent

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -9,6 +9,7 @@ import {
   FilterMapBuilder,
   PageElementMap,
   SearchParams,
+  SearchResponseSessionContext,
   SearchResult,
   SearchType,
 } from '@internetarchive/search-service';
@@ -115,6 +116,11 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   accountExtraInfo?: AccountExtraInfo;
+
+  /**
+   * @inheritdoc
+   */
+  sessionContext?: SearchResponseSessionContext;
 
   /**
    * @inheritdoc
@@ -1021,6 +1027,7 @@ export class CollectionBrowserDataSource
       this.host.emitEmptyResults();
     }
 
+    this.sessionContext = success.sessionContext;
     if (this.host.withinCollection) {
       this.collectionExtraInfo = success.response.collectionExtraInfo;
 

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -31,6 +31,7 @@ export const getMockSuccessSingleResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -72,6 +73,7 @@ export const getMockSuccessManyFields: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -134,6 +136,7 @@ export const getMockSuccessWithYearHistogramAggs: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -185,6 +188,7 @@ export const getMockSuccessLoggedInResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -228,6 +232,7 @@ export const getMockSuccessNoPreviewResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -269,6 +274,7 @@ export const getMockSuccessLoggedInAndNoPreviewResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -310,6 +316,7 @@ export const getMockSuccessFirstTitleResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -355,6 +362,7 @@ export const getMockSuccessFirstCreatorResult: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -400,6 +408,7 @@ export const getMockSuccessWithCollectionTitles: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 2,
       returnedCount: 2,
@@ -453,6 +462,7 @@ export const getMockSuccessWithCollectionAggregations: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 0,
       returnedCount: 0,
@@ -504,6 +514,7 @@ export const getMockSuccessSingleResultWithSort: (
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -548,6 +559,7 @@ export const getMockSuccessMultipleResults: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 2,
       returnedCount: 2,
@@ -597,6 +609,7 @@ export const getMockSuccessNoResults: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 0,
       returnedCount: 0,
@@ -631,6 +644,7 @@ export const getMockSuccessMultiLineDescription: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -673,6 +687,7 @@ export const getMockSuccessExtraQuotedHref: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -715,6 +730,7 @@ export const getMockSuccessWithDefaultSort: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -761,6 +777,7 @@ export const getMockSuccessWithConciseDefaultSort: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -807,6 +824,7 @@ export const getMockSuccessWithDefaultFavSort: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -853,6 +871,7 @@ export const getMockSuccessWithParentCollections: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,
@@ -899,6 +918,7 @@ export const getMockSuccessWithWebArchiveHits: () => Result<
       },
     },
     rawResponse: {},
+    sessionContext: {},
     response: {
       totalResults: 1,
       returnedCount: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@1.3.2-alpha.1":
-  version "1.3.2-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.2-alpha.1.tgz#135130391e44a9f3c270dc8d15e0e7199784adde"
-  integrity sha512-1pFm407JNY8hnty+eiQL2cvZCYcXI8SyqyhVP1C6PEzUNtuKVy9d4Aao1vVZNlOmcPK0Chm9A13HA1XRC8IA9A==
+"@internetarchive/search-service@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.2.tgz#713b1172ee13b3e3f3c72c85eb37b7c5e27b2b53"
+  integrity sha512-FiGZ13QWreeKZQ9Cpfr2cy2i9t9NRFa7pQMwVA9y+fZZwY/PyoWlPQKQySAmnjv3OKrq1I9LdZUkZ9EP4LNhxw==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,10 +182,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.1.tgz#0f182487b87a2de4fafe37a7f19b8072718b7330"
-  integrity sha512-5erMUPAgGJ2PQaOL8xmG3tmNcaPmi7cI/Ff8IiVDMim1t/fA7V7kDtzej4eQLnCCOl9yRTMyxDWve5y1vZviJQ==
+"@internetarchive/search-service@1.3.2-alpha.1":
+  version "1.3.2-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.2-alpha.1.tgz#135130391e44a9f3c270dc8d15e0e7199784adde"
+  integrity sha512-1pFm407JNY8hnty+eiQL2cvZCYcXI8SyqyhVP1C6PEzUNtuKVy9d4Aao1vVZNlOmcPK0Chm9A13HA1XRC8IA9A==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Responses from the PPS generally include a `session_context` branch containing info about the user session within which the response was generated. Notably, it includes whether the user has privs which should permit them to perform full-text searches even in the absence of public (i.e., not `noindex`) items with searchable text.

This PR adds support for that session context and makes it available in the data source.