### PR TITLE
Update CI to use newer codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Install dependencies
       run: yarn install
 
     - name: Run tests
       run: yarn run test
-
-    - name: Upload reports
-      run: npx codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16.x
-    - uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Install dependencies
       run: yarn install
 
     - name: Run tests
       run: yarn run test
+
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Our existing means of uploading coverage reports to codecov has been deprecated and superseded by the codecov-action GH action. This PR updates our CI workflow to rely on the new action.