### PR TITLE
WEBDEV-7679 Smart search refinements

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -153,6 +153,14 @@ export class CollectionBrowser
 
   @property({ type: Object }) selectedFacets?: SelectedFacets;
 
+  /**
+   * Set of filters to be applied internally to searches, but not included in URL params or
+   * visibly selected facets. Use when this instance of collection browser is being shown
+   * in a filtered context, such as a single-mediatype tab, but the corresponding filters
+   * should not be exposed/changeable within that context.
+   */
+  @property({ type: Object }) internalFilters?: SelectedFacets;
+
   @property({ type: Boolean }) showSmartFacetBar = false;
 
   /**
@@ -195,6 +203,12 @@ export class CollectionBrowser
    * If true, those options will be omitted (though the rest of the sort bar may still render).
    */
   @property({ type: Boolean }) suppressDisplayModes = false;
+
+  /**
+   * Whether to suppress the display of the `mediatype` facet group, e.g., because this instance
+   * of collection browser is being shown in a filtered single-mediatype context.
+   */
+  @property({ type: Boolean }) suppressMediatypeFacets = false;
 
   /**
    * What strategy to use for when/whether to load facet data for a search.
@@ -1145,6 +1159,7 @@ export class CollectionBrowser
         ?collapsableFacets=${this.mobileView}
         ?facetsLoading=${this.facetsLoading}
         ?fullYearAggregationLoading=${this.facetsLoading}
+        ?suppressMediatypeFacets=${this.suppressMediatypeFacets}
         @facetClick=${this.facetClickHandler}
         @facetsChanged=${this.facetsChanged}
         @histogramDateRangeUpdated=${this.histogramDateRangeUpdated}
@@ -1297,6 +1312,7 @@ export class CollectionBrowser
     this.searchType = queryState.searchType;
     this.selectedFacets =
       queryState.selectedFacets ?? getDefaultSelectedFacets();
+    this.internalFilters = queryState.internalFilters;
     this.minSelectedDate = queryState.minSelectedDate;
     this.maxSelectedDate = queryState.maxSelectedDate;
     this.selectedSort = queryState.selectedSort ?? SortField.default;
@@ -1304,6 +1320,8 @@ export class CollectionBrowser
     this.selectedTitleFilter = queryState.selectedTitleFilter;
     this.selectedCreatorFilter = queryState.selectedCreatorFilter;
     this.tvClipFilter = queryState.tvClipFilter ?? 'all';
+
+    this.pagesToRender = this.initialPageNumber;
 
     // We set this flag during the update to prevent the URL state persistence
     // from creating an unwanted extra history entry.
@@ -1725,6 +1743,7 @@ export class CollectionBrowser
           profileElement: this.profileElement,
           searchType: this.searchType,
           selectedFacets: this.selectedFacets,
+          internalFilters: this.internalFilters,
           minSelectedDate: this.minSelectedDate,
           maxSelectedDate: this.maxSelectedDate,
           selectedSort: this.selectedSort,

--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -95,6 +95,8 @@ export class CollectionFacets extends LitElement {
 
   @property({ type: Boolean }) allowExpandingDatePicker = false;
 
+  @property({ type: Boolean }) suppressMediatypeFacets = false;
+
   @property({ type: String }) query?: string;
 
   @property({ type: Object }) pageSpecifierParams?: PageSpecifierParams;
@@ -378,6 +380,8 @@ export class CollectionFacets extends LitElement {
     const facetGroups: FacetGroup[] = [];
 
     this.facetDisplayOrder.forEach(facetKey => {
+      if (facetKey === 'mediatype' && this.suppressMediatypeFacets) return;
+
       const selectedFacetGroup = this.selectedFacetGroups.find(
         group => group.key === facetKey,
       );

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -29,6 +29,7 @@ import type { CollectionBrowserDataSourceInterface } from './collection-browser-
 import type { CollectionBrowserSearchInterface } from './collection-browser-query-state';
 import { sha1 } from '../utils/sha1';
 import { log } from '../utils/log';
+import { mergeSelectedFacets } from '../utils/facet-utils';
 
 export class CollectionBrowserDataSource
   implements CollectionBrowserDataSourceInterface
@@ -694,6 +695,7 @@ export class CollectionBrowserDataSource
       minSelectedDate,
       maxSelectedDate,
       selectedFacets,
+      internalFilters,
       selectedTitleFilter,
       selectedCreatorFilter,
     } = this.host;
@@ -713,9 +715,13 @@ export class CollectionBrowserDataSource
       );
     }
 
-    // Add any selected facets
-    if (selectedFacets) {
-      for (const [facetName, facetValues] of Object.entries(selectedFacets)) {
+    // Add any selected facets and internal filters
+    const combinedFilters = mergeSelectedFacets(
+      internalFilters,
+      selectedFacets,
+    );
+    if (combinedFilters) {
+      for (const [facetName, facetValues] of Object.entries(combinedFilters)) {
         const { name, values } = this.prepareFacetForFetch(
           facetName,
           facetValues,

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -24,6 +24,7 @@ export interface CollectionBrowserQueryState {
   profileElement?: PageElementName;
   searchType: SearchType;
   selectedFacets?: SelectedFacets;
+  internalFilters?: SelectedFacets;
   minSelectedDate?: string;
   maxSelectedDate?: string;
   selectedTitleFilter: string | null;

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -169,7 +169,7 @@ export class ItemTile extends BaseTileComponent {
   }
 
   private get textSnippetsTemplate(): TemplateResult | typeof nothing {
-    if (!this.hasSnippets) return nothing;
+    if (this.useSimpleLayout || !this.hasSnippets) return nothing;
 
     return html`
       <text-snippet-block viewsize="grid" .snippets=${this.model?.snippets}>
@@ -213,9 +213,7 @@ export class ItemTile extends BaseTileComponent {
   /**
    * Template for the stats row along the bottom of the tile.
    */
