### PR TITLE
WEBDEV-7587 Do not purge ongoing facet requests when resetting pages

### DIFF
--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -156,7 +156,7 @@ export interface CollectionBrowserDataSourceInterface
   reset(): void;
 
   /**
-   * Resets the data source to its pages.
+   * Resets the data source's result pages, keeping other state intact.
    */
   resetPages(): void;
 

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -258,8 +258,10 @@ export class CollectionBrowserDataSource
     if (Object.keys(this.pages).length < this.host.maxPagesToManage) {
       this.pages = {};
 
-      // Invalidate any fetches in progress
-      this.fetchesInProgress.clear();
+      // Invalidate any page fetches in progress (keep facet fetches)
+      this.fetchesInProgress.forEach(key => {
+        if (!key.startsWith('facets-')) this.fetchesInProgress.delete(key);
+      });
       this.requestHostUpdate();
     }
   }
@@ -676,7 +678,7 @@ export class CollectionBrowserDataSource
   get facetFetchQueryKey(): string {
     const profileKey = `pf;${this.host.withinProfile}--pe;${this.host.profileElement}`;
     const pageTarget = this.host.withinCollection ?? profileKey;
-    return `fq:${this.fullQuery}-pt:${pageTarget}-st:${this.host.searchType}`;
+    return `facets-fq:${this.fullQuery}-pt:${pageTarget}-st:${this.host.searchType}`;
   }
 
   /**


### PR DESCRIPTION
When the management UI is opened, we attempt to load a larger first page of results, which entails resetting any pages that have been loaded in already. Currently this invalidates _all_ fetches in progress by the data source, including facet fetches.

However, since the facets will be the same with either result set, we do still want those fetches to succeed. This PR ensures we do not invalidate facet fetches when resetting the result pages for item management.