### PR TITLE
WEBDEV-7261 Fix discrepancy affecting old year-only publish dates

### DIFF
--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -20,8 +20,10 @@ export function formatDate(
 
   switch (format) {
     case 'year-only':
-      options.year = 'numeric';
-      break;
+      // If we're only using the year, ensure we output the correct UTC year and not
+      // the local year. If the local timezone is used, we can get strange off-by-one
+      // errors due to quirks of timezone handling for older years.
+      return `${date.getUTCFullYear()}`;
     case 'short':
       options.month = 'short';
       options.year = 'numeric';

--- a/test/utils/format-date.test.ts
+++ b/test/utils/format-date.test.ts
@@ -17,7 +17,7 @@ describe('formatDate', () => {
   });
 
   it('returns year-only date when year-only DateFormat', () => {
-    expect(formatDate(testDate, 'year-only')).to.equal(2020);
+    expect(formatDate(testDate, 'year-only')).to.equal('2020');
   });
 
   it('returns correct year for old "Jan 1 at midnight" dates and year-only DateFormat', () => {
@@ -29,7 +29,7 @@ describe('formatDate', () => {
     // receive from the search engine for date metadata that only specifies the year.
     // So we must ensure these older dates still output the correct year, not the prior one.
     expect(formatDate(new Date('1234-01-01T00:00:00Z'), 'year-only')).to.equal(
-      1234
+      '1234'
     );
   });
 

--- a/test/utils/format-date.test.ts
+++ b/test/utils/format-date.test.ts
@@ -16,6 +16,23 @@ describe('formatDate', () => {
     expect(formatDate(testDate, 'long')).to.equal('Dec 09, 2020');
   });
 
+  it('returns year-only date when year-only DateFormat', () => {
+    expect(formatDate(testDate, 'year-only')).to.equal(2020);
+  });
+
+  it('returns correct year for old "Jan 1 at midnight" dates and year-only DateFormat', () => {
+    // Many standard timezones have a discontinuity in date parsing at some point during
+    // the 19th or 20th century, corresponding to the creation of the timezone.
+    // Dates prior to the discontinuity generally have a non-hour-aligned timezone offset
+    // which can throw off the calculated year for dates which are close to a year boundary.
+    // This is particularly problematic for "Jan 1 at midnight" dates, which are what we
+    // receive from the search engine for date metadata that only specifies the year.
+    // So we must ensure these older dates still output the correct year, not the prior one.
+    expect(formatDate(new Date('1234-01-01T00:00:00Z'), 'year-only')).to.equal(
+      1234
+    );
+  });
+
   it('returns locale formatted date', () => {
     expect(formatDate(testDate, 'long', 'de-DE')).to.equal('09. Dez. 2020');
   });


### PR DESCRIPTION
Currently the date published shown on result tiles can be off by one for older years that fall before the creation of the local time zone, due to quirks in how dates are interpreted. This PR fixes the display error by ensuring that year-only dates always refer to UTC and do not involve the local time zone.