### PR TITLE
WEBDEV-7386 Distinguish favorited searches from items in removal requests

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -815,9 +815,12 @@ export class CollectionBrowser
     this.dispatchEvent(
       new CustomEvent<{ items: string[] }>('itemRemovalRequested', {
         detail: {
-          items: this.dataSource.checkedTileModels.map(model =>
-            model?.identifier ? model.identifier : '',
-          ),
+          items: this.dataSource.checkedTileModels.map(model => {
+            // For favorited searches, we attach a search: prefix to differentiate it from an item
+            const searchPrefix = model?.mediatype === 'search' ? 'search:' : '';
+            const identifier = model?.identifier ? model.identifier : '';
+            return `${searchPrefix}${identifier}`;
+          }),
         },
       }),
     );


### PR DESCRIPTION
Ensures that when removing one's favorites, favorited search queries are distinguished from ordinary items so that there is no ambiguity in what is to be removed.