### PR TITLE
WEBDEV-6636 Delay scrolling to page until content has loaded in

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -319,6 +319,13 @@ export class CollectionBrowser
   private isScrollingToCell = false;
 
   /**
+   * When we attempt to scroll to a page before the infinite scroller has
+   * been populated, this flag will be set, allowing us to complete the scroll
+   * once it is possible.
+   */
+  private needsScrollToPage = false;
+
+  /**
    * When page width resizes from desktop to mobile, set true to
    * disable expand/collapse transition when loading.
    */
@@ -1475,6 +1482,15 @@ export class CollectionBrowser
     }
 
     this.ensureAvailableTilesDisplayed();
+
+    if (
+      this.needsScrollToPage &&
+      this.currentPage &&
+      this.infiniteScroller?.itemCount
+    ) {
+      this.needsScrollToPage = false;
+      this.scrollToPage(this.currentPage);
+    }
   }
 
   connectedCallback(): void {
@@ -1915,6 +1931,16 @@ export class CollectionBrowser
   private scrollToPage(pageNumber: number): Promise<void> {
     return new Promise(resolve => {
       const cellIndexToScrollTo = this.pageSize * (pageNumber - 1);
+      // If the desired cell is not yet present in the infinite scroller, flag it to be
+      // scrolled later one ready.
+      if (
+        !this.infiniteScroller ||
+        this.infiniteScroller.itemCount < cellIndexToScrollTo
+      ) {
+        this.needsScrollToPage = true;
+        return;
+      }
+
       // without this setTimeout, Safari just pauses until the `fetchPage` is complete
       // then scrolls to the cell
       setTimeout(() => {


### PR DESCRIPTION
When a `&page=` parameter is set initially on a page equipped with collection browser, it is intended to scroll immediately to that page in the infinite scroller. However, recently this has been flaky especially on our profile pages, where usage of collection browser across multiple tabs slightly complicates the setup, resulting in the scroll being attempted before the infinite scroller has begun rendering enough placeholder items to provide a scroll target.

This PR just ensures that if we try to perform that initial page scroll before the infinite scroller is ready to handle it, that we instead just set a flag and postpone the scroll until it becomes possible.