### PR TITLE
WEBDEV-6756 Update total result count when checked tiles are removed

### DIFF
--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -475,6 +475,7 @@ export class CollectionBrowserDataSource
     this.pages = newPages;
     this.numTileModels -= numChecked;
     this.host.setTileCount(this.size);
+    this.host.setTotalResultCount(this.totalResults - numChecked);
     this.requestHostUpdate();
     this.refreshVisibleResults();
   };

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -474,8 +474,9 @@ export class CollectionBrowserDataSource
     // Swap in the new pages
     this.pages = newPages;
     this.numTileModels -= numChecked;
+    this.totalResults -= numChecked;
     this.host.setTileCount(this.size);
-    this.host.setTotalResultCount(this.totalResults - numChecked);
+    this.host.setTotalResultCount(this.totalResults);
     this.requestHostUpdate();
     this.refreshVisibleResults();
   };


### PR DESCRIPTION
When removing checked tiles via collection-browser's management UI, currently the total result count next to the facets does not change. This PR fixes that bug to ensure the total result count reflects the removals immediately.