### PR TITLE
WEBDEV-7323 Ensure target collection's title is shown in facets/results

### DIFF
--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1029,10 +1029,12 @@ export class CollectionBrowserDataSource
     }
     this.previousQueryKey = pageFetchQueryKey;
 
+    const { withinCollection, withinProfile } = this.host;
+
     let sortParams = this.host.sortParam ? [this.host.sortParam] : [];
     // TODO eventually the PPS should handle these defaults natively
     const isDefaultProfileSort =
-      this.host.withinProfile && this.host.selectedSort === SortField.default;
+      withinProfile && this.host.selectedSort === SortField.default;
     if (isDefaultProfileSort && this.host.defaultSortField) {
       const sortOption = SORT_OPTIONS[this.host.defaultSortField];
       if (sortOption.searchServiceKey) {
@@ -1097,7 +1099,7 @@ export class CollectionBrowserDataSource
     }
 
     this.sessionContext = success.sessionContext;
-    if (this.host.withinCollection) {
+    if (withinCollection) {
       this.collectionExtraInfo = success.response.collectionExtraInfo;
 
       // For collections, we want the UI to respect the default sort option
@@ -1111,7 +1113,7 @@ export class CollectionBrowserDataSource
           this.collectionExtraInfo.public_metadata?.collection ?? []
         );
       }
-    } else if (this.host.withinProfile) {
+    } else if (withinProfile) {
       this.accountExtraInfo = success.response.accountExtraInfo;
       this.pageElements = success.response.pageElements;
     }
@@ -1123,6 +1125,12 @@ export class CollectionBrowserDataSource
       if (collectionTitles) {
         for (const [id, title] of Object.entries(collectionTitles)) {
           this.collectionTitles.set(id, title);
+        }
+
+        // Also add the target collection's title if available
+        const targetTitle = this.collectionExtraInfo?.public_metadata?.title;
+        if (withinCollection && targetTitle) {
+          this.collectionTitles.set(withinCollection, targetTitle);
         }
       }
 


### PR DESCRIPTION
Currently, because the target collection is not necessarily included in the PPS `collection_titles` map, it may be displayed as a bare identifier in facets & result tiles. We already have the correct title on the separate `collection_extra_info` branch of the response, so this PR just merges that into the title map when available.