### PR TITLE
WEBDEV-6333 Don't move facets around when clicked in More... dialog

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -504,6 +504,14 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Determines what type of placeholder content should be shown instead of result tiles, if applicable.
+   * The placeholders indicate states where we have no results to show, which could be the result of:
+   *  - No query is set (on the search page)
+   *  - No results were returned for the most recent search
+   *  - The collection being searched within has no viewable items
+   *  - An error occurred on the most recent search attempt
+   */
   private setPlaceholderType() {
     const hasQuery = !!this.baseQuery?.trim();
     const isCollection = !!this.withinCollection;
@@ -530,6 +538,9 @@ export class CollectionBrowser
     }
   }
 
+  /**
+   * Template for the placeholder content to show when no results are available.
+   */
   private get emptyPlaceholderTemplate() {
     return html`
       <empty-placeholder
@@ -656,6 +667,9 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for the infinite scroller widget that contains the result tiles.
+   */
   private get infiniteScrollerTemplate() {
     return html`<infinite-scroller
       class=${this.infiniteScrollerClasses}
@@ -671,6 +685,10 @@ export class CollectionBrowser
     </infinite-scroller>`;
   }
 
+  /**
+   * Produces a `classMap` indicating which classes the infinite scroller should have
+   * given the current display mode & placeholder case.
+   */
   private get infiniteScrollerClasses() {
     return classMap({
       [this.displayMode ?? '']: !!this.displayMode,
@@ -678,6 +696,9 @@ export class CollectionBrowser
     });
   }
 
+  /**
+   * Template for the sort & filtering bar that appears atop the search results.
+   */
   private get sortFilterBarTemplate(): TemplateResult | typeof nothing {
     if (this.suppressSortBar) return nothing;
 
@@ -708,6 +729,10 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Template for the manage bar UI that appears atop the search results when we are
+   * showing the management view. This generally replaces the sort bar when present.
+   */
   private get manageBarTemplate(): TemplateResult {
     return html`
       <manage-bar
@@ -752,6 +777,9 @@ export class CollectionBrowser
     this.dataSource.removeCheckedTiles();
   }
 
+  /**
+   * Handler for when the user changes the selected sort option or direction.
+   */
   private userChangedSort(
     e: CustomEvent<{
       selectedSort: SortField;
@@ -768,6 +796,10 @@ export class CollectionBrowser
     this.currentPage = 1;
   }
 
+  /**
+   * Fires an analytics event for sorting changes.
+   * @param prevSortDirection Which sort direction was previously set.
+   */
   private sendSortByAnalytics(prevSortDirection: SortDirection | null): void {
     const directionCleared = prevSortDirection && !this.sortDirection;
 
@@ -780,11 +812,18 @@ export class CollectionBrowser
     });
   }
 
+  /**
+   * Handler for when the selected sort option is updated, whether by the user
+   * themselves or programmatically.
+   */
   private selectedSortChanged(): void {
     // Lazy-load the alphabet counts for title/creator sort bar as needed
     this.dataSource.updatePrefixFiltersForCurrentSort();
   }
 
