### PR TITLE
WEBDEV-6681 Fix offsets when tiles are removed

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1758,7 +1758,7 @@ export class CollectionBrowser
 
   cellForIndex(index: number): TemplateResult | undefined {
     const model = this.tileModelAtCellIndex(index);
-    if (!model) return undefined;
+    if (!model) return this.placeholderCellTemplate;
 
     return html`
       <tile-dispatcher

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -302,8 +302,9 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   getTileModelAt(index: number): TileModel | undefined {
-    const pageNum = Math.floor(index / this.pageSize) + 1;
-    const indexOnPage = index % this.pageSize;
+    const offsetIndex = index + this.offset;
+    const pageNum = Math.floor(offsetIndex / this.pageSize) + 1;
+    const indexOnPage = offsetIndex % this.pageSize;
     return this.pages[pageNum]?.[indexOnPage];
   }
 
@@ -311,7 +312,7 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   indexOf(tile: TileModel): number {
-    return Object.values(this.pages).flat().indexOf(tile);
+    return Object.values(this.pages).flat().indexOf(tile) - this.offset;
   }
 
   /**
@@ -455,6 +456,7 @@ export class CollectionBrowserDataSource
     // Swap in the new pages
     this.pages = newPages;
     this.numTileModels -= numChecked;
+    this.host.setTileCount(this.size);
     this.requestHostUpdate();
     this.refreshVisibleResults();
   };

--- a/src/manage/manage-bar.ts
+++ b/src/manage/manage-bar.ts
@@ -129,6 +129,7 @@ export class ManageBar extends LitElement {
         appearance: none;
         background: none;
         color: var(--ia-theme-link-color, #4b64ff);
+        font: inherit;
         text-decoration: none;
         cursor: pointer;
       }


### PR DESCRIPTION
When tiles are removed from view (e.g., by removing one's own uploads/favorites), the data source updates its tile offset accordingly to keep data pages aligned. This PR fixes a couple of bugs in data source methods that did not take the offset into account when converting b/w tile models & indices.