### PR TITLE
WEBDEV-7397 Improved flexibility for handling mange view

### DIFF
--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -255,6 +255,12 @@ export interface CollectionBrowserDataSourceInterface
   setPageSize(pageSize: number): void;
 
   /**
+   * Sets the total number of pages that should be batched together on each initial fetch.
+   * @param pages How many initial pages to batch
+   */
+  setNumInitialPages(numPages: number): void;
+
+  /**
    * Sets the total result count for this data source to the given value.
    * @param count The number of total results to set
    */

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -50,6 +50,12 @@ export class CollectionBrowserDataSource
   private numTileModels = 0;
 
   /**
+   * How many consecutive pages should be batched together on the initial page fetch.
+   * Defaults to 2 pages.
+   */
+  private numInitialPages = 2;
+
+  /**
    * A set of fetch IDs that are valid for the current query state
    */
   private fetchesInProgress = new Set<string>();
@@ -358,6 +364,13 @@ export class CollectionBrowserDataSource
   setPageSize(pageSize: number): void {
     this.reset();
     this.pageSize = pageSize;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  setNumInitialPages(numPages: number): void {
+    this.numInitialPages = numPages;
   }
 
   /**
@@ -997,7 +1010,7 @@ export class CollectionBrowserDataSource
   private async doInitialPageFetch(): Promise<void> {
     this.setSearchResultsLoading(true);
     // Try to batch 2 initial page requests when possible
-    await this.fetchPage(this.host.initialPageNumber, 2);
+    await this.fetchPage(this.host.initialPageNumber, this.numInitialPages);
   }
 
   /**

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1830,6 +1830,30 @@ describe('Collection Browser', () => {
     expect(el.dataSource.uncheckedTileModels.length).to.equal(2);
   });
 
+  it('emits event when manage view state changes', async () => {
+    const spy = sinon.spy();
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .baseNavigationUrl=${''}
+        @manageModeChanged=${spy}
+      ></collection-browser>`,
+    );
+
+    el.isManageView = true;
+    await el.updateComplete;
+
+    expect(spy.callCount).to.equal(1);
+    expect(spy.args[0][0]?.detail).to.be.true;
+
+    el.isManageView = false;
+    await el.updateComplete;
+
+    expect(spy.callCount).to.equal(2);
+    expect(spy.args[1][0]?.detail).to.be.false;
+  });
+
   it('emits event when item removal requested', async () => {
     const spy = sinon.spy();
     const searchService = new MockSearchService();

--- a/test/data-source/collection-browser-data-source.test.ts
+++ b/test/data-source/collection-browser-data-source.test.ts
@@ -101,6 +101,20 @@ describe('Collection Browser Data Source', () => {
     expect(pageFetchSpy.callCount).to.equal(0);
   });
 
+  it('can set its initial page batch size', async () => {
+    host.searchService = new MockSearchService();
+
+    const pageFetchSpy = sinon.spy();
+    const dataSource = new CollectionBrowserDataSource(host);
+    dataSource.setNumInitialPages(10);
+    dataSource.fetchPage = pageFetchSpy;
+
+    dataSource.handleQueryChange();
+
+    // Uses specified number of initial pages
+    expect(pageFetchSpy.args[0][1]).to.equal(10);
+  });
+
   it('refreshes prefix filter counts', () => {
     const dataSource = new CollectionBrowserDataSource(host);
     dataSource.addPage(1, dataPage);


### PR DESCRIPTION
Broadens the conditions under which manage view can be enabled w/ a larger result set, and adds a data source method to adjust how many pages are loaded accordingly. Also corrects the `manageModeChanged` event to only emit when its value is _actually changed_, not when it is first set to its initial value.