### PR TITLE
Prevent page number from incrementing early on very tall screens

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1451,8 +1451,13 @@ export class CollectionBrowser
     if (this.isScrollingToCell) return;
     const { visibleCellIndices } = e.detail;
     if (visibleCellIndices.length === 0) return;
-    const lastVisibleCellIndex =
-      visibleCellIndices[visibleCellIndices.length - 1];
+
+    // For page determination, do not count more than a single page of visible cells,
+    // since otherwise patrons using very tall screens will be treated as one page
+    // further than they actually are.
+    const lastIndexWithinCurrentPage =
+      Math.min(this.pageSize, visibleCellIndices.length) - 1;
+    const lastVisibleCellIndex = visibleCellIndices[lastIndexWithinCurrentPage];
     const lastVisibleCellPage =
       Math.floor(lastVisibleCellIndex / this.pageSize) + 1;
     if (this.currentPage !== lastVisibleCellPage) {


### PR DESCRIPTION
Currently if a visitor is using a tall/vertical screen that is capable of showing more than a single page of results at once, they will erroneously have a `page` param added to the URL that is one page ahead of their actual position. Most egregiously, this causes a `page=2` param to appear when they are at the top of the page, before scrolling at all.

This PR ensures that the current page indicated in the URL is never more than one page beyond that of the first visible cell.