### PR TITLE
WEBDEV-6738 Propagate profile params to more-facets component

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -932,9 +932,7 @@ export class CollectionBrowser
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
         .collectionPagePath=${this.collectionPagePath}
         .parentCollections=${this.dataSource.parentCollections}
-        .withinCollection=${this.withinCollection}
-        .withinProfile=${this.withinProfile}
-        .profileElement=${this.profileElement}
+        .pageSpecifierParams=${this.dataSource.pageSpecifierParams}
         .searchService=${this.searchService}
         .featureFeedbackService=${this.featureFeedbackService}
         .recaptchaManager=${this.recaptchaManager}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -933,6 +933,8 @@ export class CollectionBrowser
         .collectionPagePath=${this.collectionPagePath}
         .parentCollections=${this.dataSource.parentCollections}
         .withinCollection=${this.withinCollection}
+        .withinProfile=${this.withinProfile}
+        .profileElement=${this.profileElement}
         .searchService=${this.searchService}
         .featureFeedbackService=${this.featureFeedbackService}
         .recaptchaManager=${this.recaptchaManager}

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -30,6 +30,7 @@ import type { FeatureFeedbackServiceInterface } from '@internetarchive/feature-f
 import type { RecaptchaManagerInterface } from '@internetarchive/recaptcha-manager';
 import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
 import type { SharedResizeObserverInterface } from '@internetarchive/shared-resize-observer';
