### PR TITLE
WEBDEV-7747 Omit smart facets when showing an empty/error placeholder

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -536,7 +536,7 @@ export class CollectionBrowser
 
   render() {
     return html`
-      ${this.showSmartFacetBar
+      ${this.showSmartFacetBar && this.placeholderType === null
         ? html`<smart-facet-bar
             .query=${this.baseQuery}
             .aggregations=${this.dataSource.aggregations}


### PR DESCRIPTION
Currently when smart facets are enabled, we are still showing them even after hitting an error or an empty result set. This PR simply fixes the logic so that they will not be shown when one of those placeholder states is active.