### PR TITLE
WEBDEV-6333 Fix bug where unapplied facet selections can persist after cancelling More dialog

### DIFF
--- a/src/collection-facets/more-facets-content.ts
+++ b/src/collection-facets/more-facets-content.ts
@@ -526,6 +526,9 @@ export class MoreFacetsContent extends LitElement {
   }
 
   private cancelClick() {
+    // Reset the unapplied changes back to default
+    this.unappliedFacetChanges = getDefaultSelectedFacets();
+
     this.modalManager?.closeModal();
     this.analyticsHandler?.sendEvent({
       category: analyticsCategories.default,


### PR DESCRIPTION
As of #381, the More facet dialog appears to have a bug where selecting facets, cancelling the dialog, then reopening it leaves them selected. If the second dialog was opened on a different facet type than the first one, then those selections are not visible but will still be applied along with the others. This PR fixes that bug by ensuring the selections are cleared when the dialog is cancelled.