+import type { PageElementName } from '@internetarchive/search-service';
 import chevronIcon from './assets/img/icons/chevron';
 import expandIcon from './assets/img/icons/expand';
 import {
@@ -90,6 +91,10 @@ export class CollectionFacets extends LitElement {
   @property({ type: String }) query?: string;
 
   @property({ type: String }) withinCollection?: string;
+
+  @property({ type: String }) withinProfile?: string;
+
+  @property({ type: String }) profileElement?: PageElementName;
 
   @property({ type: Array }) parentCollections: string[] = [];
 
@@ -646,6 +651,8 @@ export class CollectionFacets extends LitElement {
         .query=${this.query}
         .filterMap=${this.filterMap}
         .withinCollection=${this.withinCollection}
+        .withinProfile=${this.withinProfile}
+        .profileElement=${this.profileElement}
         .modalManager=${this.modalManager}
         .searchService=${this.searchService}
         .searchType=${this.searchType}

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -30,7 +30,6 @@ import type { FeatureFeedbackServiceInterface } from '@internetarchive/feature-f
 import type { RecaptchaManagerInterface } from '@internetarchive/recaptcha-manager';
 import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
 import type { SharedResizeObserverInterface } from '@internetarchive/shared-resize-observer';
-import type { PageElementName } from '@internetarchive/search-service';
 import chevronIcon from './assets/img/icons/chevron';
 import expandIcon from './assets/img/icons/expand';
 import {
@@ -46,7 +45,10 @@ import {
   suppressedCollections,
   defaultFacetSort,
 } from './models';
-import type { CollectionTitles } from './data-source/models';
+import type {
+  CollectionTitles,
+  PageSpecifierParams,
+} from './data-source/models';
 import './collection-facets/more-facets-content';
 import './collection-facets/facets-template';
 import './collection-facets/facet-tombstone-row';
@@ -90,11 +92,7 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: String }) query?: string;
 
-  @property({ type: String }) withinCollection?: string;
-
-  @property({ type: String }) withinProfile?: string;
-
-  @property({ type: String }) profileElement?: PageElementName;
+  @property({ type: Object }) pageSpecifierParams?: PageSpecifierParams;
 
   @property({ type: Array }) parentCollections: string[] = [];
 
@@ -170,8 +168,7 @@ export class CollectionFacets extends LitElement {
 
   private get collectionPartOfTemplate(): TemplateResult | typeof nothing {
     // We only display the "Part Of" section on collection pages
-    if (!this.withinCollection || this.parentCollections.length === 0)
-      return nothing;
+    if (!this.parentCollections?.length) return nothing;
 
     const headingId = 'partof-heading';
     return html`
@@ -650,9 +647,7 @@ export class CollectionFacets extends LitElement {
         .facetAggregationKey=${facetAggrKey}
         .query=${this.query}
         .filterMap=${this.filterMap}
-        .withinCollection=${this.withinCollection}
-        .withinProfile=${this.withinProfile}
-        .profileElement=${this.profileElement}
+        .pageSpecifierParams=${this.pageSpecifierParams}
         .modalManager=${this.modalManager}
         .searchService=${this.searchService}
         .searchType=${this.searchType}

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -18,6 +18,7 @@ import {
   SearchType,
   AggregationSortType,
   FilterMap,
+  PageType,
 } from '@internetarchive/search-service';
 import type { ModalManagerInterface } from '@internetarchive/modal-manager';
 import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manager';
@@ -103,6 +104,7 @@ export class MoreFacetsContent extends LitElement {
     ) {
       this.facetsLoading = true;
       this.pageNumber = 1;
+      this.sortedBy = defaultFacetSort[this.facetKey as FacetOption];
 
       this.updateSpecificFacets();
     }
@@ -135,9 +137,10 @@ export class MoreFacetsContent extends LitElement {
    * Whether facet requests are for the search_results page type (either defaulted or explicitly).
    */
   private get isSearchResultsPage(): boolean {
-    return [undefined, 'search_results'].includes(
-      this.pageSpecifierParams?.pageType
-    );
+    // Default page type is search_results when none is specified, so we check
+    // for undefined as well.
+    const pageType: PageType | undefined = this.pageSpecifierParams?.pageType;
+    return pageType === undefined || pageType === 'search_results';
   }
 
   /**
@@ -395,7 +398,8 @@ export class MoreFacetsContent extends LitElement {
   }
 
   private get getModalHeaderTemplate(): TemplateResult {
-    const facetSort = defaultFacetSort[this.facetKey as FacetOption];
+    const facetSort =
+      this.sortedBy ?? defaultFacetSort[this.facetKey as FacetOption];
     const defaultSwitchSide =
       facetSort === AggregationSortType.COUNT ? 'left' : 'right';
 

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1099,7 +1099,7 @@ export class CollectionBrowserDataSource
     // When we reach the end of the data, we can set the infinite scroller's
     // item count to the real total number of results (rather than the
     // temporary estimates based on pages rendered so far).
-    if (results.length === 0) {
+    if (this.size >= this.totalResults || results.length === 0) {
       this.endOfDataReached = true;
       if (this.activeOnHost) this.host.setTileCount(this.size);
     }

--- a/test/collection-facets.test.ts
+++ b/test/collection-facets.test.ts
@@ -808,12 +808,10 @@ describe('Collection Facets', () => {
     expect(partOfLinks?.[1]?.getAttribute('href')).to.equal('/details/baz');
   });
 
-  it('does not include Part Of section outside of collections', async () => {
-    // No withinCollection prop
+  it('does not include Part Of section without parent collections', async () => {
+    // No parentCollections prop
     const el = await fixture<CollectionFacets>(
-      html`<collection-facets
-        .parentCollections=${['bar', 'baz']}
-      ></collection-facets>`
+      html`<collection-facets .withinCollection=${'foo'}></collection-facets>`
     );
 
     const partOfSection = el.shadowRoot?.querySelector('.partof-collections');

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -94,7 +94,10 @@ describe('More facets content', () => {
     const el = await fixture<MoreFacetsContent>(
       html`<more-facets-content
         .searchService=${searchService}
-        .withinCollection=${'foobar'}
+        .pageSpecifierParams=${{
+          pageType: 'collection_details',
+          pageTarget: 'foobar',
+        }}
       ></more-facets-content>`
     );
 
@@ -111,7 +114,10 @@ describe('More facets content', () => {
     const el = await fixture<MoreFacetsContent>(
       html`<more-facets-content
         .searchService=${searchService}
-        .withinCollection=${'foobar'}
+        .pageSpecifierParams=${{
+          pageType: 'collection_details',
+          pageTarget: 'foobar',
+        }}
       ></more-facets-content>`
     );
 


### PR DESCRIPTION
Ensures that profile-related params are propagated all the way through to the `<more-facets-content>` component to be used when fetching full facet lists.