### PR TITLE
WEBDEV-7740 Ensure tile hover panes are correctly positioned & skip showing if disconnected

### DIFF
--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -468,6 +468,10 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     // Wait for the state update to render the hover pane
     await this.host.updateComplete;
 
+    // Ensure the hover pane element is still in the document before showing,
+    // as it might have been removed by the previous update.
+    if (!this.hoverPane?.isConnected) return;
+
     this.hoverPane?.showPopover?.();
     await new Promise(resolve => {
       // Pane sizes aren't accurate until next frame

--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -306,6 +306,9 @@ export class HoverPaneController implements HoverPaneControllerInterface {
       }
     }
 
+    left += window.scrollX;
+    top += window.scrollY;
+
     return { left, top };
   }
 


### PR DESCRIPTION
Currently tile hover panes are missing the window scroll amount in their positioning calculation. This PR adds the appropriate values to their top/left position so that they appear in the desired location when scrolling down the page.

Moreover, in some cases the hover pane controller attempts to call `showPopover` on elements that have already been disconnected from the DOM because of a component update. This PR guards against that by early-returning if the popover element is disconnected.