### PR TITLE
WEBDEV-7713 Upgrade date picker to fix tooltip clipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@internetarchive/analytics-manager": "^0.1.4",
     "@internetarchive/feature-feedback": "^1.0.0",
     "@internetarchive/field-parsers": "^1.0.0",
-    "@internetarchive/histogram-date-range": "^1.3.1",
+    "@internetarchive/histogram-date-range": "1.3.2-alpha-webdev7713.0",
     "@internetarchive/ia-activity-indicator": "^0.0.6",
     "@internetarchive/ia-dropdown": "^1.3.10",
     "@internetarchive/iaux-item-metadata": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,10 +316,10 @@
   resolved "https://registry.yarnpkg.com/@internetarchive/field-parsers/-/field-parsers-1.0.0.tgz#ee3d3efb280860018193c2c52d54ec784e9bb202"
   integrity sha512-cbD0FtJOjzBm7exxFrzrkHnqbmalKbEXA4i7KrwhUGBojF/QTTLAvaIRXH/bfoiTyCh6YT1/E/mULAQPdB6yvQ==
 
-"@internetarchive/histogram-date-range@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.3.1.tgz#c983da13be8e608dcc1af1700e2953adce42c3fa"
-  integrity sha512-rPrlw8mnDAPe6eTxZarBiSNzBDdYfXSpOM/5kHRoqRyc9ZckZXLNnoz7vz6rEZ1Q7EbzfoTEL4BGrCJzyUghbg==
+"@internetarchive/histogram-date-range@1.3.2-alpha-webdev7713.0":
+  version "1.3.2-alpha-webdev7713.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.3.2-alpha-webdev7713.0.tgz#e6a1268ce5977d1b9ab34a6787051a1db17427d2"
+  integrity sha512-HWoR2W6JGrJlJhqvIgen4IETqAAT3XPqalm6h2/2mOJjWwEJnI1lRAqsMF976xPwS+8rbbZ8ntThI9b+AFK7yg==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.6"
     dayjs "^1.11.13"


### PR DESCRIPTION
The date picker's tooltips currently get clipped by the sides of the facet column, impacting readability of tooltips for bars near the start and end of the histogram. This PR upgrades the date picker to a bugfixed version that uses popovers to avoid clipping.