### PR TITLE
v2.7.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version includes bugfix for target collection not using the correct title in facets/results.