### PR TITLE
WEBDEV-6853 Opt-in facet loading for desktop view

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -197,7 +197,7 @@ export class CollectionBrowser
    *
    * To entirely suppress facets from being loaded, this may be set to `off`.
    */
-  @property({ type: String }) facetLoadStrategy: FacetLoadStrategy = 'opt-in';
+  @property({ type: String }) facetLoadStrategy: FacetLoadStrategy = 'eager';
 
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 
@@ -941,24 +941,8 @@ export class CollectionBrowser
         </p>
       `;
     }
-    if (
-      this.facetLoadStrategy === 'opt-in' &&
-      !this.mobileView &&
-      !this.facetsOptedIn
-    ) {
-      return html`
-        <button
-          class="load-facets-btn"
-          @click=${() => {
-            this.facetsOptedIn = true;
-          }}
-        >
-          ${msg('Load facets')}
-        </button>
-      `;
-    }
 
-    return html`
+    const facets = html`
       <collection-facets
         @facetsChanged=${this.facetsChanged}
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
@@ -993,6 +977,27 @@ export class CollectionBrowser
       >
       </collection-facets>
     `;
+
+    // In the desktop facets opt-in case, wrap the facet sidebar in a <details> widget
+    // that can be opened and closed as needed.
+    if (this.facetLoadStrategy === 'opt-in' && !this.mobileView) {
+      return html`
+        <details
+          class="desktop-facets-dropdown"
+          @toggle=${() => {
+            this.facetsOptedIn = true;
+          }}
+        >
+          <summary>
+            <span class="collapser-icon">${chevronIcon}</span>
+            <h2>${msg('Filters')}</h2>
+          </summary>
+          ${facets}
+        </button>
+      `;
+    }
+    // Otherwise, just render the facets component bare
+    return facets;
   }
 
   /**
@@ -2048,6 +2053,25 @@ export class CollectionBrowser
           font-size: 1.4rem;
         }
 
+        .desktop-facets-dropdown > summary {
+          cursor: pointer;
+          list-style: none;
+        }
+
+        .desktop-facets-dropdown h2 {
+          display: inline-block;
+          margin: 0;
+          font-size: 1.6rem;
+        }
+
+        .desktop-facets-dropdown[open] > summary {
+          margin-bottom: 10px;
+        }
+
+        .desktop-facets-dropdown[open] svg {
+          transform: rotate(90deg);
+        }
+
         .desktop #left-column-scroll-sentinel {
           width: 1px;
           height: 100vh;
@@ -2085,8 +2109,7 @@ export class CollectionBrowser
           width: 100%;
         }
 
-        .clear-filters-btn,
-        .load-facets-btn {
+        .clear-filters-btn {
           display: inline-block;
           appearance: none;
           margin: 0;
@@ -2099,8 +2122,7 @@ export class CollectionBrowser
           cursor: pointer;
         }
 
-        .clear-filters-btn:hover,
-        .load-facets-btn:hover {
+        .clear-filters-btn:hover {
           text-decoration: underline;
         }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -197,7 +197,7 @@ export class CollectionBrowser
    *
    * To entirely suppress facets from being loaded, this may be set to `off`.
    */
-  @property({ type: String }) facetLoadStrategy: FacetLoadStrategy = 'eager';
+  @property({ type: String }) facetLoadStrategy: FacetLoadStrategy = 'opt-in';
 
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 
@@ -941,10 +941,14 @@ export class CollectionBrowser
         </p>
       `;
     }
-    if (this.facetLoadStrategy === 'opt-in' && !this.facetsOptedIn) {
+    if (
+      this.facetLoadStrategy === 'opt-in' &&
+      !this.mobileView &&
+      !this.facetsOptedIn
+    ) {
       return html`
         <button
-          class="facets-opt-in"
+          class="load-facets-btn"
           @click=${() => {
             this.facetsOptedIn = true;
           }}
@@ -2081,7 +2085,8 @@ export class CollectionBrowser
           width: 100%;
         }
 
