### PR TITLE
WEBDEV-7610 Check default sort applied by PPS instead of metadata

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1992,13 +1992,12 @@ export class CollectionBrowser
   }
 
   /**
-   * Applies any default sort option for the current collection, by checking
-   * for one in the collection's metadata. If none is found, defaults to sorting
-   * descending by:
+   * Applies any default sort option for the current collection, using the sort applied
+   * by the backend if applicable. If none is found, defaults to sorting descending by:
    *  - Date Favorited for fav-* collections
    *  - Weekly views for all other collections
    */
-  applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo): void {
+  applyDefaultCollectionSort(backendSort?: string): void {
     if (this.baseQuery) {
       // If there's a query set, then we default to relevance sorting regardless of
       // the collection metadata-specified sort.
@@ -2009,17 +2008,14 @@ export class CollectionBrowser
 
     // Favorite collections sort on Date Favorited by default.
     // Other collections fall back to sorting on weekly views.
-    const baseDefaultSort: string =
-      collectionInfo?.public_metadata?.identifier?.startsWith('fav-')
-        ? '-favoritedate'
-        : '-week';
+    const baseDefaultSort: string = this.withinCollection?.startsWith('fav-')
+      ? '-favoritedate'
+      : '-week';
 
-    // The collection metadata may override the default sorting with something else
-    const metadataSort: string | undefined =
-      collectionInfo?.public_metadata?.['sort-by'];
-
-    // Prefer the metadata-specified sort if one exists
-    const defaultSortToApply = metadataSort ?? baseDefaultSort;
+    // The PPS may override the default sorting with something else
+    // E.g., sort-by metadata, or TV collection defaults
+    // Prefer the backend-specified sort if one exists
+    const defaultSortToApply = backendSort ?? baseDefaultSort;
 
     // Account for both -field and field:dir formats
     let [field, dir] = defaultSortToApply.split(':');

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1139,7 +1139,7 @@ export class CollectionBrowserDataSource
         // Normalize any backend-applied sort to an array and take the first element.
         // This accounts for the backend sort being a string, a string[], or undefined entirely.
         const backendSortRaw =
-          success.request.backendRequests['search'].finalized_parameters.sort;
+          success.request.backendRequests['search']?.finalized_parameters.sort;
         const backendSort = ([] as (string | undefined)[]).concat(
           backendSortRaw,
         )?.[0];

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1136,7 +1136,14 @@ export class CollectionBrowserDataSource
       // For collections, we want the UI to respect the default sort option
       // which can be specified in metadata, or otherwise assumed to be week:desc
       if (this.activeOnHost) {
-        this.host.applyDefaultCollectionSort(this.collectionExtraInfo);
+        // Normalize any backend-applied sort to an array and take the first element.
+        // This accounts for the backend sort being a string, a string[], or undefined entirely.
+        const backendSortRaw =
+          success.request.backendRequests['search'].finalized_parameters.sort;
+        const backendSort = ([] as (string | undefined)[]).concat(
+          backendSortRaw,
+        )?.[0];
+        this.host.applyDefaultCollectionSort(backendSort);
       }
 
       if (this.collectionExtraInfo) {

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -49,7 +49,7 @@ export interface CollectionBrowserSearchInterface
   setFacetsLoading(loading: boolean): void;
   setTotalResultCount(count: number): void;
   setTileCount(count: number): void;
-  applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo): void;
+  applyDefaultCollectionSort(backendSort?: string): void;
   emitEmptyResults(): void;
   emitQueryStateChanged(): void;
   refreshVisibleResults(): void;

--- a/src/models.ts
+++ b/src/models.ts
@@ -449,7 +449,7 @@ export const SORT_OPTIONS: Record<SortField, SortOption> = {
     handledBySearchService: false,
     searchServiceKey: 'favoritedate',
     displayName: 'Date favorited',
-    urlNames: ['favoritedate'],
+    urlNames: ['favoritedate', 'date_favorited'],
   },
   [SortField.creator]: {
     field: SortField.creator,

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1092,7 +1092,7 @@ describe('Collection Browser', () => {
     );
   });
 
-  it('sets default sort from collection metadata', async () => {
+  it('sets default sort from backend applied sort', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
@@ -1117,7 +1117,7 @@ describe('Collection Browser', () => {
     expect(sortBar.sortDirection).to.be.null;
   });
 
-  it('sets default sort from collection metadata in "-field" format', async () => {
+  it('sets default sort from backend applied sort in "-field" format', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -723,7 +723,7 @@ export const getMockSuccessWithDefaultSort: () => Result<
         sort: [],
       },
       backendRequests: {
-        primary: {
+        search: {
           kind: 'hits',
           finalized_parameters: {
             user_query: 'default-sort',
@@ -770,7 +770,7 @@ export const getMockSuccessWithConciseDefaultSort: () => Result<
         sort: [],
       },
       backendRequests: {
-        primary: {
+        search: {
           kind: 'hits',
           finalized_parameters: {
             user_query: 'default-sort-concise',

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -745,11 +745,6 @@ export const getMockSuccessWithDefaultSort: () => Result<
           },
         }),
       ],
-      collectionExtraInfo: {
-        public_metadata: {
-          'sort-by': 'titleSorter',
-        },
-      },
     },
     responseHeader: {
       succeeded: true,
@@ -792,11 +787,6 @@ export const getMockSuccessWithConciseDefaultSort: () => Result<
           },
         }),
       ],
-      collectionExtraInfo: {
-        public_metadata: {
-          'sort-by': '-addeddate',
-        },
-      },
     },
     responseHeader: {
       succeeded: true,


### PR DESCRIPTION
Currently to determine the default sort option to select for a collection, we check for its `sort-by` metadata and fall back to global defaults otherwise. However, TV collections have their own default that is not always specified in metadata. And since we can't always identify TV collections until after receiving a PPS response, we need to rely on the PPS layer to both apply and inform the client of the correct default sort.

This PR updates how we determine which sort option to select, relying on the PPS's finalized request parameters rather than the collection metadata for this purpose.