### PR TITLE
WEBDEV-7687 Support filters on TV clip types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",
     "@internetarchive/modal-manager": "^2.0.1",
-    "@internetarchive/search-service": "2.3.2-alpha-webdev7687.0",
+    "@internetarchive/search-service": "^2.3.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.12.2",
     "dompurify": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",
     "@internetarchive/modal-manager": "^2.0.1",
-    "@internetarchive/search-service": "^2.2.1",
+    "@internetarchive/search-service": "2.3.2-alpha-webdev7687.0",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.12.2",
     "dompurify": "^3.2.4",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -132,7 +132,7 @@ export class CollectionBrowser
 
   @property({ type: String }) selectedCreatorFilter: string | null = null;
 
-  @property({ type: String }) tvClipFilter?: TvClipFilterType = 'all';
+  @property({ type: String }) tvClipFilter: TvClipFilterType = 'all';
 
   @property({ type: String }) sortDirection: SortDirection | null = null;
 
@@ -1895,7 +1895,7 @@ export class CollectionBrowser
     this.currentPage = restorationState.currentPage ?? 1;
     this.minSelectedDate = restorationState.minSelectedDate;
     this.maxSelectedDate = restorationState.maxSelectedDate;
-    this.tvClipFilter = restorationState.tvClipFilter;
+    this.tvClipFilter = restorationState.tvClipFilter ?? 'all';
     if (this.currentPage > 1) {
       this.goToPage(this.currentPage);
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -132,7 +132,7 @@ export class CollectionBrowser
 
   @property({ type: String }) selectedCreatorFilter: string | null = null;
 
-  @property({ type: String }) tvClipFilter: TvClipFilterType = 'all';
+  @property({ type: String }) tvClipFilter?: TvClipFilterType = 'all';
 
   @property({ type: String }) sortDirection: SortDirection | null = null;
 
@@ -1895,6 +1895,7 @@ export class CollectionBrowser
     this.currentPage = restorationState.currentPage ?? 1;
     this.minSelectedDate = restorationState.minSelectedDate;
     this.maxSelectedDate = restorationState.maxSelectedDate;
+    this.tvClipFilter = restorationState.tvClipFilter;
     if (this.currentPage > 1) {
       this.goToPage(this.currentPage);
     }
@@ -1915,6 +1916,7 @@ export class CollectionBrowser
       maxSelectedDate: this.maxSelectedDate,
       selectedTitleFilter: this.selectedTitleFilter ?? undefined,
       selectedCreatorFilter: this.selectedCreatorFilter ?? undefined,
+      tvClipFilter: this.tvClipFilter,
     };
     const persistOptions: RestorationStatePersistOptions = {
       forceReplace: this.dataSourceInstallInProgress,

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -45,6 +45,7 @@ import {
   FacetLoadStrategy,
   defaultFacetDisplayOrder,
   tvFacetDisplayOrder,
+  TvClipFilterType,
 } from './models';
 import {
   RestorationStateHandlerInterface,
@@ -130,6 +131,8 @@ export class CollectionBrowser
   @property({ type: String }) selectedTitleFilter: string | null = null;
 
   @property({ type: String }) selectedCreatorFilter: string | null = null;
+
+  @property({ type: String }) tvClipFilter: TvClipFilterType = 'all';
 
   @property({ type: String }) sortDirection: SortDirection | null = null;
 
@@ -1300,6 +1303,7 @@ export class CollectionBrowser
     this.sortDirection = queryState.sortDirection;
     this.selectedTitleFilter = queryState.selectedTitleFilter;
     this.selectedCreatorFilter = queryState.selectedCreatorFilter;
+    this.tvClipFilter = queryState.tvClipFilter ?? 'all';
 
     // We set this flag during the update to prevent the URL state persistence
     // from creating an unwanted extra history entry.
@@ -1727,6 +1731,7 @@ export class CollectionBrowser
           sortDirection: this.sortDirection,
           selectedTitleFilter: this.selectedTitleFilter,
           selectedCreatorFilter: this.selectedCreatorFilter,
+          tvClipFilter: this.tvClipFilter,
         },
       }),
     );

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -751,6 +751,24 @@ export class CollectionBrowserDataSource
       );
     }
 
+    // Add any TV clip type filter, if applicable
+    if (this.host.searchType === SearchType.TV) {
+      switch (this.host.tvClipFilter) {
+        case 'commercials':
+          builder.addFilter('ad_id', '*', FilterConstraint.INCLUDE);
+          break;
+        case 'factchecks':
+          builder.addFilter('factcheck', '*', FilterConstraint.INCLUDE);
+          break;
+        case 'quotes':
+          builder.addFilter('clip', '1', FilterConstraint.INCLUDE);
+          break;
+        case 'all':
+        default:
+          break;
+      }
+    }
+
     const filterMap = builder.build();
     return filterMap;
   }

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -6,7 +6,12 @@ import type {
   SortDirection,
   SortParam,
 } from '@internetarchive/search-service';
