### PR TITLE
v2.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version includes `stats-only` and `snippets-only` options for simple grid tile layout, and a bugfix to hide smart facets when the results view is empty or an error.