### PR TITLE
Upgrade dompurify version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@internetarchive/search-service": "^1.4.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.11.2",
-    "dompurify": "^2.3.6",
+    "dompurify": "^3.1.7",
     "eslint-plugin-lit": "^1.6.1",
     "lit": "^2.2.2",
     "typescript-cookie": "^1.0.3"
@@ -43,7 +43,7 @@
     "@internetarchive/result-type": "^0.0.1",
     "@open-wc/eslint-config": "^8.0.2",
     "@open-wc/testing": "^3.0.3",
-    "@types/dompurify": "^2.3.3",
+    "@types/dompurify": "^3.0.5",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "@web/dev-server": "^0.1.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,10 +475,10 @@
   resolved "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.1.tgz"
   integrity sha512-epMsEE85fi4lfmJUH/89/iV/LI+F5CvNIvmgs5g5jYFPfhO2S/ae8WSsLOKWdwtoaZw9Q2IhJ4tQ5tFCcS/4HA==
 
-"@types/dompurify@^2.3.3":
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz"
-  integrity sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==
+"@types/dompurify@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.5.tgz#02069a2fcb89a163bacf1a788f73cb415dd75cb7"
+  integrity sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==
   dependencies:
     "@types/trusted-types" "*"
 
@@ -1690,10 +1690,10 @@ domhandler@^5.0.1, domhandler@^5.0.2:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz"
-  integrity sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw==
+dompurify@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
+  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
 
 domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
Bumps `dompurify` to latest version `3.1.7` and `@types/dompurify` to latest version `3.0.5`.