### PR TITLE
v2.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version includes:
 - Bugfix for tile hover panes appearing at the wrong position & emitting errors when scrolling
 - Support for month-snapped buckets in the date picker, for TV searches
 - Support for channel aliases (network names) appearing in facets for TV searches