### PR TITLE
Update GH runner for pr-preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -16,7 +16,7 @@ concurrency: preview-${{ github.ref }}
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes:

- `ubuntu-20.04` is now deprecated, we should use `ubuntu-latest` instead to prevent this in the future

<img width="1191" alt="Screenshot 2025-04-25 at 08 05 25" src="https://github.com/user-attachments/assets/6582c676-0e68-4988-a1a5-328e9251ae58" />