+  /**
+   * An object representing the current sort field & direction.
+   */
   get sortParam(): SortParam | null {
     const sortOption = SORT_OPTIONS[this.selectedSort];
     if (!sortOption?.handledBySearchService) {
@@ -804,6 +843,9 @@ export class CollectionBrowser
     return { field: sortField, direction: this.sortDirection };
   }
 
+  /**
+   * Handler for when the display mode option is changed (grid/list/compact-list views).
+   */
   private displayModeChanged(
     e: CustomEvent<{ displayMode?: CollectionDisplayMode }>
   ): void {
@@ -1031,14 +1073,9 @@ export class CollectionBrowser
     `;
   }
 
-  private get loadingTemplate() {
-    return html`
-      <div class="loading-cover">
-        <circular-activity-indicator></circular-activity-indicator>
-      </div>
-    `;
-  }
-
+  /**
+   * Template for the table header content that appears atop the compact list view.
+   */
   private get listHeaderTemplate() {
     return html`
       <div id="list-header">
@@ -1055,6 +1092,9 @@ export class CollectionBrowser
     `;
   }
 
+  /**
+   * Handler for when the date picker's date range is changed.
+   */
   private histogramDateRangeUpdated(
     e: CustomEvent<{
       minDate: string;
@@ -1071,6 +1111,9 @@ export class CollectionBrowser
     });
   }
 
+  /**
+   * The Lucene query corresponding to the current date range.
+   */
   private get dateRangeQueryClause() {
     if (!this.minSelectedDate || !this.maxSelectedDate) {
       return undefined;
@@ -1090,6 +1133,19 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Installs a new data source component and associated query state parameters into
+   * this component, causing it to efficiently update its views to represent the
+   * newly-provided data. In this way, one can reuse a single instance of
+   * <collection-browser> to handle multiple different sets of search results on
+   * a single page, each set of results being loaded & updated by its own data
+   * source.
+   *
+   * @param dataSource The data source component containing (or prepared to fetch)
+   * the tile data to be displayed.
+   * @param queryState The new query-related state that this component should
+   * represent, such as the search query, sort option, and any filters applied.
+   */
   async installDataSourceAndQueryState(
     dataSource: CollectionBrowserDataSourceInterface,
     queryState: CollectionBrowserQueryState
@@ -1131,6 +1187,10 @@ export class CollectionBrowser
     this.setInitialSize();
   }
 
+  /**
+   * Determines the initial size of the content container and whether or not
+   * the mobile layout should be used.
+   */
   setInitialSize(): void {
     this.contentWidth = this.contentContainer.getBoundingClientRect().width;
     this.mobileView =
@@ -1138,6 +1198,10 @@ export class CollectionBrowser
     this.sendLayoutSizeAnalytics();
   }
 
+  /**
+   * Fires an analytics event indicating which type of layout was rendered:
+   * mobile or desktop.
+   */
   private sendLayoutSizeAnalytics(): void {
     if (this.analyticsHandler) {
       this.layoutSizeAnalyticsSent = true;
@@ -1430,6 +1494,9 @@ export class CollectionBrowser
     fadeElmt?.classList.toggle('hidden', entries?.[0]?.isIntersecting);
   };
 
+  /**
+   * Emits a `baseQueryChanged` event indicating an update to the search query.
+   */
   private emitBaseQueryChanged() {
     this.dispatchEvent(
       new CustomEvent<{ baseQuery?: string }>('baseQueryChanged', {
@@ -1440,6 +1507,10 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Emits a `searchTypeChanged` event indicating an update to the search type
+   * (e.g., metadata vs. full-text).
+   */
   private emitSearchTypeChanged() {
     this.dispatchEvent(
       new CustomEvent<SearchType>('searchTypeChanged', {
@@ -1448,6 +1519,10 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Emits a `queryStateChanged` event indicating that one or more of this component's
+   * properties have changed in a way that could affect the set of search results.
+   */
   emitQueryStateChanged() {
     this.dispatchEvent(
       new CustomEvent<CollectionBrowserQueryState>('queryStateChanged', {
@@ -1469,6 +1544,10 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Emits an `emptyResults` event indicating that we have received an empty result set
+   * for the most recent query.
+   */
   emitEmptyResults() {
     this.dispatchEvent(new Event('emptyResults'));
   }
@@ -1543,6 +1622,10 @@ export class CollectionBrowser
     return this.dataSource.initialSearchComplete;
   }
 
+  /**
+   * Handler for whenever the component's properties change in a way that may require
+   * fetching new results.
+   */
   private async handleQueryChange() {
     // only reset if the query has actually changed
     if (
@@ -1647,6 +1730,10 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Emits a `searchResultsLoadingChanged` event indicating that our loading state has
+   * changed (either we have started loading new results, or we have finished loading them).
+   */
   private emitSearchResultsLoadingChanged(): void {
     this.dispatchEvent(
       new CustomEvent<{ loading: boolean }>('searchResultsLoadingChanged', {
@@ -1657,10 +1744,17 @@ export class CollectionBrowser
     );
   }
 
+  /**
+   * Handler for when the set of selected facets changes.
+   */
   facetsChanged(e: CustomEvent<SelectedFacets>) {
     this.selectedFacets = e.detail;
   }
 
+  /**
+   * Handler for when any facet is selected/unselected/hidden/unhidden.
+   * Fires analytics indicating the type of facet event that took place.
+   */
   facetClickHandler({
     detail: { facetType, bucket, negative },
   }: CustomEvent<FacetEventDetails>): void {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -351,11 +351,6 @@ export class CollectionBrowser
     return this.pagesToRender * this.pageSize;
   }
 
-  /**
-   * How many tiles to offset the data source by, to account for any removed tiles.
-   */
-  private tileModelOffset = 0;
-
   @query('infinite-scroller')
   private infiniteScroller?: InfiniteScroller;
 
@@ -492,8 +487,11 @@ export class CollectionBrowser
     );
   }
 
-  render() {
+  willUpdate(): void {
     this.setPlaceholderType();
+  }
+
+  render() {
     return html`
       <div
         id="content-container"
@@ -1561,9 +1559,7 @@ export class CollectionBrowser
       return;
 
     this.previousQueryKey = this.dataSource.pageFetchQueryKey;
-    // this.emitQueryStateChanged();
 
-    this.tileModelOffset = 0;
     this.totalResults = undefined;
     this.pagesToRender =
       this.initialPageNumber === 1
@@ -1593,9 +1589,6 @@ export class CollectionBrowser
       this.persistState();
     }
     this.historyPopOccurred = false;
-
-    // Fire the initial page and facets requests
-    // await this.dataSource.handleQueryChange();
   }
 
   private setupStateRestorationObserver() {

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -44,6 +44,7 @@ import {
   LendingFacetKey,
   suppressedCollections,
   defaultFacetSort,
+  FacetEventDetails,
 } from './models';
 import type {
   CollectionTitles,
@@ -59,6 +60,10 @@ import {
 } from './utils/analytics-events';
 import { srOnlyStyle } from './styles/sr-only';
 import { ExpandedDatePicker } from './expanded-date-picker';
+import {
+  sortBucketsBySelectionState,
+  updateSelectedFacetBucket,
+} from './utils/facet-utils';
 
 @customElement('collection-facets')
 export class CollectionFacets extends LitElement {
@@ -429,6 +434,9 @@ export class CollectionFacets extends LitElement {
         }
       }
 
+      // Sort the FacetBuckets so that selected and hidden buckets come before the rest
+      sortBucketsBySelectionState(bucketsWithCount);
+
       // splice how many items we want to show in page facet area
       facetGroup.buckets = bucketsWithCount.splice(0, allowedFacetCount);
 
@@ -692,11 +700,18 @@ export class CollectionFacets extends LitElement {
         .collectionPagePath=${this.collectionPagePath}
         .facetGroup=${facetGroup}
         .selectedFacets=${this.selectedFacets}
-        .renderOn=${'page'}
         .collectionTitles=${this.collectionTitles}
-        @selectedFacetsChanged=${(e: CustomEvent) => {
+        @facetClick=${(e: CustomEvent<FacetEventDetails>) => {
+          console.log('received facetClick in collection-facets', e.detail);
+          this.selectedFacets = updateSelectedFacetBucket(
+            this.selectedFacets,
+            facetGroup.key,
+            e.detail.bucket,
+            true
+          );
+
           const event = new CustomEvent<SelectedFacets>('facetsChanged', {
-            detail: e.detail,
+            detail: this.selectedFacets,
             bubbles: true,
             composed: true,
           });

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -416,6 +416,9 @@ export class CollectionFacets extends LitElement {
         );
       }
 
+      // Sort the FacetBuckets so that selected and hidden buckets come before the rest
+      sortBucketsBySelectionState(bucketsWithCount);
+
       // For mediatype facets, ensure the collection bucket is always shown if present
       if (facetKey === 'mediatype') {
         const collectionIndex = bucketsWithCount.findIndex(
@@ -427,18 +430,18 @@ export class CollectionFacets extends LitElement {
             collectionIndex,
             1
           );
-          bucketsWithCount.splice(allowedFacetCount - 1, 0, collectionBucket);
+
           // If we're showing lots of selected facets, ensure we're not cutting off the last one
-          if (allowedFacetCount > this.allowedFacetCount)
+          if (allowedFacetCount > this.allowedFacetCount) {
             allowedFacetCount += 1;
+          }
+
+          bucketsWithCount.splice(allowedFacetCount - 1, 0, collectionBucket);
         }
       }
 
-      // Sort the FacetBuckets so that selected and hidden buckets come before the rest
-      sortBucketsBySelectionState(bucketsWithCount);
-
-      // splice how many items we want to show in page facet area
-      facetGroup.buckets = bucketsWithCount.splice(0, allowedFacetCount);
+      // slice off how many items we want to show in page facet area
+      facetGroup.buckets = bucketsWithCount.slice(0, allowedFacetCount);
 
       facetGroups.push(facetGroup);
     });
@@ -699,7 +702,6 @@ export class CollectionFacets extends LitElement {
         .selectedFacets=${this.selectedFacets}
         .collectionTitles=${this.collectionTitles}
         @facetClick=${(e: CustomEvent<FacetEventDetails>) => {
-          console.log('received facetClick in collection-facets', e.detail);
           this.selectedFacets = updateSelectedFacetBucket(
             this.selectedFacets,
             facetGroup.key,

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -646,13 +646,10 @@ export class CollectionFacets extends LitElement {
     facetGroup: FacetGroup,
     sortedBy: AggregationSortType
   ): Promise<void> {
-    const facetAggrKey = facetGroup.key;
-
     const customModalContent = html`
       <more-facets-content
         .analyticsHandler=${this.analyticsHandler}
         .facetKey=${facetGroup.key}
-        .facetAggregationKey=${facetAggrKey}
         .query=${this.query}
         .filterMap=${this.filterMap}
         .pageSpecifierParams=${this.pageSpecifierParams}

--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -138,11 +138,14 @@ export class FacetRow extends LitElement {
 
     const target = e.target as HTMLInputElement;
     const { checked } = target;
-    bucket.state = FacetRow.getFacetState(checked, negative);
+    this.bucket = {
+      ...bucket,
+      state: FacetRow.getFacetState(checked, negative),
+    };
 
     this.dispatchFacetClickEvent({
       facetType,
-      bucket,
+      bucket: this.bucket,
       negative,
     });
   }

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -8,75 +8,19 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import {
-  FacetGroup,
-  FacetBucket,
-  SelectedFacets,
-  getDefaultSelectedFacets,
-  FacetEventDetails,
-} from '../models';
+import type { FacetGroup, FacetBucket, FacetEventDetails } from '../models';
 import type { CollectionTitles } from '../data-source/models';
-import { FacetRow } from './facet-row';
+import './facet-row';
 
 @customElement('facets-template')
 export class FacetsTemplate extends LitElement {
   @property({ type: Object }) facetGroup?: FacetGroup;
 
-  @property({ type: Object }) selectedFacets?: SelectedFacets;
-
-  @property({ type: String }) renderOn?: string;
-
   @property({ type: Object })
   collectionTitles?: CollectionTitles;
 
   private facetClicked(e: CustomEvent<FacetEventDetails>) {
-    const { bucket, negative } = e.detail;
-    if (bucket.state === 'none') {
-      this.facetUnchecked(bucket);
-    } else {
-      this.facetChecked(bucket, negative);
-    }
-
     this.dispatchFacetClickEvent(e.detail);
-  }
-
-  private facetChecked(bucket: FacetBucket, negative: boolean) {
-    const { facetGroup, selectedFacets } = this;
-    if (!facetGroup) return;
-
-    let newFacets: SelectedFacets;
-    if (selectedFacets) {
-      newFacets = {
-        ...selectedFacets,
-      };
-    } else {
-      newFacets = getDefaultSelectedFacets();
-    }
-    newFacets[facetGroup.key][bucket.key] = {
-      ...bucket,
-      state: FacetRow.getFacetState(true, negative),
-    };
-
-    this.selectedFacets = newFacets;
-    this.dispatchSelectedFacetsChanged();
-  }
-
-  private facetUnchecked(bucket: FacetBucket) {
-    const { facetGroup, selectedFacets } = this;
-    if (!facetGroup) return;
-
-    let newFacets: SelectedFacets;
-    if (selectedFacets) {
-      newFacets = {
-        ...selectedFacets,
-      };
-    } else {
-      newFacets = getDefaultSelectedFacets();
-    }
-    delete newFacets[facetGroup.key][bucket.key];
-
-    this.selectedFacets = newFacets;
-    this.dispatchSelectedFacetsChanged();
   }
 
   private dispatchFacetClickEvent(detail: FacetEventDetails) {
@@ -87,39 +31,14 @@ export class FacetsTemplate extends LitElement {
     this.dispatchEvent(event);
   }
 
-  private dispatchSelectedFacetsChanged() {
-    const event = new CustomEvent<SelectedFacets>('selectedFacetsChanged', {
-      detail: this.selectedFacets,
-      bubbles: true,
-      composed: true,
-    });
-    this.dispatchEvent(event);
-  }
-
   private get facetsTemplate(): TemplateResult | typeof nothing {
     const { facetGroup } = this;
     if (!facetGroup) return nothing;
 
-    let facetBuckets = facetGroup.buckets as FacetBucket[];
-
-    /**
-     * sorting FacetBucket before render page / modal
-     * - first, selected items should be at top having sorted
-     * - second, suppressed/hidden items should be after selected having sorted
-     * - and then no-selected / not suppressed items should render having sorted
-     */
-    facetBuckets = [
-      ...facetBuckets
-        .filter(x => x.state === 'selected')
-        .sort((a, b) => (a.count < b.count ? 1 : -1)),
-      ...facetBuckets
-        .filter(x => x.state === 'hidden')
-        .sort((a, b) => (a.count < b.count ? 1 : -1)),
-      ...facetBuckets.filter(x => x.state === 'none'),
-    ];
+    const facetBuckets = facetGroup.buckets as FacetBucket[];
 
     return html`
-      <div class="facets-on-${this.renderOn}">
+      <div class="facet-rows">
         ${repeat(
           facetBuckets,
           bucket => `${facetGroup.key}:${bucket.key}`,
@@ -139,36 +58,13 @@ export class FacetsTemplate extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
+    const columnCount = css`var(--facetsColumnCount, 1)`;
+    const columnGap = css`var(--facetsColumnGap, 15px)`;
+
     return css`
-      @media (max-width: 560px) {
-        .facets-on-modal {
-          column-count: 1 !important;
-        }
-      }
-      .facets-on-modal {
-        column-gap: 15px;
-        column-count: 3;
-      }
-
-      ul.facet-list {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-      ul.facet-list li {
-        margin-bottom: 0.2rem;
-        display: grid;
-      }
-
-      .facet-row {
-        display: flex;
-        font-weight: 500;
-        font-size: 1.2rem;
-        margin: 2.5px auto;
-        height: auto;
-        border-top: var(--facet-row-border-top, 1px solid transparent);
-        border-bottom: var(--facet-row-border-bottom, 1px solid transparent);
-        overflow: hidden;
+      .facet-rows {
+        column-count: ${columnCount};
+        column-gap: ${columnGap};
       }
 
       a:link,

--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -119,20 +119,12 @@ export class MoreFacetsContent extends LitElement {
   @state() private pageNumber = 1;
 
   willUpdate(changed: PropertyValues): void {
-    console.log('willUpdate');
     if (
       changed.has('aggregations') ||
       changed.has('facetsPerPage') ||
       changed.has('pageNumber') ||
       changed.has('selectedFacets')
     ) {
-      console.log(
-        'updating facet group',
-        changed.has('aggregations'),
-        changed.has('facetsPerPage'),
-        changed.has('pageNumber'),
-        changed.has('selectedFacets')
-      );
       this.facetGroup = this.mergedFacets;
     }
   }
@@ -299,6 +291,8 @@ export class MoreFacetsContent extends LitElement {
     if (!this.selectedFacets || !this.facetKey) return undefined;
 
     const selectedFacetsForKey = this.selectedFacets[this.facetKey];
+    if (!selectedFacetsForKey) return undefined;
+
     const facetGroupTitle = facetTitles[this.facetKey];
 
     const buckets: FacetBucket[] = Object.entries(selectedFacetsForKey).map(

--- a/src/utils/facet-utils.ts
+++ b/src/utils/facet-utils.ts
@@ -144,16 +144,23 @@ const BUCKET_STATE_ORDER = ['selected', 'hidden', 'none'];
 
 /**
  * Sorts the provided FacetBuckets so that:
- * - Any selected items come first, sorted by count (desc.)
- * - Any hidden items come after all the selected items, also sorted by count (desc.)
+ * - Any selected items come first
+ * - Any hidden items come after all the selected items
  * - Any unselected / unhidden items come last
+ *
+ * Within each of the above groups, the buckets will be sorted according to
+ * the provided sort type, or by their bucket count by default.
  *
  * The sort is performed in-place using `Array.sort`, so the return value is
  * a reference to the same array that was passed in, only sorted.
+ *
+ * @param buckets The array of facet buckets to sort
+ * @param sort (Optional) How buckets within each state group should be sorted.
+ * Defaults to `AggregationSortType.COUNT` (i.e., descending by bucket count).
  */
 export function sortBucketsBySelectionState(
   buckets: FacetBucket[],
-  sort?: AggregationSortType
+  sort = AggregationSortType.COUNT
 ) {
   return buckets.sort((a, b) => {
     const aStateIndex = BUCKET_STATE_ORDER.indexOf(a.state);

--- a/src/utils/facet-utils.ts
+++ b/src/utils/facet-utils.ts
@@ -13,9 +13,18 @@ import {
  * object. The function is always called with the facet type, bucket key, bucket object,
  * and the given SelectedFacets object.
  *
- * @param selectedFacets
- * @param fn
- * @returns
+ * @param selectedFacets The SelectedFacets object whose buckets should be iterated over
+ * @param fn The function to apply to each facet bucket.
+ *
+ * @example
+ * forEachFacetBucket(
+ *   myFacets,
+ *   (facetType, bucketKey, bucket) => {
+ *     if (facetType === 'collection' && bucket.state === 'hidden') {
+ *       console.log(`Excluding any results in the ${bucketKey} collection`);
+ *     }
+ *   }
+ * );
  */
 export function forEachFacetBucket(
   selectedFacets: SelectedFacets | undefined,

--- a/src/utils/facet-utils.ts
+++ b/src/utils/facet-utils.ts
@@ -1,0 +1,152 @@
+import {
+  FacetOption,
+  getDefaultSelectedFacets,
+  type FacetBucket,
+  type SelectedFacets,
+} from '../models';
+
+// This file contains several helper functions designed to make working immutably
+// with SelectedFacet objects and FacetGroups cleaner & easier.
+
+/**
+ * Calls the given function for each FacetBucket specified in the given SelectedFacets
+ * object. The function is always called with the facet type, bucket key, bucket object,
+ * and the given SelectedFacets object.
+ *
+ * @param selectedFacets
+ * @param fn
+ * @returns
+ */
+export function forEachFacetBucket(
+  selectedFacets: SelectedFacets | undefined,
+  fn: (
+    facetType: FacetOption,
+    bucketKey: string,
+    bucket: FacetBucket,
+    selectedFacets: SelectedFacets
+  ) => unknown
+): void {
+  if (!selectedFacets) return;
+  for (const [facetType, facetBuckets] of Object.entries(selectedFacets)) {
+    for (const [bucketKey, bucket] of Object.entries(facetBuckets)) {
+      fn(facetType as FacetOption, bucketKey, bucket, selectedFacets);
+    }
+  }
+}
+
+/**
+ * Returns a new SelectedFacets object having only the specified bucket changed to
+ * reflect its new provided value. The bucket key is determined from the provided
+ * `bucket` itself.
+ * @param selectedFacets The SelectedFacets object to produce an updated clone of
+ * @param facetType The type of facet to be modified (e.g., 'mediatype', 'subject', ...)
+ * @param bucket The new bucket that should be present on the result
+ * @param omitNoneState If set to true, the returned object will omit the given
+ * bucket entirely if it is updated to state `'none'`. Default is false, which leaves
+ * the `'none'` state in place.
+ */
+export function updateSelectedFacetBucket(
+  selectedFacets: SelectedFacets | undefined,
+  facetType: FacetOption,
+  bucket: FacetBucket,
+  omitNoneState = false
+): SelectedFacets {
+  const defaultedSelectedFacets = selectedFacets ?? getDefaultSelectedFacets();
+  const newFacets = {
+    ...defaultedSelectedFacets,
+    [facetType]: {
+      ...defaultedSelectedFacets[facetType],
+      [bucket.key]: bucket,
+    },
+  };
+
+  if (omitNoneState && bucket.state === 'none') {
+    delete newFacets[facetType][bucket.key];
+  }
+
+  return newFacets;
+}
+
+/**
+ * Creates a clone of the given SelectedFacets object.
+ *
+ * Note that the underlying FacetBucket objects are not deep-cloned -- they will
+ * be references to the same objects as in the input. However, the objects
+ * containing the FacetBuckets for each FacetOption are created anew.
+ *
+ * If the provided argument is undefined, returns an empty SelectedFacets object.
+ *
+ * @param selectedFacets The SelectedFacets object to be cloned
+ */
+export function cloneSelectedFacets(
+  selectedFacets: SelectedFacets | undefined
+): SelectedFacets {
+  const cloneResult = getDefaultSelectedFacets();
+  forEachFacetBucket(selectedFacets, (facetType, bucketKey, bucket) => {
+    cloneResult[facetType][bucketKey] = bucket;
+  });
+  return cloneResult;
+}
+
+/**
+ * Creates a new SelectedFacets object representing a merge of the `source` facets object
+ * into the `destination` facets object. Any facets existing in `source` take precedence
+ * over those in `destination` in the event of conflicts.
+ *
+ * The resulting SelectedFacets object is normalized to omit any facet buckets whose
+ * state is `'none'` in the merged result. Consequently, any facets buckets with state
+ * `'none'` in `source` will always be absent from the end result. Likewise, any facet
+ * buckets with state `'none'` in `destination` will be absent _unless_ they are also
+ * present in `source` with a state of `'selected'` or `'hidden'` (in which case `source`
+ * takes precedence as usual).
+ *
+ * @param source The source of the new facets to merge in. Any facet buckets existing in
+ * this `source` object will take precedence over those in `destination` having the same
+ * key, if they exist in both. Any facet buckets that are _not_ present in `source` will
+ * remain unmodified from their state in `destination`, if they are present there at all.
+ * @param destination The destination onto which facets should be merged. Note that this
+ * object is _not_ re-used for the return value, but it is conceptually the "existing base"
+ * onto which the source facets are merged.
+ */
+export function mergeSelectedFacets(
+  destination: SelectedFacets | undefined,
+  source: SelectedFacets | undefined
+): SelectedFacets {
+  const mergeResult = cloneSelectedFacets(destination);
+  forEachFacetBucket(source, (facetType, bucketKey, bucket) => {
+    mergeResult[facetType][bucketKey] = bucket;
+  });
+
+  // Normalize any 'none' states on the result (from either source or destination)
+  forEachFacetBucket(mergeResult, (facetType, bucketKey, bucket) => {
+    if (bucket.state === 'none') {
+      delete mergeResult[facetType][bucketKey];
+    }
+  });
+
+  return mergeResult;
+}
+
+/**
+ * Defines the order of states in which to display SelectedFacets buckets
+ */
+const BUCKET_STATE_ORDER = ['selected', 'hidden', 'none'];
+
+/**
+ * Sorts the provided FacetBuckets so that:
+ * - Any selected items come first, sorted by count (desc.)
+ * - Any hidden items come after all the selected items, also sorted by count (desc.)
+ * - Any unselected / unhidden items come last
+ *
+ * The sort is performed in-place using `Array.sort`, so the return value is
+ * a reference to the same array that was passed in, only sorted.
+ */
+export function sortBucketsBySelectionState(buckets: FacetBucket[]) {
+  return buckets.sort((a, b) => {
+    const aStateIndex = BUCKET_STATE_ORDER.indexOf(a.state);
+    const bStateIndex = BUCKET_STATE_ORDER.indexOf(b.state);
+    const stateDiff = aStateIndex - bStateIndex; // Sort bucket states in the order defined by BUCKET_STATE_ORDER
+    const countDiff = b.count - a.count; // If both buckets have the same state, sort them by descending count
+    return stateDiff || countDiff; // Primary sort on state, secondary sort on count
+  });
+}

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1956,6 +1956,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
+    await aTimeout(10);
 
     const sortBar = el.shadowRoot?.querySelector(
       'sort-filter-bar'

--- a/test/collection-facets/facet-row.test.ts
+++ b/test/collection-facets/facet-row.test.ts
@@ -178,7 +178,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'selected',
+        count: 5,
+      },
       negative: false,
     });
   });
@@ -208,7 +212,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'none',
+        count: 5,
+      },
       negative: false,
     });
   });
@@ -238,7 +246,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'hidden',
+        count: 5,
+      },
       negative: true,
     });
   });
@@ -268,7 +280,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'none',
+        count: 5,
+      },
       negative: true,
     });
   });
@@ -299,7 +315,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(1);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'selected',
+        count: 5,
+      },
       negative: false,
     });
 
@@ -308,7 +328,11 @@ describe('Facet row', () => {
     expect(facetClickSpy.callCount).to.equal(2);
     expect(facetClickSpy.lastCall.args[0]?.detail).to.deep.equal({
       facetType: 'subject',
-      bucket,
+      bucket: {
+        key: 'foo',
+        state: 'none',
+        count: 5,
+      },
       negative: false,
     });
   });

--- a/test/collection-facets/facets-template.test.ts
+++ b/test/collection-facets/facets-template.test.ts
@@ -28,26 +28,12 @@ describe('Render facets', () => {
     expect(el.shadowRoot?.querySelector('facet-row')).to.exist;
   });
 
-  it('facets render on page', async () => {
+  it('facets template renders facet rows', async () => {
     const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${facetGroup}
-        .renderOn=${'page'}
-      ></facets-template>`
+      html`<facets-template .facetGroup=${facetGroup}></facets-template>`
     );
 
-    expect(el.shadowRoot?.querySelector('.facets-on-page')).to.exist;
-  });
-
-  it('facets render on modal', async () => {
-    const el = await fixture<FacetsTemplate>(
-      html`<facets-template
-        .facetGroup=${facetGroup}
-        .renderOn=${'modal'}
-      ></facets-template>`
-    );
-
-    expect(el.shadowRoot?.querySelector('.facets-on-modal')).to.exist;
+    expect(el.shadowRoot?.querySelector('.facet-rows')).to.exist;
   });
 
   it('applies correct bucket values to facet row', async () => {
@@ -66,14 +52,12 @@ describe('Render facets', () => {
     });
   });
 
-  it('emits facet click and change events when a facet is selected/deselected', async () => {
+  it('emits facet click event when a facet is selected/deselected', async () => {
     const facetClickSpy = sinon.spy();
-    const facetChangeSpy = sinon.spy();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${facetGroup}
         @facetClick=${facetClickSpy}
-        @selectedFacetsChanged=${facetChangeSpy}
       ></facets-template>`
     );
 
@@ -87,23 +71,19 @@ describe('Render facets', () => {
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(1);
-    expect(facetChangeSpy.callCount).to.equal(1);
     expect(facetRow.bucket?.state).to.equal('selected');
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(2);
-    expect(facetChangeSpy.callCount).to.equal(2);
     expect(facetRow.bucket?.state).to.equal('none');
   });
 
-  it('emits facet click and change events when a facet is negated/un-negated', async () => {
+  it('emits facet click event when a facet is negated/un-negated', async () => {
     const facetClickSpy = sinon.spy();
-    const facetChangeSpy = sinon.spy();
     const el = await fixture<FacetsTemplate>(
       html`<facets-template
         .facetGroup=${facetGroup}
         @facetClick=${facetClickSpy}
-        @selectedFacetsChanged=${facetChangeSpy}
       ></facets-template>`
     );
 
@@ -117,18 +97,15 @@ describe('Render facets', () => {
 
     facetNegateCheck.click();
     expect(facetClickSpy.callCount).to.equal(1);
-    expect(facetChangeSpy.callCount).to.equal(1);
     expect(facetRow.bucket?.state).to.equal('hidden');
 
     facetNegateCheck.click();
     expect(facetClickSpy.callCount).to.equal(2);
-    expect(facetChangeSpy.callCount).to.equal(2);
     expect(facetRow.bucket?.state).to.equal('none');
   });
 
-  it('emits facet click and change events when a pre-selected facet is deselected', async () => {
+  it('emits facet click event when a pre-selected facet is deselected', async () => {
     const facetClickSpy = sinon.spy();
-    const facetChangeSpy = sinon.spy();
     const facetGroupWithSelection = { ...facetGroup };
     facetGroupWithSelection.buckets = [
       { ...facetGroup.buckets[0], state: 'selected' },
@@ -139,7 +116,6 @@ describe('Render facets', () => {
       html`<facets-template
         .facetGroup=${facetGroupWithSelection}
         @facetClick=${facetClickSpy}
-        @selectedFacetsChanged=${facetChangeSpy}
       ></facets-template>`
     );
 
@@ -154,12 +130,10 @@ describe('Render facets', () => {
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(1);
-    expect(facetChangeSpy.callCount).to.equal(1);
     expect(facetRow.bucket?.state).to.equal('none');
 
     facetSelectCheck.click();
     expect(facetClickSpy.callCount).to.equal(2);
-    expect(facetChangeSpy.callCount).to.equal(2);
     expect(facetRow.bucket?.state).to.equal('selected');
   });
 });

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -67,11 +67,8 @@ describe('More facets content', () => {
     el.facetKey = 'year';
     el.query = 'more-facets'; // Produces a response with 40+ aggregations for multiple pages
     await el.updateComplete;
-    await aTimeout(100);
+    await aTimeout(50); // Give it a moment to perform the (mock) search query after the initial update
 
-    // @ts-ignore
-    console.log(el.facetGroup);
-    console.log(el.shadowRoot);
     expect(el.shadowRoot?.querySelectorAll('more-facets-pagination')).to.exist;
   });
 

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -6,6 +6,7 @@ import type { MoreFacetsContent } from '../../src/collection-facets/more-facets-
 import '../../src/collection-facets/more-facets-content';
 import { MockSearchService } from '../mocks/mock-search-service';
 import { MockAnalyticsHandler } from '../mocks/mock-analytics-handler';
+import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
 
 const selectedFacetsGroup = {
   title: 'Media Type',
@@ -64,7 +65,6 @@ describe('More facets content', () => {
 
     el.facetKey = 'mediatype';
     el.facetsLoading = false;
-    el.paginationSize = 6;
     await el.updateComplete;
 
     expect(el.shadowRoot?.querySelectorAll('more-facets-pagination')).to.exist;
@@ -146,7 +146,7 @@ describe('More facets content', () => {
     expect(searchService.searchParams?.query).to.equal('title:hello');
   });
 
-  it('combine selectedFacets and aggregationFacets and render on modal', async () => {
+  it('combines selectedFacets and aggregationFacets and renders on modal', async () => {
     const searchService = new MockSearchService();
 
     const el = await fixture<MoreFacetsContent>(
@@ -157,11 +157,12 @@ describe('More facets content', () => {
       ></more-facets-content>`
     );
 
-    await el.updateComplete;
+    const facetsTemplate = el.shadowRoot?.querySelector(
+      'facets-template'
+    ) as FacetsTemplate;
+    expect(facetsTemplate).to.exist;
 
-    expect(el.facetGroupTitle).to.equal('Collection');
-
-    const facetGroup = el.facetGroup?.shift();
+    const { facetGroup } = facetsTemplate;
     expect(facetGroup?.key).to.equal('collection');
     expect(facetGroup?.title).to.equal('Collection');
 
@@ -180,7 +181,6 @@ describe('More facets content', () => {
     );
 
     el.facetsLoading = false;
-    el.paginationSize = 5;
     await el.updateComplete;
 
     // select cancel button
@@ -204,7 +204,6 @@ describe('More facets content', () => {
     );
 
     el.facetsLoading = false;
-    el.paginationSize = 5;
     el.facetKey = 'collection';
     await el.updateComplete;
 

--- a/test/collection-facets/more-facets-content.test.ts
+++ b/test/collection-facets/more-facets-content.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable import/no-duplicates */
-import { expect, fixture } from '@open-wc/testing';
+import { aTimeout, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit';
-import { Aggregation } from '@internetarchive/search-service';
 import type { MoreFacetsContent } from '../../src/collection-facets/more-facets-content';
 import '../../src/collection-facets/more-facets-content';
 import { MockSearchService } from '../mocks/mock-search-service';
 import { MockAnalyticsHandler } from '../mocks/mock-analytics-handler';
 import type { FacetsTemplate } from '../../src/collection-facets/facets-template';
+import type { SelectedFacets } from '../../src/models';
 
 const selectedFacetsGroup = {
   title: 'Media Type',
@@ -20,15 +20,16 @@ const selectedFacetsGroup = {
   ],
 };
 
-const aggregations: Record<string, Aggregation> = {
-  collection: new Aggregation({
-    buckets: [
-      {
-        key: 'foo',
-        doc_count: 5,
-      },
-    ],
-  }),
+const yearSelectedFacets: SelectedFacets = {
+  mediatype: {},
+  lending: {},
+  year: {
+    '2000': { key: '2000', count: 5, state: 'selected' },
+  },
+  subject: {},
+  collection: {},
+  creator: {},
+  language: {},
 };
 
 describe('More facets content', () => {
@@ -63,10 +64,14 @@ describe('More facets content', () => {
       ></more-facets-content>`
     );
 
-    el.facetKey = 'mediatype';
-    el.facetsLoading = false;
+    el.facetKey = 'year';
+    el.query = 'more-facets'; // Produces a response with 40+ aggregations for multiple pages
     await el.updateComplete;
+    await aTimeout(100);
 
+    // @ts-ignore
+    console.log(el.facetGroup);
+    console.log(el.shadowRoot);
     expect(el.shadowRoot?.querySelectorAll('more-facets-pagination')).to.exist;
   });
 
@@ -151,9 +156,10 @@ describe('More facets content', () => {
 
     const el = await fixture<MoreFacetsContent>(
       html`<more-facets-content
+        .facetKey=${'year'}
+        .query=${'more-facets'}
         .searchService=${searchService}
-        .selectedFacets=${selectedFacetsGroup}
-        .aggregations=${aggregations}
+        .selectedFacets=${yearSelectedFacets}
       ></more-facets-content>`
     );
 
@@ -163,54 +169,63 @@ describe('More facets content', () => {
     expect(facetsTemplate).to.exist;
 
     const { facetGroup } = facetsTemplate;
-    expect(facetGroup?.key).to.equal('collection');
-    expect(facetGroup?.title).to.equal('Collection');
+    expect(facetGroup?.key).to.equal('year');
+    expect(facetGroup?.title).to.equal('Year');
 
-    const bucket = facetGroup?.buckets[0];
-    expect(bucket?.key).to.equal('foo');
-    expect(bucket?.count).to.equal(5);
+    // First bucket is the one that was included in the selected facets
+    const firstBucket = facetGroup?.buckets[0];
+    expect(firstBucket?.key).to.equal('2000');
+    expect(firstBucket?.count).to.equal(5);
+
+    // Second bucket is the most recent year, since year facets default to descending order of year
+    const secondBucket = facetGroup?.buckets[1];
+    expect(secondBucket?.key).to.equal('2024');
+    expect(secondBucket?.count).to.equal(5);
   });
 
   it('cancel button clicked event', async () => {
+    const searchService = new MockSearchService();
     const mockAnalyticsHandler = new MockAnalyticsHandler();
 
     const el = await fixture<MoreFacetsContent>(
       html`<more-facets-content
+        .facetKey=${'collection'}
+        .query=${'collection-aggregations'}
+        .searchService=${searchService}
         .analyticsHandler=${mockAnalyticsHandler}
       ></more-facets-content>`
     );
-
-    el.facetsLoading = false;
-    await el.updateComplete;
 
     // select cancel button
     const cancelButton = el.shadowRoot?.querySelector(
       '.footer > .btn-cancel'
     ) as HTMLButtonElement;
+    expect(cancelButton).to.exist;
     cancelButton?.click();
 
     expect(mockAnalyticsHandler.callCategory).to.equal('collection-browser');
     expect(mockAnalyticsHandler.callAction).to.equal('closeMoreFacetsModal');
-    expect(mockAnalyticsHandler.callLabel).to.equal('undefined');
+    expect(mockAnalyticsHandler.callLabel).to.equal('collection');
   });
 
   it('facet apply button clicked event', async () => {
+    const searchService = new MockSearchService();
     const mockAnalyticsHandler = new MockAnalyticsHandler();
 
     const el = await fixture<MoreFacetsContent>(
       html`<more-facets-content
+        .facetKey=${'collection'}
+        .query=${'collection-aggregations'}
+        .searchService=${searchService}
         .analyticsHandler=${mockAnalyticsHandler}
       ></more-facets-content>`
     );
-
-    el.facetsLoading = false;
-    el.facetKey = 'collection';
-    await el.updateComplete;
 
     // select submit button
     const submitButton = el.shadowRoot?.querySelector(
       '.footer > .btn-submit'
     ) as HTMLButtonElement;
+    expect(submitButton).to.exist;
     submitButton?.click();
 
     expect(mockAnalyticsHandler.callCategory).to.equal('collection-browser');

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -940,6 +940,92 @@ export const getMockSuccessWithWebArchiveHits: () => Result<
   },
 });
 
+export const getMockSuccessWithManyAggregations: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      kind: 'aggregations',
+      clientParameters: {
+        user_query: 'more-facets',
+        sort: [],
+      },
+      backendRequests: {
+        primary: {
+          kind: 'aggregations',
+          finalized_parameters: {
+            user_query: 'more-facets',
+            sort: [],
+          },
+        },
+      },
+    },
+    rawResponse: {},
+    sessionContext: {},
+    response: {
+      totalResults: 0,
+      returnedCount: 0,
+      results: [],
+      aggregations: {
+        year: new Aggregation({
+          buckets: [
+            { key: '1980', doc_count: 5 },
+            { key: '1981', doc_count: 6 },
+            { key: '1982', doc_count: 7 },
+            { key: '1983', doc_count: 8 },
+            { key: '1984', doc_count: 5 },
+            { key: '1985', doc_count: 6 },
+            { key: '1986', doc_count: 7 },
+            { key: '1987', doc_count: 8 },
+            { key: '1988', doc_count: 5 },
+            { key: '1989', doc_count: 6 },
+            { key: '1990', doc_count: 7 },
+            { key: '1991', doc_count: 8 },
+            { key: '1992', doc_count: 5 },
+            { key: '1993', doc_count: 6 },
+            { key: '1994', doc_count: 7 },
+            { key: '1995', doc_count: 8 },
+            { key: '1996', doc_count: 5 },
+            { key: '1997', doc_count: 6 },
+            { key: '1998', doc_count: 7 },
+            { key: '1999', doc_count: 8 },
+            { key: '2000', doc_count: 5 },
+            { key: '2001', doc_count: 6 },
+            { key: '2002', doc_count: 7 },
+            { key: '2003', doc_count: 8 },
+            { key: '2004', doc_count: 5 },
+            { key: '2005', doc_count: 6 },
+            { key: '2006', doc_count: 7 },
+            { key: '2007', doc_count: 8 },
+            { key: '2008', doc_count: 5 },
+            { key: '2009', doc_count: 6 },
+            { key: '2010', doc_count: 7 },
+            { key: '2011', doc_count: 8 },
+            { key: '2012', doc_count: 5 },
+            { key: '2013', doc_count: 6 },
+            { key: '2014', doc_count: 7 },
+            { key: '2015', doc_count: 8 },
+            { key: '2016', doc_count: 5 },
+            { key: '2017', doc_count: 6 },
+            { key: '2018', doc_count: 7 },
+            { key: '2019', doc_count: 8 },
+            { key: '2020', doc_count: 5 },
+            { key: '2021', doc_count: 6 },
+            { key: '2022', doc_count: 7 },
+            { key: '2023', doc_count: 8 },
+            { key: '2024', doc_count: 5 },
+          ],
+        }),
+      },
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
 export const getMockErrorResult: () => Result<
   SearchResponse,
   SearchServiceError

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -29,6 +29,7 @@ import {
   getMockSuccessManyFields,
   getMockSuccessNoResults,
   getMockSuccessWithWebArchiveHits,
+  getMockSuccessWithManyAggregations,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -51,6 +52,7 @@ const responses: Record<
   'fav-sort': getMockSuccessWithDefaultFavSort,
   'parent-collections': getMockSuccessWithParentCollections,
   'web-archive': getMockSuccessWithWebArchiveHits,
+  'more-facets': getMockSuccessWithManyAggregations,
   'many-fields': getMockSuccessManyFields,
   'no-results': getMockSuccessNoResults,
   error: getMockErrorResult,


### PR DESCRIPTION
Currently facets in the More... dialog have the following behavior: when checked they immediately bubble up to the top of the page, and when unchecked they immediately return to their original sorted position. This behavior is similar to how facet selections bubble up to the top when selected in the _sidebar_, although the sidebar triggers a full refresh upon each selection while the dialog does not.

While the original intent was presumably to keep all the selected facets grouped separately from the unselected ones, the reflow upon making any facet changes is jarring and produces frustrating UX in many cases.

This PR adjusts the behavior in the dialog to leave facets in place when they are clicked, and performs a bit of cleanup & refactoring to improve some unusual data flows in our facet components that were making changes more challenging than they needed to be.

Moreover, facets that were selected/hidden prior to opening the dialog now appear only once, at the very beginning of the pagination, rather than following you from page to page (which had some undesired behavior in cases where many facets were selected).