### PR TITLE
WEBDEV-6909 Ensure radio searches are properly read/written to URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/ia-dropdown": "^1.3.8",
     "@internetarchive/infinite-scroller": "1.0.1",
     "@internetarchive/modal-manager": "^0.2.8",
-    "@internetarchive/search-service": "1.3.3-alpha.0",
+    "@internetarchive/search-service": "^1.4.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/ia-dropdown": "^1.3.8",
     "@internetarchive/infinite-scroller": "1.0.1",
     "@internetarchive/modal-manager": "^0.2.8",
-    "@internetarchive/search-service": "^1.3.2",
+    "@internetarchive/search-service": "1.3.3-alpha.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
     "dompurify": "^2.3.6",

--- a/src/models.ts
+++ b/src/models.ts
@@ -127,7 +127,7 @@ export class TileModel {
     this.href = collapseRepeatedQuotes(
       result.review?.__href__ ?? result.__href__?.value
     );
-    this.identifier = result.identifier;
+    this.identifier = TileModel.cleanIdentifier(result.identifier);
     this.issue = result.issue?.value;
     this.itemCount = result.item_count?.value ?? 0;
     this.mediatype = resolveMediatype(result);
@@ -209,6 +209,17 @@ export class TileModel {
     }
 
     return flags;
+  }
+
+  private static cleanIdentifier(
+    identifier: string | undefined
+  ): string | undefined {
+    // Some identifiers (e.g., from Whisper) represent documents rather than items, and
+    // are suffixed with values that need to be stripped. Those values are separated
+    // from the item identifier itself with '|'.
+    const barIndex = identifier?.indexOf('|') ?? -1;
+    const cleaned = barIndex > 0 ? identifier?.slice(0, barIndex) : identifier;
+    return cleaned;
   }
 }
 

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -101,6 +101,8 @@ export class RestorationStateHandler
 
     if (state.searchType === SearchType.FULLTEXT) {
       newParams.set('sin', 'TXT');
+    } else if (state.searchType === SearchType.RADIO) {
+      newParams.set('sin', 'RADIO');
     }
     if (oldParams.get('sin') === '') {
       // Treat empty sin the same as no sin at all
@@ -263,6 +265,9 @@ export class RestorationStateHandler
       // Eventually there will be TV/Radio search types here too.
       case 'TXT':
         restorationState.searchType = SearchType.FULLTEXT;
+        break;
+      case 'RADIO':
+        restorationState.searchType = SearchType.RADIO;
         break;
       default:
         restorationState.searchType = SearchType.METADATA;

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,10 +211,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.2.tgz#713b1172ee13b3e3f3c72c85eb37b7c5e27b2b53"
-  integrity sha512-FiGZ13QWreeKZQ9Cpfr2cy2i9t9NRFa7pQMwVA9y+fZZwY/PyoWlPQKQySAmnjv3OKrq1I9LdZUkZ9EP4LNhxw==
+"@internetarchive/search-service@1.3.3-alpha.0":
+  version "1.3.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.3-alpha.0.tgz#9fcc252e4f6b500d9e267ce7d66bfd8288bf8df7"
+  integrity sha512-K+KREoXAwES9gHqYdUdc3S49jINFwxtG72lVDDUn8G5q/qZk6CI3Fy6PcoxaJ+8rY03s4bC6IAFvsAW96+Opzg==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,10 +211,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@1.3.3-alpha.1":
-  version "1.3.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.3-alpha.1.tgz#966ac0ec307ed67824f48691adcd52a7c71e0fc8"
-  integrity sha512-idSD1Qf5zZwEytwI3auwyGm6erUeiMZBUruMeaNQKQlA1WUqmnWcCuVXU93Tckh2mkqqphu4J3XJIXPCTEzVgQ==
+"@internetarchive/search-service@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.4.0.tgz#e8fea0609eaf832b3fcdb02acb21e1a6c79bf028"
+  integrity sha512-6+GH5NbDLE1v+JfY5Ryo1GnsTUbpkbX/B0NCkoB25iYQZA82AbiNEyb6M6X332/5mUDRTGx6HKi+74CcJpDVEw==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,10 +211,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@1.3.3-alpha.0":
-  version "1.3.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.3-alpha.0.tgz#9fcc252e4f6b500d9e267ce7d66bfd8288bf8df7"
-  integrity sha512-K+KREoXAwES9gHqYdUdc3S49jINFwxtG72lVDDUn8G5q/qZk6CI3Fy6PcoxaJ+8rY03s4bC6IAFvsAW96+Opzg==
+"@internetarchive/search-service@1.3.3-alpha.1":
+  version "1.3.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.3-alpha.1.tgz#966ac0ec307ed67824f48691adcd52a7c71e0fc8"
+  integrity sha512-idSD1Qf5zZwEytwI3auwyGm6erUeiMZBUruMeaNQKQlA1WUqmnWcCuVXU93Tckh2mkqqphu4J3XJIXPCTEzVgQ==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Adds support in the restoration state handler for `sin=RADIO` being read from/written to the URL. This is to support radio searches being performed entirely within Offshoot rather than redirecting away to a legacy page.