### PR TITLE
WEBDEV-6944 Add `opt-in-or-login` facet load strategy and related bugfix

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1411,14 +1411,19 @@ export class CollectionBrowser
    * current facet loading strategy.
    */
   private updateFacetReadiness(): void {
-    // In desktop view, we are always ready to load facets *unless* we are
-    // using the `opt-in` strategy and the facets dropdown is not open.
-    const desktopFacetsReady =
-      !this.mobileView &&
-      (this.facetLoadStrategy !== 'opt-in' || this.collapsibleFacetsVisible);
+    // There are two ways to opt into facet production:
+    //  (1) be logged into an account, or
+    //  (2) have the facets dropdown open
+    const optedIn = this.loggedIn || this.collapsibleFacetsVisible;
 
-    // In mobile view, facets are considered ready provided they are currently visible (their dropdown is opened).
-    const mobileFacetsReady = this.mobileView && this.collapsibleFacetsVisible;
+    // In desktop view, we are always ready to load facets *unless* we are using the
+    // `opt-in` strategy while logged out and with the facets dropdown closed.
+    const desktopFacetsReady =
+      !this.mobileView && (this.facetLoadStrategy !== 'opt-in' || optedIn);
+
+    // In the mobile view, facets are considered ready provided they are currently
+    // visible (their dropdown is opened) or we are logged in.
+    const mobileFacetsReady = this.mobileView && optedIn;
 
     this.dataSource.handleFacetReadinessChange(
       desktopFacetsReady || mobileFacetsReady

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -404,11 +404,7 @@ export class CollectionBrowserDataSource
     const facetsBecameReady = !this.facetsReadyToLoad && ready;
     this.facetsReadyToLoad = ready;
 
-    const lazyLoadFacets = ['lazy-mobile', 'opt-in'].includes(
-      this.host.facetLoadStrategy
-    );
-    const needsFetch =
-      lazyLoadFacets && facetsBecameReady && this.canFetchFacets;
+    const needsFetch = facetsBecameReady && this.canFetchFacets;
     if (needsFetch) {
       this.fetchFacets();
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -467,12 +467,19 @@ export const prefixFilterAggregationKeys: Record<PrefixFilterType, string> = {
  *  - `eager`: Facet data is always loaded as soon as a search is performed
  *  - `lazy-mobile`: In the desktop layout, functions exactly as `eager`.
  *     In the mobile layout, facet data will only be loaded once the "Filters" accordion is opened.
+ *  - `opt-in-or-login`: Same as `opt-in` for guest users not logged into an account, but same as `eager` for
+ *     any logged in user.
  *  - `opt-in`: In the desktop layout, facet data will only be loaded after the user presses a "Load Facets" button.
  *     In the mobile layout, functions exactly as `lazy-mobile`.
  *  - `off`: Facet data will never be loaded, and a message will be displayed in place of facets
  *     indicating that they are unavailable.
  */
-export type FacetLoadStrategy = 'eager' | 'lazy-mobile' | 'opt-in' | 'off';
+export type FacetLoadStrategy =
+  | 'eager'
+  | 'lazy-mobile'
+  | 'opt-in-or-login'
+  | 'opt-in'
+  | 'off';
 
 /**
  * Union of the facet types that are available in the sidebar.


### PR DESCRIPTION
This PR adds a new `opt-in-or-login` facet load strategy which works like `opt-in` for anyone who is not logged into an account, but like `eager` for anyone who is logged in. In other words, it treats being logged in as an automatic opt-in for facet production.

Moreover, when the facet load strategy changes from any non-eager strategy to `'eager'`, any pending delayed facet fetch is supposed to go ahead immediately. However, currently no facet fetch is made in that scenario. This PR patches the bug to make that fetch.