-import type { FacetLoadStrategy, SelectedFacets, SortField } from '../models';
+import type {
+  FacetLoadStrategy,
+  SelectedFacets,
+  SortField,
+  TvClipFilterType,
+} from '../models';
 import type { CollectionBrowserDataSourceInterface } from './collection-browser-data-source-interface';
 
 /**
@@ -23,6 +28,7 @@ export interface CollectionBrowserQueryState {
   maxSelectedDate?: string;
   selectedTitleFilter: string | null;
   selectedCreatorFilter: string | null;
+  tvClipFilter?: TvClipFilterType;
   selectedSort?: SortField;
   sortDirection: SortDirection | null;
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -629,6 +629,11 @@ export const getDefaultSelectedFacets = (): Required<SelectedFacets> => ({
 });
 
 /**
+ * For TV search results, what types of TV clips to restrict the results to.
+ */
+export type TvClipFilterType = 'all' | 'commercials' | 'factchecks' | 'quotes';
+
+/**
  * Facet display order when presenting results for all search types *except* TV (see below).
  */
 export const defaultFacetDisplayOrder: FacetOption[] = [

--- a/src/models.ts
+++ b/src/models.ts
@@ -54,11 +54,16 @@ export type HitRequestSource =
  * Class for converting & storing raw search results in the correct format for UI tiles.
  */
 export class TileModel {
+  /** For TV hits. List of identifiers for any commercials contained. */
+  adIds?: string[];
+
   averageRating?: number;
 
-  captureDates?: Date[]; // List of capture dates for a URL, used on profile Web Archives tiles
+  /** For Web Archive hits on profile pages. List of capture dates for the current URL. */
+  captureDates?: Date[];
 
-  checked: boolean; // Whether this tile is currently checked for item management functions
+  /** Whether this tile is currently checked for item management functions */
+  checked: boolean;
 
   collectionIdentifier?: string;
 
@@ -76,17 +81,25 @@ export class TileModel {
 
   creators: string[];
 
-  dateStr?: string; // A string representation of the publication date, used strictly for passing preformatted dates to the parent
+  /** A string representation of the publication date, used strictly for passing preformatted dates to the parent */
+  dateStr?: string;
 
-  dateAdded?: Date; // Date added to public search (software-defined) [from: addeddate]
+  /** Date added to public search (software-defined) [from MD field: addeddate] */
+  dateAdded?: Date;
 
-  dateArchived?: Date; // Date archived (software-defined) item created on archive.org [from: publicdate]
+  /** Date archived (software-defined) item created on archive.org [from MD field: publicdate] */
+  dateArchived?: Date;
 
-  datePublished?: Date; // Date work published in the world (user-defined) [from: date]
+  /** Date work published in the world (user-defined) [from MD field: date] */
+  datePublished?: Date;
 
-  dateReviewed?: Date; // Date reviewed (user-created) most recent review [from: reviewdate]
+  /** Date reviewed (user-created) most recent review [from MD field: reviewdate] */
+  dateReviewed?: Date;
 
   description?: string;
+
+  /** For TV hits. List of URLs for any fact-checks of the contained clips. */
+  factChecks?: string[];
 
   favCount: number;
 
@@ -97,6 +110,9 @@ export class TileModel {
   href?: string;
 
   identifier?: string;
+
+  /** Whether this model represents a TV clip */
+  isClip?: boolean;
 
   issue?: string;
 
@@ -134,6 +150,7 @@ export class TileModel {
   ) {
     const flags = this.getFlags(result);
 
+    this.adIds = result.ad_id?.values;
     this.averageRating = result.avg_rating?.value;
     this.captureDates = result.capture_dates?.values;
     this.checked = false;
@@ -148,6 +165,7 @@ export class TileModel {
     this.datePublished = result.date?.value;
     this.dateReviewed = result.reviewdate?.value;
     this.description = result.description?.values.join('\n');
+    this.factChecks = result.factcheck?.values;
     this.favCount = result.num_favorites?.value ?? 0;
     this.hitRequestSource = hitRequestSource;
     this.hitType = result.rawMetadata?.hit_type;
@@ -155,6 +173,7 @@ export class TileModel {
       result.review?.__href__ ?? result.__href__?.value,
     );
     this.identifier = TileModel.cleanIdentifier(result.identifier);
+    this.isClip = result.is_clip?.value;
     this.issue = result.issue?.value;
     this.itemCount = result.item_count?.value ?? 0;
     this.mediatype = resolveMediatype(result);
@@ -177,6 +196,7 @@ export class TileModel {
    */
   clone(): TileModel {
     const cloned = new TileModel({});
+    cloned.adIds = this.adIds;
     cloned.averageRating = this.averageRating;
     cloned.captureDates = this.captureDates;
     cloned.checked = this.checked;
@@ -192,11 +212,13 @@ export class TileModel {
     cloned.datePublished = this.datePublished;
     cloned.dateReviewed = this.dateReviewed;
     cloned.description = this.description;
+    cloned.factChecks = this.factChecks;
     cloned.favCount = this.favCount;
     cloned.hitRequestSource = this.hitRequestSource;
     cloned.hitType = this.hitType;
     cloned.href = this.href;
     cloned.identifier = this.identifier;
+    cloned.isClip = this.isClip;
     cloned.issue = this.issue;
     cloned.itemCount = this.itemCount;
     cloned.mediatype = this.mediatype;

--- a/src/models.ts
+++ b/src/models.ts
@@ -656,6 +656,25 @@ export const getDefaultSelectedFacets = (): Required<SelectedFacets> => ({
 export type TvClipFilterType = 'all' | 'commercials' | 'factchecks' | 'quotes';
 
 /**
+ * Map from TV clip filter types to their corresponding URL params
+ */
+export const tvClipFiltersToURLParams: Record<TvClipFilterType, string> = {
+  all: '',
+  commercials: 'only_commercials',
+  factchecks: 'only_factchecks',
+  quotes: 'only_quotes',
+};
+
+/**
+ * Map from allowed TV filtering parameters in the URL to their corresponding filter type
+ */
+export const tvClipURLParamsToFilters: Record<string, TvClipFilterType> = {
+  only_commercials: 'commercials',
+  only_factchecks: 'factchecks',
+  only_quotes: 'quotes',
+};
+
+/**
  * Facet display order when presenting results for all search types *except* TV (see below).
  */
 export const defaultFacetDisplayOrder: FacetOption[] = [

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -509,6 +509,9 @@ export class RestorationStateHandler
     // Also remove some legacy params that should have been upgraded to the ones above
     searchParams.delete('q');
     searchParams.delete('search');
+    searchParams.delete('only_commercials');
+    searchParams.delete('only_factchecks');
+    searchParams.delete('only_quotes');
 
     return searchParams;
   }

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -5,6 +5,7 @@ import {
   CollectionBrowserContext,
   CollectionDisplayMode,
   SelectedFacets,
+  TvClipFilterType,
   SortField,
   FacetBucket,
   FacetState,
@@ -28,6 +29,7 @@ export interface RestorationState {
   maxSelectedDate?: string;
   selectedTitleFilter?: string;
   selectedCreatorFilter?: string;
+  tvClipFilter?: TvClipFilterType;
 }
 
 export interface RestorationStatePersistOptions {
@@ -204,6 +206,21 @@ export class RestorationStateHandler
 
     if (state.creatorQuery) {
       newParams.append('and[]', state.creatorQuery);
+    }
+
+    // TV clip special filters
+    switch (state.tvClipFilter) {
+      case 'commercials':
+        newParams.append('only_commercials', '1');
+        break;
+      case 'factchecks':
+        newParams.append('only_factchecks', '1');
+        break;
+      case 'quotes':
+        newParams.append('only_quotes', '1');
+        break;
+      default:
+      // Don't add anything to the URL
     }
 
     // Ensure we aren't pushing consecutive identical states to the history stack.
@@ -396,6 +413,20 @@ export class RestorationStateHandler
           'hidden',
         );
       });
+    }
+
+    // TV clip special filters (carryovers from legacy page)
+    const commercialsParam = url.searchParams.get('only_commercials');
+    const factchecksParam = url.searchParams.get('only_factchecks');
+    const quotesParam = url.searchParams.get('only_quotes');
+    if (commercialsParam) {
+      restorationState.tvClipFilter = 'commercials';
+    } else if (factchecksParam) {
+      restorationState.tvClipFilter = 'factchecks';
+    } else if (quotesParam) {
+      restorationState.tvClipFilter = 'quotes';
+    } else {
+      restorationState.tvClipFilter = 'all';
     }
 
     return restorationState;

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -68,6 +68,7 @@ export class ItemTile extends BaseTileComponent {
           </div>
 
           <tile-stats
+            .model=${this.model}
             .mediatype=${this.model?.mediatype}
             .collections=${this.model?.collections}
             .viewCount=${viewCount}

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -10,9 +10,13 @@ import { quoteIcon } from '../../assets/img/icons/quote';
 import { srOnlyStyle } from '../../styles/sr-only';
 
 import { formatCount } from '../../utils/format-count';
+import { TileModel } from '../../models';
 
 @customElement('tile-stats')
 export class TileStats extends LitElement {
+  /** The tile model these stats represent */
+  @property({ type: Object }) model?: TileModel;
+
   /** The mediatype of the item these stats represent */
   @property({ type: String }) mediatype?: string;
 
@@ -71,6 +75,7 @@ export class TileStats extends LitElement {
       <li class="col">
         <p class="sr-only">${msg('Mediatype:')}</p>
         <tile-mediatype-icon
+          .model=${this.model}
           .mediatype=${this.mediatype}
           .collections=${this.collections}
           ?isTvSearchResult=${this.isTvSearchResult}

--- a/src/tiles/grid/tile-stats.ts
+++ b/src/tiles/grid/tile-stats.ts
@@ -74,12 +74,7 @@ export class TileStats extends LitElement {
     return html`
       <li class="col">
         <p class="sr-only">${msg('Mediatype:')}</p>
-        <tile-mediatype-icon
-          .model=${this.model}
-          .mediatype=${this.mediatype}
-          .collections=${this.collections}
-          ?isTvSearchResult=${this.isTvSearchResult}
-        ></tile-mediatype-icon>
+        <tile-mediatype-icon .model=${this.model}></tile-mediatype-icon>
       </li>
     `;
   }

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -51,6 +51,7 @@ export class TileListCompact extends BaseTileComponent {
         <div id="date">${formatDate(this.date, this.dateFormatSize)}</div>
         <div id="icon">
           <tile-mediatype-icon
+            .model=${this.model}
             .mediatype=${this.model?.mediatype}
             .collections=${this.model?.collections}
             ?isTvSearchResult=${this.model?.isTvSearchResult}

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -50,13 +50,7 @@ export class TileListCompact extends BaseTileComponent {
         </div>
         <div id="date">${formatDate(this.date, this.dateFormatSize)}</div>
         <div id="icon">
-          <tile-mediatype-icon
-            .model=${this.model}
-            .mediatype=${this.model?.mediatype}
-            .collections=${this.model?.collections}
-            ?isTvSearchResult=${this.model?.isTvSearchResult}
-          >
-          </tile-mediatype-icon>
+          <tile-mediatype-icon .model=${this.model}> </tile-mediatype-icon>
         </div>
         <div id="views">${formatCount(this.views ?? 0, this.formatSize)}</div>
       </div>

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -126,13 +126,7 @@ export class TileList extends BaseTileComponent {
   private get iconRightTemplate() {
     return html`
       <a id="icon-right" href=${this.mediatypeURL}>
-        <tile-mediatype-icon
-          .model=${this.model}
-          .mediatype=${this.model?.mediatype}
-          .collections=${this.model?.collections}
-          ?isTvSearchResult=${this.model?.isTvSearchResult}
-        >
-        </tile-mediatype-icon>
+        <tile-mediatype-icon .model=${this.model}> </tile-mediatype-icon>
       </a>
     `;
   }

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -127,6 +127,7 @@ export class TileList extends BaseTileComponent {
     return html`
       <a id="icon-right" href=${this.mediatypeURL}>
         <tile-mediatype-icon
+          .model=${this.model}
           .mediatype=${this.model?.mediatype}
           .collections=${this.model?.collections}
           ?isTvSearchResult=${this.model?.isTvSearchResult}

--- a/src/tiles/tile-mediatype-icon.ts
+++ b/src/tiles/tile-mediatype-icon.ts
@@ -5,7 +5,7 @@ import {
   mediatypeConfig,
   MediatypeConfigKey,
 } from '../mediatype/mediatype-config';
-import { TileModel } from '../models';
+import type { TileModel } from '../models';
 
 const TV_COLLECTIONS = new Set(['tvnews', 'tvarchive', 'television']);
 const RADIO_COLLECTIONS = new Set(['radio', 'radioprogram']);

--- a/src/tiles/tile-mediatype-icon.ts
+++ b/src/tiles/tile-mediatype-icon.ts
@@ -7,18 +7,14 @@ import {
 } from '../mediatype/mediatype-config';
 import type { TileModel } from '../models';
 
+const TV_COMMERCIAL_COLLECTION = 'tv_ads';
+const TV_FACT_CHECK_COLLECTION = 'factchecked';
 const TV_COLLECTIONS = new Set(['tvnews', 'tvarchive', 'television']);
 const RADIO_COLLECTIONS = new Set(['radio', 'radioprogram']);
 
 @customElement('tile-mediatype-icon')
 export class TileMediatypeIcon extends LitElement {
-  @property({ type: String }) mediatype?: MediatypeConfigKey;
-
   @property({ type: Object }) model?: TileModel;
-
-  @property({ type: Array }) collections?: string[];
-
-  @property({ type: Boolean }) isTvSearchResult = false;
 
   @property({ type: Boolean }) showText = false;
 
@@ -28,7 +24,7 @@ export class TileMediatypeIcon extends LitElement {
   private get displayMediatype(): MediatypeConfigKey {
     if (this.isTvItem) return this.tvDisplayMediatype;
     if (this.isRadioItem) return 'radio';
-    return this.mediatype ?? 'none';
+    return this.model?.mediatype ?? 'none';
   }
 
   /**
@@ -37,9 +33,9 @@ export class TileMediatypeIcon extends LitElement {
   private get tvDisplayMediatype(): MediatypeConfigKey {
     if (this.isTvCommercial) {
       return 'tvCommercial';
-    } else if (this.isTvSearchResult && this.isTvFactCheck) {
+    } else if (this.model?.isTvSearchResult && this.isTvFactCheck) {
       return 'tvFactCheck';
-    } else if (this.isTvSearchResult && this.isTvQuote) {
+    } else if (this.model?.isTvSearchResult && this.isTvQuote) {
       return 'tvQuote';
     }
 
@@ -50,20 +46,26 @@ export class TileMediatypeIcon extends LitElement {
    * Whether this represents a TV item
    */
   private get isTvItem(): boolean {
-    return (
-      this.mediatype === 'movies' &&
-      !!this.collections?.some(id => TV_COLLECTIONS.has(id))
+    return !!(
+      this.model?.mediatype === 'movies' &&
+      this.model?.collections.some(id => TV_COLLECTIONS.has(id))
     );
   }
 
   private get isTvCommercial(): boolean {
-    // Contains one or more TV ad identifiers
-    return !!this.model?.adIds?.length;
+    // Contains one or more TV ad identifiers or is in the tv_ads collection
+    return !!(
+      this.model?.adIds?.length ||
+      this.model?.collections.includes(TV_COMMERCIAL_COLLECTION)
+    );
   }
 
   private get isTvFactCheck(): boolean {
-    // Contains one or more fact-check URLs
-    return !!this.model?.factChecks?.length;
+    // Contains one or more fact-check URLs or is in the factchecked collection
+    return !!(
+      this.model?.factChecks?.length ||
+      this.model?.collections.includes(TV_FACT_CHECK_COLLECTION)
+    );
   }
 
   private get isTvQuote(): boolean {
@@ -74,9 +76,9 @@ export class TileMediatypeIcon extends LitElement {
    * Whether this represents a radio item
    */
   private get isRadioItem(): boolean {
-    return (
-      this.mediatype === 'audio' &&
-      !!this.collections?.some(id => RADIO_COLLECTIONS.has(id))
+    return !!(
+      this.model?.mediatype === 'audio' &&
+      this.model?.collections.some(id => RADIO_COLLECTIONS.has(id))
     );
   }
 

--- a/src/tiles/tile-mediatype-icon.ts
+++ b/src/tiles/tile-mediatype-icon.ts
@@ -5,6 +5,7 @@ import {
   mediatypeConfig,
   MediatypeConfigKey,
 } from '../mediatype/mediatype-config';
+import { TileModel } from '../models';
 
 const TV_COMMERCIAL_COLLECTION = 'tv_ads';
 const TV_FACT_CHECK_COLLECTION = 'factchecked';
@@ -14,6 +15,8 @@ const RADIO_COLLECTIONS = new Set(['radio', 'radioprogram']);
 @customElement('tile-mediatype-icon')
 export class TileMediatypeIcon extends LitElement {
   @property({ type: String }) mediatype?: MediatypeConfigKey;
+
+  @property({ type: Object }) model?: TileModel;
 
   @property({ type: Array }) collections?: string[];
 
@@ -34,13 +37,12 @@ export class TileMediatypeIcon extends LitElement {
    * Returns the appropriate TV mediatype, depending on the current collections.
    */
   private get tvDisplayMediatype(): MediatypeConfigKey {
-    if (this.collections?.includes(TV_COMMERCIAL_COLLECTION)) {
+    if (this.isTvCommercial) {
       return 'tvCommercial';
-    } else if (
-      this.isTvSearchResult &&
-      this.collections?.includes(TV_FACT_CHECK_COLLECTION)
-    ) {
+    } else if (this.isTvSearchResult && this.isTvFactCheck) {
       return 'tvFactCheck';
+    } else if (this.isTvSearchResult && this.isTvQuote) {
+      return 'tvQuote';
     }
 
     return 'tv';
@@ -54,6 +56,20 @@ export class TileMediatypeIcon extends LitElement {
       this.mediatype === 'movies' &&
       !!this.collections?.some(id => TV_COLLECTIONS.has(id))
     );
+  }
+
+  private get isTvCommercial(): boolean {
+    // Contains one or more TV ad identifiers
+    return !!this.model?.adIds?.length;
+  }
+
+  private get isTvFactCheck(): boolean {
+    // Contains one or more fact-check URLs
+    return !!this.model?.factChecks?.length;
+  }
+
+  private get isTvQuote(): boolean {
+    return !!this.model?.isClip;
   }
 
   /**

--- a/src/tiles/tile-mediatype-icon.ts
+++ b/src/tiles/tile-mediatype-icon.ts
@@ -7,8 +7,6 @@ import {
 } from '../mediatype/mediatype-config';
 import { TileModel } from '../models';
 
-const TV_COMMERCIAL_COLLECTION = 'tv_ads';
-const TV_FACT_CHECK_COLLECTION = 'factchecked';
 const TV_COLLECTIONS = new Set(['tvnews', 'tvarchive', 'television']);
 const RADIO_COLLECTIONS = new Set(['radio', 'radioprogram']);
 

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -972,6 +972,60 @@ describe('Collection Browser', () => {
     });
   });
 
+  it('applies correct search filter when TV clip filter set to commercials', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'tv-fields';
+    el.searchType = SearchType.TV;
+    el.tvClipFilter = 'commercials';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.ad_id?.['*']).to.equal(
+      FilterConstraint.INCLUDE,
+    );
+  });
+
+  it('applies correct search filter when TV clip filter set to factchecks', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'tv-fields';
+    el.searchType = SearchType.TV;
+    el.tvClipFilter = 'factchecks';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.factcheck?.['*']).to.equal(
+      FilterConstraint.INCLUDE,
+    );
+  });
+
+  it('applies correct search filter when TV clip filter set to quotes', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'tv-fields';
+    el.searchType = SearchType.TV;
+    el.tvClipFilter = 'quotes';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.clip?.['1']).to.equal(
+      FilterConstraint.INCLUDE,
+    );
+  });
+
   it('resets letter filters when query changes', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(

--- a/test/mocks/mock-search-responses.ts
+++ b/test/mocks/mock-search-responses.ts
@@ -7,6 +7,7 @@ import {
   SearchServiceError,
   TextHit,
 } from '@internetarchive/search-service';
+import { TvClipHit } from '@internetarchive/search-service/dist/src/models/hit-types/tv-clip-hit';
 import { WebArchiveHit } from '@internetarchive/search-service/dist/src/models/hit-types/web-archive-hit';
 import { SearchServiceErrorType } from '@internetarchive/search-service/dist/src/search-service-error';
 
@@ -104,6 +105,73 @@ export const getMockSuccessManyFields: () => Result<
             title: 'Foo Bar',
             volume: 2,
             week: 50,
+            __href__: 'https://archive.org/details/foo',
+            __img__: '//services/img/foo',
+          },
+        }),
+      ],
+    },
+    responseHeader: {
+      succeeded: true,
+      query_time: 0,
+    },
+  },
+});
+
+export const getMockSuccessTvFields: () => Result<
+  SearchResponse,
+  SearchServiceError
+> = () => ({
+  success: {
+    request: {
+      kind: 'hits',
+      clientParameters: {
+        user_query: 'tv-fields',
+        sort: [],
+      },
+      backendRequests: {
+        primary: {
+          kind: 'hits',
+          finalized_parameters: {
+            user_query: 'tv-fields',
+            sort: [],
+          },
+        },
+      },
+    },
+    rawResponse: {},
+    sessionContext: {},
+    response: {
+      totalResults: 1,
+      returnedCount: 1,
+      results: [
+        new TvClipHit({
+          fields: {
+            identifier: 'foo',
+            ad_id: ['foo-ad'],
+            clip: true,
+            collection: ['foo', 'bar', 'tvnews'],
+            creator: ['baz', 'boop'],
+            date: '2010-01-03T01:23:45Z',
+            addeddate: '2010-01-01T01:23:45Z',
+            publicdate: '2010-01-02T01:23:45Z',
+            reviewdate: '2010-01-04T01:23:45Z',
+            description: 'foo bar baz',
+            downloads: 246,
+            factcheck: ['https://foo.bar'],
+            files_count: 75,
+            indexflag: ['index', 'nonoindex'],
+            item_size: 123456,
+            language: 'eng',
+            mediatype: 'movies',
+            num_favorites: 12,
+            nclips: 34,
+            source: 'foo bar',
+            start: '1234',
+            subject: ['baz', 'quux'],
+            title: 'Foo Bar',
+            week: 50,
+            year: 2010,
             __href__: 'https://archive.org/details/foo',
             __img__: '//services/img/foo',
           },

--- a/test/mocks/mock-search-service.ts
+++ b/test/mocks/mock-search-service.ts
@@ -31,6 +31,7 @@ import {
   getMockSuccessNoResults,
   getMockSuccessWithWebArchiveHits,
   getMockSuccessWithManyAggregations,
+  getMockSuccessTvFields,
 } from './mock-search-responses';
 
 const responses: Record<
@@ -56,6 +57,7 @@ const responses: Record<
   'web-archive': getMockSuccessWithWebArchiveHits,
   'more-facets': getMockSuccessWithManyAggregations,
   'many-fields': getMockSuccessManyFields,
+  'tv-fields': getMockSuccessTvFields,
   'no-results': getMockSuccessNoResults,
   error: getMockErrorResult,
   malformed: getMockMalformedResult,

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -1,10 +1,7 @@
 import { SearchType } from '@internetarchive/search-service';
 import { expect } from '@open-wc/testing';
 import { SortField, getDefaultSelectedFacets } from '../src/models';
-import {
-  RestorationState,
-  RestorationStateHandler,
-} from '../src/restoration-state-handler';
+import { RestorationStateHandler } from '../src/restoration-state-handler';
 
 describe('Restoration state handler', () => {
   it('should restore query from URL', async () => {

--- a/test/restoration-state-handler.test.ts
+++ b/test/restoration-state-handler.test.ts
@@ -1,7 +1,10 @@
 import { SearchType } from '@internetarchive/search-service';
 import { expect } from '@open-wc/testing';
 import { SortField, getDefaultSelectedFacets } from '../src/models';
-import { RestorationStateHandler } from '../src/restoration-state-handler';
+import {
+  RestorationState,
+  RestorationStateHandler,
+} from '../src/restoration-state-handler';
 
 describe('Restoration state handler', () => {
   it('should restore query from URL', async () => {
@@ -242,6 +245,35 @@ describe('Restoration state handler', () => {
     );
   });
 
+  it('should restore any TV clip filters from URL', async () => {
+    const handler = new RestorationStateHandler({ context: 'search' });
+    const url = new URL(window.location.href);
+
+    // Commercials
+    url.search = '?only_commercials=1';
+    window.history.replaceState({ path: url.href }, '', url.href);
+    const commercialsRestorationState = handler.getRestorationState();
+    expect(commercialsRestorationState.tvClipFilter).to.equal('commercials');
+
+    // Fact checks
+    url.search = '?only_factchecks=1';
+    window.history.replaceState({ path: url.href }, '', url.href);
+    const factchecksRestorationState = handler.getRestorationState();
+    expect(factchecksRestorationState.tvClipFilter).to.equal('factchecks');
+
+    // Quotes
+    url.search = '?only_quotes=1';
+    window.history.replaceState({ path: url.href }, '', url.href);
+    const quotesRestorationState = handler.getRestorationState();
+    expect(quotesRestorationState.tvClipFilter).to.equal('quotes');
+
+    // No filter param
+    url.search = '';
+    window.history.replaceState({ path: url.href }, '', url.href);
+    const unfilteredRestorationState = handler.getRestorationState();
+    expect(unfilteredRestorationState.tvClipFilter).not.to.exist;
+  });
+
   it('should restore sort from URL (space format)', async () => {
     const handler = new RestorationStateHandler({ context: 'search' });
 
@@ -371,6 +403,44 @@ describe('Restoration state handler', () => {
     });
 
     expect(window.location.search).to.equal('?page=2');
+  });
+
+  it('should persist TV clip filter types to the URL', async () => {
+    const url = new URL(window.location.href);
+    url.search = '';
+    window.history.replaceState({ path: url.href }, '', url.href);
+
+    // Commercials
+    const handler = new RestorationStateHandler({ context: 'search' });
+    handler.persistState({
+      tvClipFilter: 'commercials',
+      selectedFacets: getDefaultSelectedFacets(),
+    });
+    expect(window.location.search).to.equal('?only_commercials=1');
+
+    // Fact checks
+    window.history.replaceState({ path: url.href }, '', url.href);
+    handler.persistState({
+      tvClipFilter: 'factchecks',
+      selectedFacets: getDefaultSelectedFacets(),
+    });
+    expect(window.location.search).to.equal('?only_factchecks=1');
+
+    // Quotes
+    window.history.replaceState({ path: url.href }, '', url.href);
+    handler.persistState({
+      tvClipFilter: 'quotes',
+      selectedFacets: getDefaultSelectedFacets(),
+    });
+    expect(window.location.search).to.equal('?only_quotes=1');
+
+    // Unfiltered
+    window.history.replaceState({ path: url.href }, '', url.href);
+    handler.persistState({
+      tvClipFilter: 'all',
+      selectedFacets: getDefaultSelectedFacets(),
+    });
+    expect(window.location.search).to.equal('');
   });
 
   it('should upgrade legacy search params to new ones', async () => {

--- a/test/tiles/tile-mediatype-icon.test.ts
+++ b/test/tiles/tile-mediatype-icon.test.ts
@@ -3,11 +3,19 @@ import { html } from 'lit';
 import type { TileMediatypeIcon } from '../../src/tiles/tile-mediatype-icon';
 
 import '../../src/tiles/tile-mediatype-icon';
+import { TileModel } from '../../src/models';
+import { MediaType } from '@internetarchive/field-parsers';
 
 describe('Mediatype Icon', () => {
+  let model: TileModel;
+  beforeEach(() => {
+    model = new TileModel({});
+  });
+
   it('renders component', async () => {
+    model.mediatype = 'texts';
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon mediatype="texts"></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon');
@@ -15,8 +23,9 @@ describe('Mediatype Icon', () => {
   });
 
   it('renders basic mediatype correctly', async () => {
+    model.mediatype = 'movies';
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon mediatype="movies"></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
@@ -26,36 +35,60 @@ describe('Mediatype Icon', () => {
   });
 
   it('renders TV mediatype', async () => {
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon
-        mediatype="movies"
-        .collections=${['tvnews']}
-      ></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
     expect(iconDiv.title).to.equal('TV');
   });
 
-  it('renders TV Commercial mediatype', async () => {
+  it('renders TV Commercial mediatype for TV items with ad ids', async () => {
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
+    model.adIds = ['foo'];
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon
-        mediatype="movies"
-        .collections=${['tvnews', 'tv_ads']}
-      ></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
     expect(iconDiv.title).to.equal('TV Commercial');
   });
 
-  it('renders TV Fact Check mediatype for search results', async () => {
+  it('renders TV Commercial mediatype for TV items in tv_ads collection', async () => {
+    model.mediatype = 'movies';
+    model.collections = ['tvnews', 'tv_ads'];
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon
-        isTvSearchResult
-        mediatype="movies"
-        .collections=${['tvnews', 'factchecked']}
-      ></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
+    `);
+
+    const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
+    expect(iconDiv.title).to.equal('TV Commercial');
+  });
+
+  it('renders TV Fact Check mediatype for TV search results with fact check URLs', async () => {
+    model.hitType = 'tv_clip';
+    model.hitRequestSource = 'search_query';
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
+    model.factChecks = ['https://example.com'];
+    const el = await fixture<TileMediatypeIcon>(html`
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
+    `);
+
+    const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
+    expect(iconDiv.title).to.equal('TV Fact Check');
+  });
+
+  it('renders TV Fact Check mediatype for TV search results in factchecked collection', async () => {
+    model.hitType = 'tv_clip';
+    model.hitRequestSource = 'search_query';
+    model.mediatype = 'movies';
+    model.collections = ['tvnews', 'factchecked'];
+    const el = await fixture<TileMediatypeIcon>(html`
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
@@ -63,11 +96,41 @@ describe('Mediatype Icon', () => {
   });
 
   it('does not use TV Fact Check mediatype for non-search results', async () => {
+    model.hitType = 'tv_clip';
+    model.hitRequestSource = 'collection_members';
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
+    model.factChecks = ['https://example.com'];
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon
-        mediatype="movies"
-        .collections=${['tvnews', 'factchecked']}
-      ></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
+    `);
+
+    const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
+    expect(iconDiv.title).to.equal('TV');
+  });
+
+  it('renders TV Quote mediatype for TV search results that are clips', async () => {
+    model.hitType = 'tv_clip';
+    model.hitRequestSource = 'search_query';
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
+    model.isClip = true;
+    const el = await fixture<TileMediatypeIcon>(html`
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
+    `);
+
+    const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
+    expect(iconDiv.title).to.equal('TV Quote');
+  });
+
+  it('does not use TV Quote mediatype for non-search results', async () => {
+    model.hitType = 'tv_clip';
+    model.hitRequestSource = 'collection_members';
+    model.mediatype = 'movies';
+    model.collections = ['tvnews'];
+    model.isClip = true;
+    const el = await fixture<TileMediatypeIcon>(html`
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
@@ -75,11 +138,10 @@ describe('Mediatype Icon', () => {
   });
 
   it('renders radio mediatype', async () => {
+    model.mediatype = 'audio';
+    model.collections = ['radio'];
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon
-        mediatype="audio"
-        .collections=${['radio']}
-      ></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
@@ -87,8 +149,9 @@ describe('Mediatype Icon', () => {
   });
 
   it('renders no icon if mediatype is unrecognized', async () => {
+    model.mediatype = 'foobar' as MediaType;
     const el = await fixture<TileMediatypeIcon>(html`
-      <tile-mediatype-icon mediatype="foobar"></tile-mediatype-icon>
+      <tile-mediatype-icon .model=${model}></tile-mediatype-icon>
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon');

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,7 +339,7 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/iaux-item-metadata@^1.0.4", "@internetarchive/iaux-item-metadata@^1.0.5":
+"@internetarchive/iaux-item-metadata@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@internetarchive/iaux-item-metadata/-/iaux-item-metadata-1.0.5.tgz#d6854754aced46e12dae4ea89aeb4a14b5643391"
   integrity sha512-FArosV3Y/x588QjBSrH15mqeWCivh7hGgRGXoSdauuwqRyPjY/FI3VM69Ox92zZ9Qrm8JOTn3dzbHN0WbiiVtg==
@@ -407,14 +407,13 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.2.1.tgz#bb3339b3ebbbd8b4d5e02166aa90b8309073ff58"
-  integrity sha512-MNwlgvC5M6XNMq/7fuK6Wvg3oF7tJLGwWhEovJeZSmNSwaiL/tYHMofNuCYiGcSpZq4vENcqQRnJ6xgk3mkpqg==
+"@internetarchive/search-service@2.3.2-alpha-webdev7687.0":
+  version "2.3.2-alpha-webdev7687.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.3.2-alpha-webdev7687.0.tgz#19d0667bfefe3b5339bb085edeea4de479d694ad"
+  integrity sha512-HyIDcJAyuiBFLNL+p6HuoA8TTr9rtacGCXnLAD0dWcp9tDr+CSmGHrKYT3Y7j+ryhZCEo75g6dmrGUQ5Y61O0A==
   dependencies:
-    "@internetarchive/iaux-item-metadata" "^1.0.4"
+    "@internetarchive/iaux-item-metadata" "^1.0.5"
     "@internetarchive/result-type" "^0.0.1"
-    decorator-cache-getter "^1.0.0"
     typescript-memoize "^1.1.1"
 
 "@internetarchive/shared-resize-observer@^0.2.0":
@@ -1969,11 +1968,6 @@ debug@^3.1.0, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-decorator-cache-getter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/decorator-cache-getter/-/decorator-cache-getter-1.0.0.tgz"
-  integrity sha512-yB49c5qi0govRjpe18vutEkkKzosIt2XggYSs1Qyev1TJYTh2WmLgDp0dV6VJ/6yNBRlKG+qMG80Vy4Bg0mLJw==
 
 deep-equal@~1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,10 +407,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@2.3.2-alpha-webdev7687.0":
-  version "2.3.2-alpha-webdev7687.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.3.2-alpha-webdev7687.0.tgz#19d0667bfefe3b5339bb085edeea4de479d694ad"
-  integrity sha512-HyIDcJAyuiBFLNL+p6HuoA8TTr9rtacGCXnLAD0dWcp9tDr+CSmGHrKYT3Y7j+ryhZCEo75g6dmrGUQ5Y61O0A==
+"@internetarchive/search-service@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.3.2.tgz#5331a7f9489de306d071ce6c21f16be366fd76ca"
+  integrity sha512-I1j47OB7jbJ+uFH3b+u4Gh81P+8hVXkAOZpMb2bB0gL27oKtC2VvbIL0P10/AIuBaDOo1iUgriePT+JOvI9KaQ==
   dependencies:
     "@internetarchive/iaux-item-metadata" "^1.0.5"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Adds support for TV search filters on clip types, such as `only_quotes`. Also corrects the logic for when each clip type should be displayed, using fields newly available from the search service.