### PR TITLE
WEBDEV-6646 Ensure sort bar's resize observer is reinstalled after reconnected

### DIFF
--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -255,6 +255,11 @@ export class SortFilterBar
     }
   };
 
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    this.setupResizeObserver();
+  }
+
   disconnectedCallback(): void {
     if (this.resizeObserver) {
       this.disconnectResizeObserver(this.resizeObserver);


### PR DESCRIPTION
Fixes a bug where changing tabs on the profile page causes the sort bar to lose its resize behavior (i.e., it thereafter fails to switch between mobile/desktop layouts when resizing).