### PR TITLE
WEBDEV-7022 Ensure initial page of results always triggers scroller refresh

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1231,11 +1231,6 @@ export class CollectionBrowser
     this.dataSourceInstallInProgress = false;
 
     if (!this.searchResultsLoading) {
-      console.log(
-        'setting total result count and tile count from installed data source',
-        this.dataSource.totalResults,
-        this.dataSource.size
-      );
       this.setTotalResultCount(this.dataSource.totalResults);
       this.setTileCount(this.dataSource.size);
     }
@@ -1411,12 +1406,7 @@ export class CollectionBrowser
     }
 
     if (changed.has('pagesToRender')) {
-      console.log('pagesToRender changed', this.pagesToRender);
       if (!this.dataSource.endOfDataReached && this.infiniteScroller) {
-        console.log(
-          'updating infinite scroller item count to new estimate',
-          this.estimatedTileCount
-        );
         this.infiniteScroller.itemCount = this.estimatedTileCount;
       }
     }
@@ -1483,12 +1473,6 @@ export class CollectionBrowser
       this.infiniteScroller &&
       this.infiniteScroller.itemCount < this.dataSource.size
     ) {
-      console.log(
-        'infinite scroller lags data source, setting tile count',
-        this.infiniteScroller.itemCount,
-        this.dataSource.size,
-        this.estimatedTileCount
-      );
       this.setTileCount(
         this.dataSource.endOfDataReached
           ? this.dataSource.size
@@ -1754,10 +1738,6 @@ export class CollectionBrowser
     // Reset the infinite scroller's item count, so that it
     // shows tile placeholders until the new query's results load in
     if (this.infiniteScroller) {
-      console.log(
-        'resetting infinite scroller tile count to estimate',
-        this.estimatedTileCount
-      );
       this.infiniteScroller.itemCount = this.estimatedTileCount;
       this.infiniteScroller.reload();
     }
@@ -1917,7 +1897,6 @@ export class CollectionBrowser
    * Sets the total number of tiles displayed in the infinite scroller.
    */
   setTileCount(count: number): void {
-    console.log('setTileCount called', count, !!this.infiniteScroller);
     if (this.infiniteScroller) {
       this.infiniteScroller.itemCount = count;
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1231,6 +1231,11 @@ export class CollectionBrowser
     this.dataSourceInstallInProgress = false;
 
     if (!this.searchResultsLoading) {
+      console.log(
+        'setting total result count and tile count from installed data source',
+        this.dataSource.totalResults,
+        this.dataSource.size
+      );
       this.setTotalResultCount(this.dataSource.totalResults);
       this.setTileCount(this.dataSource.size);
     }
@@ -1406,7 +1411,12 @@ export class CollectionBrowser
     }
 
     if (changed.has('pagesToRender')) {
+      console.log('pagesToRender changed', this.pagesToRender);
       if (!this.dataSource.endOfDataReached && this.infiniteScroller) {
+        console.log(
+          'updating infinite scroller item count to new estimate',
+          this.estimatedTileCount
+        );
         this.infiniteScroller.itemCount = this.estimatedTileCount;
       }
     }
@@ -1718,6 +1728,10 @@ export class CollectionBrowser
     // Reset the infinite scroller's item count, so that it
     // shows tile placeholders until the new query's results load in
     if (this.infiniteScroller) {
+      console.log(
+        'resetting infinite scroller tile count to estimate',
+        this.estimatedTileCount
+      );
       this.infiniteScroller.itemCount = this.estimatedTileCount;
       this.infiniteScroller.reload();
     }
@@ -1877,6 +1891,7 @@ export class CollectionBrowser
    * Sets the total number of tiles displayed in the infinite scroller.
    */
   setTileCount(count: number): void {
+    console.log('setTileCount called', count, !!this.infiniteScroller);
     if (this.infiniteScroller) {
       this.infiniteScroller.itemCount = count;
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1434,6 +1434,8 @@ export class CollectionBrowser
       if (oldObserver) this.disconnectResizeObserver(oldObserver);
       this.setupResizeObserver();
     }
+
+    this.ensureAvailableTilesDisplayed();
   }
 
   connectedCallback(): void {
@@ -1469,6 +1471,30 @@ export class CollectionBrowser
 
     // Ensure the facet sidebar remains sized correctly
     this.updateLeftColumnHeight();
+  }
+
+  /**
+   * Ensures that if we have new results from the data source that are not yet
+   * displayed in the infinite scroller, that they are immediately reflected
+   * in the tile count.
+   */
+  private ensureAvailableTilesDisplayed(): void {
+    if (
+      this.infiniteScroller &&
+      this.infiniteScroller.itemCount < this.dataSource.size
+    ) {
+      console.log(
+        'infinite scroller lags data source, setting tile count',
+        this.infiniteScroller.itemCount,
+        this.dataSource.size,
+        this.estimatedTileCount
+      );
+      this.setTileCount(
+        this.dataSource.endOfDataReached
+          ? this.dataSource.size
+          : this.estimatedTileCount
+      );
+    }
   }
 
   /**

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1143,7 +1143,6 @@ export class CollectionBrowserDataSource
     // item count to the real total number of results (rather than the
     // temporary estimates based on pages rendered so far).
     if (this.size >= this.totalResults || results.length === 0) {
-      console.log('end of data reached. active?:', !!this.activeOnHost);
       this.endOfDataReached = true;
       if (this.activeOnHost) this.host.setTileCount(this.size);
     }
@@ -1163,7 +1162,6 @@ export class CollectionBrowserDataSource
     results: SearchResult[],
     needsReload = true
   ): void {
-    console.log('adding page', pageNumber, 'to data source');
     const tiles: TileModel[] = [];
     results?.forEach(result => {
       if (!result.identifier) return;
@@ -1173,7 +1171,6 @@ export class CollectionBrowserDataSource
     this.addPage(pageNumber, tiles);
 
     if (needsReload) {
-      console.log('needed reload -- refreshing visible cells');
       this.refreshVisibleResults();
     }
   }

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1141,6 +1141,7 @@ export class CollectionBrowserDataSource
     // item count to the real total number of results (rather than the
     // temporary estimates based on pages rendered so far).
     if (this.size >= this.totalResults || results.length === 0) {
+      console.log('end of data reached. active?:', !!this.activeOnHost);
       this.endOfDataReached = true;
       if (this.activeOnHost) this.host.setTileCount(this.size);
     }
@@ -1159,6 +1160,7 @@ export class CollectionBrowserDataSource
     pageNumber: number,
     results: SearchResult[]
   ): void {
+    console.log('adding page', pageNumber, 'to data source');
     const tiles: TileModel[] = [];
     results?.forEach(result => {
       if (!result.identifier) return;
@@ -1166,11 +1168,13 @@ export class CollectionBrowserDataSource
     });
 
     const isInitialPage = this.numTileModels === 0;
+    console.log('isInitialPage:', isInitialPage);
     this.addPage(pageNumber, tiles);
 
     const visiblePages = this.host.currentVisiblePageNumbers;
     const needsReload = visiblePages.includes(pageNumber) || isInitialPage;
     if (needsReload) {
+      console.log('needed reload -- refreshing visible cells');
       this.refreshVisibleResults();
     }
   }

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1164,9 +1164,12 @@ export class CollectionBrowserDataSource
       if (!result.identifier) return;
       tiles.push(new TileModel(result));
     });
+
+    const isInitialPage = this.numTileModels === 0;
     this.addPage(pageNumber, tiles);
+
     const visiblePages = this.host.currentVisiblePageNumbers;
-    const needsReload = visiblePages.includes(pageNumber);
+    const needsReload = visiblePages.includes(pageNumber) || isInitialPage;
     if (needsReload) {
       this.refreshVisibleResults();
     }


### PR DESCRIPTION
Broadens the conditions under which the infinite scroller's results will be refreshed, to always include the initial page of results (even when multiple pages are being loaded in simultaneously).