-  private get tileStatsTemplate(): TemplateResult | typeof nothing {
-    if (this.useSimpleLayout) return nothing;
-
+  private get tileStatsTemplate(): TemplateResult {
     const effectiveSort = this.sortParam ?? this.defaultSortParam;
     const [viewCount, viewLabel] =
       effectiveSort?.field === 'week'
@@ -284,10 +282,6 @@ export class ItemTile extends BaseTileComponent {
           border: 1px solid ${tileBorderColor};
         }
 
-        .simple .item-info {
-          padding-bottom: 5px;
-        }
-
         .simple #title > .truncated {
           -webkit-line-clamp: 2;
         }
@@ -296,10 +290,6 @@ export class ItemTile extends BaseTileComponent {
         .simple .date-sorted-by > .truncated,
         .simple .volume-issue > .truncated {
           -webkit-line-clamp: 1;
-        }
-
-        .simple text-snippet-block {
-          margin-top: auto; /* Force the snippets to the bottom of the tile */
         }
 
         .capture-dates {

--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -182,6 +182,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     return this.shouldRenderHoverPane
       ? html` ${this.touchBackdropTemplate}
           <tile-hover-pane
+            popover
             .model=${this.hoverPaneProps?.model}
             .baseNavigationUrl=${this.hoverPaneProps?.baseNavigationUrl}
             .baseImageUrl=${this.hoverPaneProps?.baseImageUrl}
@@ -259,7 +260,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
    * Returns the desired top/left offsets (in pixels) for this tile's hover pane.
    * The desired offsets balance positioning the hover pane under the primary pointer
    * while preventing it from flowing outside the viewport. The returned offsets are
-   * given relative to this tile's content box.
+   * relative to the viewport, intended to position the pane as a popover element.
    *
    * These offsets are only valid if the hover pane is already rendered with its
    * correct width and height. If the hover pane is not present, the returned offsets
@@ -302,11 +303,6 @@ export class HoverPaneController implements HoverPaneControllerInterface {
         top = clamp(top, 20, window.innerHeight - hoverPaneRect.height - 20);
       }
     }
-
-    // Subtract off the tile's own offsets
-    const hostRect = this.host.getBoundingClientRect();
-    left -= hostRect.left;
-    top -= hostRect.top;
 
     return { left, top };
   }
@@ -466,6 +462,8 @@ export class HoverPaneController implements HoverPaneControllerInterface {
 
     // Wait for the state update to render the hover pane
     await this.host.updateComplete;
+
+    this.hoverPane?.showPopover?.();
     await new Promise(resolve => {
       // Pane sizes aren't accurate until next frame
       requestAnimationFrame(resolve);

--- a/src/tiles/hover/tile-hover-pane.ts
+++ b/src/tiles/hover/tile-hover-pane.ts
@@ -92,6 +92,12 @@ export class TileHoverPane extends LitElement {
 
     return css`
       :host {
+        margin: 0;
+        border: 0;
+        padding: 0;
+        overflow: visible;
+        color: inherit;
+        background: none;
         visibility: hidden;
         opacity: 0;
         transform: translateY(8px);
@@ -146,6 +152,7 @@ export class TileHoverPane extends LitElement {
         column-gap: 5px;
         height: 3.4rem;
         padding: 0 10px;
+        border-radius: 4px 4px 0 0;
         width: fit-content;
         font-size: 1.4rem;
         color: ${iaLinkColor};


### PR DESCRIPTION
Updates the styling & content of grid tiles in simple view, adds an `internalFilters` property to allow filters that are not added to the URL (e.g., for content within a mediatype tab), and adjust tile hover panes to use popovers so that they can be used within an otherwise overflow-clipped carousel.