-        .clear-filters-btn {
+        .clear-filters-btn,
+        .load-facets-btn {
           display: inline-block;
           appearance: none;
           margin: 0;
@@ -2094,7 +2099,8 @@ export class CollectionBrowser
           cursor: pointer;
         }
 
-        .clear-filters-btn:hover {
+        .clear-filters-btn:hover,
+        .load-facets-btn:hover {
           text-decoration: underline;
         }
 

--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -269,10 +269,10 @@ export interface CollectionBrowserDataSourceInterface
   handleQueryChange(): Promise<void>;
 
   /**
-   * Notifies the data source that the visibility of the facets has been changed, which
+   * Notifies the data source that the readiness state of the facets has been changed, which
    * may trigger facet fetches if they were previously delayed.
    */
-  handleFacetVisibilityChange(visible: boolean): Promise<void>;
+  handleFacetReadinessChange(ready: boolean): Promise<void>;
 
   /**
    * Applies the given map function to all of the tile models in every page of the data

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -76,7 +76,7 @@ export class CollectionBrowserDataSource
    * Whether the facets are actually visible -- if not, then we can delay any facet
    * fetches until they become visible.
    */
-  private facetsVisible = false;
+  private facetsReady = false;
 
   /**
    * Whether further query changes should be ignored and not trigger fetches
@@ -400,12 +400,15 @@ export class CollectionBrowserDataSource
   /**
    * @inheritdoc
    */
-  async handleFacetVisibilityChange(visible: boolean): Promise<void> {
-    const facetsBecameVisible = !this.facetsVisible && visible;
-    this.facetsVisible = visible;
+  async handleFacetReadinessChange(ready: boolean): Promise<void> {
+    const facetsBecameReady = !this.facetsReady && ready;
+    this.facetsReady = ready;
 
+    const lazyLoadFacets = ['lazy-mobile', 'opt-in'].includes(
+      this.host.facetLoadStrategy
+    );
     const needsFetch =
-      this.host.lazyLoadFacets && facetsBecameVisible && this.canFetchFacets;
+      lazyLoadFacets && facetsBecameReady && this.canFetchFacets;
     if (needsFetch) {
       this.fetchFacets();
     }
@@ -417,13 +420,14 @@ export class CollectionBrowserDataSource
    */
   private get canFetchFacets(): boolean {
     // Don't fetch facets if they are suppressed entirely or not required for the current profile page element
-    if (this.host.suppressFacets) return false;
+    if (this.host.facetLoadStrategy === 'off') return false;
     if (FACETLESS_PAGE_ELEMENTS.includes(this.host.profileElement!))
       return false;
 
     // If facets are to be lazy-loaded, don't fetch them if they are not going to be visible anyway
     // (wait until they become visible instead)
-    if (this.host.lazyLoadFacets && !this.facetsVisible) return false;
+    if (this.host.facetLoadStrategy !== 'eager' && !this.facetsReady)
+      return false;
 
     // Don't fetch facets again if they are already fetched or pending
     const facetsAlreadyFetched =

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -6,7 +6,7 @@ import type {
   SortDirection,
   SortParam,
 } from '@internetarchive/search-service';
-import type { SelectedFacets, SortField } from '../models';
+import type { FacetLoadStrategy, SelectedFacets, SortField } from '../models';
 import type { CollectionBrowserDataSourceInterface } from './collection-browser-data-source-interface';
 
 /**
@@ -36,8 +36,7 @@ export interface CollectionBrowserSearchInterface
   searchService?: SearchServiceInterface;
   readonly sortParam: SortParam | null;
   readonly defaultSortParam: SortParam | null;
-  readonly suppressFacets?: boolean;
-  readonly lazyLoadFacets?: boolean;
+  readonly facetLoadStrategy: FacetLoadStrategy;
   readonly initialPageNumber: number;
   readonly currentVisiblePageNumbers: number[];
   readonly clearResultsOnEmptyQuery?: boolean;

--- a/src/models.ts
+++ b/src/models.ts
@@ -463,6 +463,18 @@ export const prefixFilterAggregationKeys: Record<PrefixFilterType, string> = {
 };
 
 /**
+ * Different facet loading strategies that can be used with collection browser.
+ *  - `eager`: Facet data is always loaded as soon as a search is performed
+ *  - `lazy-mobile`: In the desktop layout, functions exactly as `eager`.
+ *     In the mobile layout, facet data will only be loaded once the "Filters" accordion is opened.
+ *  - `opt-in`: In the desktop layout, facet data will only be loaded after the user presses a "Load Facets" button.
+ *     In the mobile layout, functions exactly as `lazy-mobile`.
+ *  - `off`: Facet data will never be loaded, and a message will be displayed in place of facets
+ *     indicating that they are unavailable.
+ */
+export type FacetLoadStrategy = 'eager' | 'lazy-mobile' | 'opt-in' | 'off';
+
+/**
  * Union of the facet types that are available in the sidebar.
  */
 export type FacetOption =


### PR DESCRIPTION
Consolidates the `suppressFacets` and `lazyLoadFacets` options into a single property for adjusting the facet loading strategy, adding an additional option to display opt-in style facets in desktop view as well. This new option delays the facet load until patrons open a disclosure widget, much like in the current mobile behavior. The intent is for this new option to be used when it is necessary to reduce facet load on the backend temporarily.