### PR TITLE
WEBDEV-6753 Allow facets to be lazy-loaded on demand in mobile view

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -42,6 +42,10 @@ export class AppRoot extends LitElement {
 
   @state() private colGap: number = 1.7;
 
+  @state() private suppressFacets: boolean = false;
+
+  @state() private lazyLoadFacets: boolean = false;
+
   @state() private loggedIn: boolean = false;
 
   @state() private searchType: SearchType = SearchType.METADATA;
@@ -306,6 +310,15 @@ export class AppRoot extends LitElement {
               />
               <label for="enable-facets">Enable facets</label>
             </div>
+            <div class="checkbox-control indent">
+              <input
+                type="checkbox"
+                id="lazy-load-facets"
+                ?disabled=${this.suppressFacets}
+                @click=${this.lazyLoadFacetsChanged}
+              />
+              <label for="lazy-load-facets">Lazy load facets</label>
+            </div>
             <div class="checkbox-control">
               <input
                 type="checkbox"
@@ -450,6 +463,8 @@ export class AppRoot extends LitElement {
           .searchService=${this.searchService}
           .resizeObserver=${this.resizeObserver}
           .showHistogramDatePicker=${true}
+          .suppressFacets=${this.suppressFacets}
+          .lazyLoadFacets=${this.lazyLoadFacets}
           .loggedIn=${this.loggedIn}
           .modalManager=${this.modalManager}
           .analyticsHandler=${this.analyticsHandler}
@@ -651,7 +666,12 @@ export class AppRoot extends LitElement {
 
   private facetsChanged(e: Event) {
     const target = e.target as HTMLInputElement;
-    this.collectionBrowser.suppressFacets = !target.checked;
+    this.suppressFacets = !target.checked;
+  }
+
+  private lazyLoadFacetsChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.lazyLoadFacets = target.checked;
   }
 
   /**
@@ -1015,6 +1035,9 @@ export class AppRoot extends LitElement {
 
     .checkbox-control {
       flex-basis: 50%;
+    }
+    .checkbox-control.indent {
+      margin-left: 10px;
     }
     .checkbox-control label {
       user-select: none;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1098,6 +1098,13 @@ export class CollectionBrowser
 
   firstUpdated(): void {
     this.restoreState();
+    this.setInitialSize();
+  }
+
+  setInitialSize(): void {
+    this.contentWidth = this.contentContainer.getBoundingClientRect().width;
+    this.mobileView =
+      this.contentWidth > 0 && this.contentWidth < this.mobileBreakpoint;
   }
 
   updated(changed: PropertyValues) {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -170,7 +170,7 @@ export class CollectionBrowser
   @property({ type: Boolean }) suppressURLQuery = false;
 
   /**
-   * Whether to suppress the display of facets.
+   * Whether to suppress the display of facets entirely.
    * If true, the facet sidebar content will be replaced by a message that facets are
    * temporarily unavailable.
    */
@@ -187,6 +187,14 @@ export class CollectionBrowser
    * If true, those options will be omitted (though the rest of the sort bar may still render).
    */
   @property({ type: Boolean }) suppressDisplayModes = false;
+
+  /**
+   * Whether facets should be lazy-loaded.
+   * If false (default), facet data will be loaded eagerly along with search hits.
+   * If true, facet data will only be requested once the facet pane actually becomes visible,
+   * either by displaying in desktop mode or by the mobile facet dropdown being opened.
+   */
+  @property({ type: Boolean }) lazyLoadFacets = false;
 
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 
@@ -1160,13 +1168,6 @@ export class CollectionBrowser
       this.persistState();
     }
 
-    // Facets are always visible in the desktop view.
-    // But in the mobile view, their visibility state can be toggled by the user.
-    // In either case, inform the data source so that it can determine whether/when to fetch facets.
-    this.dataSource.handleFacetVisibilityChange(
-      !this.mobileView || this.mobileFacetsVisible
-    );
-
     if (
       changed.has('baseQuery') ||
       changed.has('minSelectedDate') ||
@@ -1196,6 +1197,13 @@ export class CollectionBrowser
         changed.get('selectedCreatorFilter') as string
       );
     }
+
+    // Facets are always visible in the desktop view.
+    // But in the mobile view, their visibility state can be toggled by the user.
+    // In either case, inform the data source so that it can determine whether/when to fetch facets.
+    this.dataSource.handleFacetVisibilityChange(
+      !this.mobileView || this.mobileFacetsVisible
+    );
 
     if (
       changed.has('baseQuery') ||

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1160,14 +1160,12 @@ export class CollectionBrowser
       this.persistState();
     }
 
-    if (changed.has('mobileView') || changed.has('mobileFacetsVisible')) {
-      // Facets are always visible in the desktop view.
-      // But in the mobile view, their visibility state can be toggled by the user.
-      // In either case, inform the data source so that it can determine whether/when to fetch facets.
-      this.dataSource.handleFacetVisibilityChange(
-        !this.mobileView || this.mobileFacetsVisible
-      );
-    }
+    // Facets are always visible in the desktop view.
+    // But in the mobile view, their visibility state can be toggled by the user.
+    // In either case, inform the data source so that it can determine whether/when to fetch facets.
+    this.dataSource.handleFacetVisibilityChange(
+      !this.mobileView || this.mobileFacetsVisible
+    );
 
     if (
       changed.has('baseQuery') ||

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1160,6 +1160,15 @@ export class CollectionBrowser
       this.persistState();
     }
 
+    if (changed.has('mobileView') || changed.has('mobileFacetsVisible')) {
+      // Facets are always visible in the desktop view.
+      // But in the mobile view, their visibility state can be toggled by the user.
+      // In either case, inform the data source so that it can determine whether/when to fetch facets.
+      this.dataSource.handleFacetVisibilityChange(
+        !this.mobileView || this.mobileFacetsVisible
+      );
+    }
+
     if (
       changed.has('baseQuery') ||
       changed.has('minSelectedDate') ||

--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -266,7 +266,13 @@ export interface CollectionBrowserDataSourceInterface
    * Notifies the data source that a query change has occurred, which may trigger a data
    * reset & new fetches.
    */
-  handleQueryChange(): void;
+  handleQueryChange(): Promise<void>;
+
+  /**
+   * Notifies the data source that the visibility of the facets has been changed, which
+   * may trigger facet fetches if they were previously delayed.
+   */
+  handleFacetVisibilityChange(visible: boolean): Promise<void>;
 
   /**
    * Applies the given map function to all of the tile models in every page of the data

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -375,6 +375,7 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   async handleQueryChange(): Promise<void> {
+    console.log('in handleQueryChange');
     // Don't react to the change if fetches are suppressed for this data source
     if (this.suppressFetches) return;
 
@@ -386,6 +387,7 @@ export class CollectionBrowserDataSource
     });
 
     // Fire the initial page & facet requests
+    console.log('handling query change:', this.shouldFetchFacets);
     this.queryInitialized = true;
     await Promise.all([
       this.doInitialPageFetch(),
@@ -400,6 +402,12 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   async handleFacetVisibilityChange(visible: boolean): Promise<void> {
+    console.log(
+      'handling facet visibility change:',
+      this.facetsVisible,
+      '->',
+      visible
+    );
     const facetsBecameVisible = !this.facetsVisible && visible;
     this.facetsVisible = visible;
 
@@ -422,7 +430,8 @@ export class CollectionBrowserDataSource
     if (!this.facetsVisible) return false;
 
     // Don't fetch facets again if they are already fetched or pending
-    if (this.facetsLoading || !!this.aggregations) return false;
+    if (this.facetsLoading || Object.keys(this.aggregations ?? {}).length > 0)
+      return false;
 
     return true;
   }
@@ -901,6 +910,7 @@ export class CollectionBrowserDataSource
    * the current search state.
    */
   private async fetchFacets(): Promise<void> {
+    console.log('called fetchFacets');
     const trimmedQuery = this.host.baseQuery?.trim();
     if (!this.canPerformSearch) return;
 
@@ -908,6 +918,7 @@ export class CollectionBrowserDataSource
     if (this.fetchesInProgress.has(facetFetchQueryKey)) return;
     this.fetchesInProgress.add(facetFetchQueryKey);
 
+    console.log('setting facets loading');
     this.setFacetsLoading(true);
 
     const sortParams = this.host.sortParam ? [this.host.sortParam] : [];

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -376,7 +376,6 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   async handleQueryChange(): Promise<void> {
-    console.log('in handleQueryChange');
     // Don't react to the change if fetches are suppressed for this data source
     if (this.suppressFetches) return;
 
@@ -388,7 +387,6 @@ export class CollectionBrowserDataSource
     });
 
     // Fire the initial page & facet requests
-    console.log('handling query change:', this.canFetchFacets);
     this.queryInitialized = true;
     await Promise.all([
       this.doInitialPageFetch(),
@@ -403,12 +401,6 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   async handleFacetVisibilityChange(visible: boolean): Promise<void> {
-    console.log(
-      'handling facet visibility change:',
-      this.facetsVisible,
-      '->',
-      visible
-    );
     const facetsBecameVisible = !this.facetsVisible && visible;
     this.facetsVisible = visible;
 
@@ -915,7 +907,6 @@ export class CollectionBrowserDataSource
    * the current search state.
    */
   private async fetchFacets(): Promise<void> {
-    console.log('called fetchFacets');
     const trimmedQuery = this.host.baseQuery?.trim();
     if (!this.canPerformSearch) return;
 
@@ -923,7 +914,6 @@ export class CollectionBrowserDataSource
     if (this.fetchesInProgress.has(facetFetchQueryKey)) return;
     this.fetchesInProgress.add(facetFetchQueryKey);
 
-    console.log('setting facets loading');
     this.setFacetsLoading(true);
 
     const sortParams = this.host.sortParam ? [this.host.sortParam] : [];

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -37,6 +37,7 @@ export interface CollectionBrowserSearchInterface
   readonly sortParam: SortParam | null;
   readonly defaultSortParam: SortParam | null;
   readonly suppressFacets?: boolean;
+  readonly lazyLoadFacets?: boolean;
   readonly initialPageNumber: number;
   readonly currentVisiblePageNumbers: number[];
   readonly clearResultsOnEmptyQuery?: boolean;


### PR DESCRIPTION
Adds a bit of logic to the data source so that facets can be lazy-loaded when they are actually needed, avoiding expensive facet requests in cases where they are not (i.e., the majority of visits).