### PR TITLE
WEBDEV-7167 Fix broken unit tests

### DIFF
--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -360,7 +360,7 @@ describe('Collection Browser', () => {
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
-    await nextTick();
+    await el.initialSearchComplete;
 
     expect(searchService.searchParams?.query).to.equal('collection:foo');
     expect(searchService.searchType).to.equal(SearchType.FULLTEXT);
@@ -940,6 +940,7 @@ describe('Collection Browser', () => {
     el.sortDirection = 'asc';
     el.selectedCreatorFilter = 'X';
     await el.updateComplete;
+    await el.initialSearchComplete;
     await nextTick();
 
     expect(searchService.searchParams?.query).to.equal('first-creator');
@@ -1005,7 +1006,7 @@ describe('Collection Browser', () => {
     expect(el.maxSelectedDate).to.equal('2000');
   });
 
-  it('emits event when loading state changes', async () => {
+  it('emits event when results start and end loading', async () => {
     const spy = sinon.spy();
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
@@ -1014,6 +1015,7 @@ describe('Collection Browser', () => {
         @searchResultsLoadingChanged=${spy}
       ></collection-browser>`,
     );
+    spy.resetHistory();
 
     el.baseQuery = 'collection:foo';
     await el.updateComplete;
@@ -1040,17 +1042,10 @@ describe('Collection Browser', () => {
     await el.updateComplete;
     await aTimeout(50);
 
-    const infiniteScroller = el.shadowRoot?.querySelector('infinite-scroller');
-    expect(infiniteScroller).to.exist;
-
-    const firstResult =
-      infiniteScroller!.shadowRoot?.querySelector('tile-dispatcher');
-    expect(firstResult).to.exist;
-
     // Original href q param starts/ends with %22%22, but should be collapsed to %22 before render
-    expect(
-      firstResult!.shadowRoot?.querySelector('a[href]')?.getAttribute('href'),
-    ).to.equal('/details/foo?q=%22quoted+query%22');
+    expect(el.dataSource.getTileModelAt(0)?.href).to.equal(
+      '/details/foo?q=%22quoted+query%22',
+    );
   });
 
   it('sets default sort from collection metadata', async () => {

--- a/test/tile-stats.test.ts
+++ b/test/tile-stats.test.ts
@@ -34,22 +34,23 @@ describe('Tile Stats', () => {
     // get second column item in stats row
     const itemStatCount = statsRow?.children
       .item(1)
-      ?.querySelector('.status-text')?.textContent;
+      ?.querySelector('.status-text')
+      ?.textContent?.trim();
     // get third column item in stats row
     const favoritesStatCount = statsRow?.children
       .item(2)
-      ?.querySelector('.status-text')?.textContent;
+      ?.querySelector('.status-text')
+      ?.textContent?.trim();
     // get fourth column item in stats row
     const reviewsStatCount = statsRow?.children
       .item(3)
-      ?.querySelector('.status-text')?.textContent;
+      ?.querySelector('.status-text')
+      ?.textContent?.trim();
 
     expect(mediatypeStat).to.exist;
-
-    // Snapshot testing - reference: https://open-wc.org/docs/testing/semantic-dom-diff/#snapshot-testing
-    expect(itemStatCount).to.equalSnapshot(1);
-    expect(favoritesStatCount).to.equalSnapshot(2);
-    expect(reviewsStatCount).to.equalSnapshot(3);
+    expect(itemStatCount).to.match(/Uploads:\s+1/);
+    expect(favoritesStatCount).to.match(/Favorites:\s+2/);
+    expect(reviewsStatCount).to.match(/Reviews:\s+3/);
   });
 
   it('should render view count for non-account items', async () => {


### PR DESCRIPTION
Some of our unit tests have been failing both on unrelated features branches and on `main`, for reasons mostly unrelated to the actual behavior being tested. This PR updates them for greater reliability and ensure they are less susceptible to quirks of timing.