### PR TITLE
WEBDEV-7757 Adjust sort options shown for TV searches

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -47,9 +47,9 @@ import {
   tvFacetDisplayOrder,
   TvClipFilterType,
   TileBlurOverrideState,
-  defaultSortBarFields,
-  favoritesSortBarFields,
-  tvSortBarFields,
+  defaultSortAvailability,
+  favoritesSortAvailability,
+  tvSortAvailability,
 } from './models';
 import {
   RestorationStateHandlerInterface,
@@ -794,22 +794,24 @@ export class CollectionBrowser
     // Determine the set of sortable fields that should be shown in the sort bar
     let defaultViewSort = SortField.weeklyview;
     let defaultDateSort = SortField.date;
-    let displayedSortFields = defaultSortBarFields;
+    let sortFieldAvailability = defaultSortAvailability;
 
+    // We adjust the sort options for a couple of special cases...
     if (this.withinCollection?.startsWith('fav-')) {
       // When viewing a fav- collection, we include the Date Favorited option and show
       // it as the default in the date dropdown.
       defaultDateSort = SortField.datefavorited;
-      displayedSortFields = favoritesSortBarFields;
+      sortFieldAvailability = favoritesSortAvailability;
     } else if (!this.withinCollection && this.searchType === SearchType.TV) {
       // When viewing TV search results, we default the views dropdown to All-time Views
       // and exclude several of the usual date sort options.
       defaultViewSort = SortField.alltimeview;
-      displayedSortFields = tvSortBarFields;
+      defaultDateSort = SortField.datearchived;
+      sortFieldAvailability = tvSortAvailability;
     }
 
-    // We only show relevance sort if a search query is defined
-    displayedSortFields.relevance = this.isRelevanceSortAvailable;
+    // We only show relevance sort if a search query is currently defined
+    sortFieldAvailability.relevance = this.isRelevanceSortAvailable;
 
     return html`
       <sort-filter-bar
@@ -819,7 +821,7 @@ export class CollectionBrowser
         .defaultDateSort=${defaultDateSort}
         .selectedSort=${this.selectedSort}
         .sortDirection=${this.sortDirection}
-        .displayedSortFields=${displayedSortFields}
+        .sortFieldAvailability=${sortFieldAvailability}
         .displayMode=${this.displayMode}
         .selectedTitleFilter=${this.selectedTitleFilter}
         .selectedCreatorFilter=${this.selectedCreatorFilter}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -47,6 +47,9 @@ import {
   tvFacetDisplayOrder,
   TvClipFilterType,
   TileBlurOverrideState,
+  defaultSortBarFields,
+  favoritesSortBarFields,
+  tvSortBarFields,
 } from './models';
 import {
   RestorationStateHandlerInterface,
@@ -788,14 +791,35 @@ export class CollectionBrowser
   private get sortFilterBarTemplate(): TemplateResult | typeof nothing {
     if (this.suppressSortBar) return nothing;
 
+    // Determine the set of sortable fields that should be shown in the sort bar
+    let defaultViewSort = SortField.weeklyview;
+    let defaultDateSort = SortField.date;
+    let displayedSortFields = defaultSortBarFields;
+
+    if (this.withinCollection?.startsWith('fav-')) {
+      // When viewing a fav- collection, we include the Date Favorited option and show
+      // it as the default in the date dropdown.
+      defaultDateSort = SortField.datefavorited;
+      displayedSortFields = favoritesSortBarFields;
+    } else if (!this.withinCollection && this.searchType === SearchType.TV) {
+      // When viewing TV search results, we default the views dropdown to All-time Views
+      // and exclude several of the usual date sort options.
+      defaultViewSort = SortField.alltimeview;
+      displayedSortFields = tvSortBarFields;
+    }
+
+    // We only show relevance sort if a search query is defined
+    displayedSortFields.relevance = this.isRelevanceSortAvailable;
+
     return html`
       <sort-filter-bar
         .defaultSortField=${this.defaultSortField}
         .defaultSortDirection=${this.defaultSortDirection}
+        .defaultViewSort=${defaultViewSort}
+        .defaultDateSort=${defaultDateSort}
         .selectedSort=${this.selectedSort}
         .sortDirection=${this.sortDirection}
-        .showRelevance=${this.isRelevanceSortAvailable}
-        .showDateFavorited=${this.withinCollection?.startsWith('fav-')}
+        .displayedSortFields=${displayedSortFields}
         .displayMode=${this.displayMode}
         .selectedTitleFilter=${this.selectedTitleFilter}
         .selectedCreatorFilter=${this.selectedCreatorFilter}

--- a/src/models.ts
+++ b/src/models.ts
@@ -326,8 +326,8 @@ export enum SortField {
  * Views-related sort fields
  */
 export const ALL_VIEWS_SORT_FIELDS = [
-  SortField.alltimeview,
   SortField.weeklyview,
+  SortField.alltimeview,
 ] as const;
 export type ViewsSortField = (typeof ALL_VIEWS_SORT_FIELDS)[number];
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -553,7 +553,7 @@ export function sortOptionFromAPIString(sortName?: string | null): SortOption {
   );
 }
 
-export const defaultSortBarFields: Record<SortField, boolean> = {
+export const defaultSortAvailability: Record<SortField, boolean> = {
   [SortField.relevance]: true,
   [SortField.weeklyview]: true,
   [SortField.alltimeview]: true,
@@ -568,13 +568,13 @@ export const defaultSortBarFields: Record<SortField, boolean> = {
   [SortField.unrecognized]: false,
 };
 
-export const favoritesSortBarFields: Record<SortField, boolean> = {
-  ...defaultSortBarFields,
+export const favoritesSortAvailability: Record<SortField, boolean> = {
+  ...defaultSortAvailability,
   [SortField.datefavorited]: true,
 };
 
-export const tvSortBarFields: Record<SortField, boolean> = {
-  ...defaultSortBarFields,
+export const tvSortAvailability: Record<SortField, boolean> = {
+  ...defaultSortAvailability,
   [SortField.date]: false,
   [SortField.datereviewed]: false,
   [SortField.dateadded]: false,

--- a/src/models.ts
+++ b/src/models.ts
@@ -322,6 +322,27 @@ export enum SortField {
   'creator' = 'creator',
 }
 
+/**
+ * Views-related sort fields
+ */
+export const ALL_VIEWS_SORT_FIELDS = [
+  SortField.alltimeview,
+  SortField.weeklyview,
+] as const;
+export type ViewsSortField = (typeof ALL_VIEWS_SORT_FIELDS)[number];
+
+/**
+ * Date-related sort fields
+ */
+export const ALL_DATE_SORT_FIELDS = [
+  SortField.datefavorited,
+  SortField.date,
+  SortField.datearchived,
+  SortField.datereviewed,
+  SortField.dateadded,
+] as const;
+export type DateSortField = (typeof ALL_DATE_SORT_FIELDS)[number];
+
 export interface SortOption {
   /**
    * The SortField enum member corresponding to this option.
@@ -531,6 +552,33 @@ export function sortOptionFromAPIString(sortName?: string | null): SortOption {
     ) ?? SORT_OPTIONS[SortField.unrecognized]
   );
 }
+
+export const defaultSortBarFields: Record<SortField, boolean> = {
+  [SortField.relevance]: true,
+  [SortField.weeklyview]: true,
+  [SortField.alltimeview]: true,
+  [SortField.title]: true,
+  [SortField.datefavorited]: false,
+  [SortField.date]: true,
+  [SortField.datearchived]: true,
+  [SortField.datereviewed]: true,
+  [SortField.dateadded]: true,
+  [SortField.creator]: true,
+  [SortField.default]: false,
+  [SortField.unrecognized]: false,
+};
+
+export const favoritesSortBarFields: Record<SortField, boolean> = {
+  ...defaultSortBarFields,
+  [SortField.datefavorited]: true,
+};
+
+export const tvSortBarFields: Record<SortField, boolean> = {
+  ...defaultSortBarFields,
+  [SortField.date]: false,
+  [SortField.datereviewed]: false,
+  [SortField.dateadded]: false,
+};
 
 export const defaultProfileElementSorts: Record<
   string,

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -378,52 +378,6 @@ export class SortFilterBar
     `;
   }
 
-  private get relevanceSortSelectorTemplate(): TemplateResult {
-    return html`<li>
-      ${this.getSortDisplayOption(SortField.relevance, {
-        onClick: () => {
-          this.dropdownBackdropVisible = false;
-          if (this.finalizedSortField !== SortField.relevance) {
-            this.clearAlphaBarFilters();
-            this.setSelectedSort(SortField.relevance);
-          }
-        },
-      })}
-    </li>`;
-  }
-
-  private get titleSortSelectorTemplate(): TemplateResult {
-    return html`<li>
-      ${this.getSortDisplayOption(SortField.title, {
-        onClick: () => {
-          this.dropdownBackdropVisible = false;
-          if (this.finalizedSortField !== SortField.title) {
-            this.alphaSelectorVisible = 'title';
-            this.selectedCreatorFilter = null;
-            this.setSelectedSort(SortField.title);
-            this.emitCreatorLetterChangedEvent();
-          }
-        },
-      })}
-    </li>`;
-  }
-
-  private get creatorSortSelectorTemplate(): TemplateResult {
-    return html`<li>
-      ${this.getSortDisplayOption(SortField.creator, {
-        onClick: () => {
-          this.dropdownBackdropVisible = false;
-          if (this.finalizedSortField !== SortField.creator) {
-            this.alphaSelectorVisible = 'creator';
-            this.selectedTitleFilter = null;
-            this.setSelectedSort(SortField.creator);
-            this.emitTitleLetterChangedEvent();
-          }
-        },
-      })}
-    </li>`;
-  }
-
   /** The template to render all the sort options in desktop view */
   private get desktopSortSelectorTemplate() {
     return html`
@@ -432,17 +386,11 @@ export class SortFilterBar
         class=${this.mobileSelectorVisible ? 'hidden' : 'visible'}
       >
         <ul id="desktop-sort-selector">
-          ${this.displayedSortFields.relevance
-            ? this.relevanceSortSelectorTemplate
-            : nothing}
+          <li>${this.relevanceSortSelectorTemplate}</li>
           <li>${this.viewsDropdownTemplate}</li>
-          ${this.displayedSortFields.title
-            ? this.titleSortSelectorTemplate
-            : nothing}
+          <li>${this.titleSortSelectorTemplate}</li>
           <li>${this.dateDropdownTemplate}</li>
-          ${this.displayedSortFields.creator
-            ? this.creatorSortSelectorTemplate
-            : nothing}
+          <li>${this.creatorSortSelectorTemplate}</li>
         </ul>
       </div>
     `;
@@ -602,6 +550,52 @@ export class SortFilterBar
     } else if (this.dateOptionSelected) {
       this.lastSelectedDateSort = sortField as DateSortField;
     }
+  }
+
+  private get relevanceSortSelectorTemplate(): TemplateResult | typeof nothing {
+    if (!this.displayedSortFields.relevance) return nothing;
+
+    return this.getSortDisplayOption(SortField.relevance, {
+      onClick: () => {
+        this.dropdownBackdropVisible = false;
+        if (this.finalizedSortField !== SortField.relevance) {
+          this.clearAlphaBarFilters();
+          this.setSelectedSort(SortField.relevance);
+        }
+      },
+    });
+  }
+
+  private get titleSortSelectorTemplate(): TemplateResult | typeof nothing {
+    if (!this.displayedSortFields.title) return nothing;
+
+    return this.getSortDisplayOption(SortField.title, {
+      onClick: () => {
+        this.dropdownBackdropVisible = false;
+        if (this.finalizedSortField !== SortField.title) {
+          this.alphaSelectorVisible = 'title';
+          this.selectedCreatorFilter = null;
+          this.setSelectedSort(SortField.title);
+          this.emitCreatorLetterChangedEvent();
+        }
+      },
+    });
+  }
+
+  private get creatorSortSelectorTemplate(): TemplateResult | typeof nothing {
+    if (!this.displayedSortFields.creator) return nothing;
+
+    return this.getSortDisplayOption(SortField.creator, {
+      onClick: () => {
+        this.dropdownBackdropVisible = false;
+        if (this.finalizedSortField !== SortField.creator) {
+          this.alphaSelectorVisible = 'creator';
+          this.selectedTitleFilter = null;
+          this.setSelectedSort(SortField.creator);
+          this.emitTitleLetterChangedEvent();
+        }
+      },
+    });
   }
 
   /** The template to render for the views dropdown */

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -166,18 +166,6 @@ export class SortFilterBar
   @query('#mobile-dropdown')
   private mobileDropdown!: IaDropdown;
 
-  /**
-   * Array of all views sort fields that are displayed, regenerated when the sort
-   * availability changes.
-   */
-  private availableViewsFields: SortField[] = [];
-
-  /**
-   * Array of all views sort fields that are displayed, regenerated when the sort
-   * availability changes.
-   */
-  private availableDateFields: SortField[] = [];
-
   render() {
     return html`
       <div id="container">
@@ -230,15 +218,6 @@ export class SortFilterBar
       } else if (this.dateOptionSelected) {
         this.lastSelectedDateSort = this.finalizedSortField as DateSortField;
       }
-    }
-
-    if (changed.has('sortFieldAvailability')) {
-      this.availableViewsFields = ALL_VIEWS_SORT_FIELDS.filter(
-        field => this.sortFieldAvailability[field],
-      );
-      this.availableDateFields = ALL_DATE_SORT_FIELDS.filter(
-        field => this.sortFieldAvailability[field],
-      );
     }
 
     // If we change which dropdown options are defaulted, update the default selections
@@ -971,6 +950,24 @@ export class SortFilterBar
    */
   private get viewSortDisplayName(): string {
     return SORT_OPTIONS[this.lastSelectedViewSort].displayName;
+  }
+
+  /**
+   * Array of all the views sorts that should be shown
+   */
+  private get availableViewsFields(): SortField[] {
+    return ALL_VIEWS_SORT_FIELDS.filter(
+      field => this.sortFieldAvailability[field],
+    );
+  }
+
+  /**
+   * Array of all the date sorts that should be shown
+   */
+  private get availableDateFields(): SortField[] {
+    return ALL_DATE_SORT_FIELDS.filter(
+      field => this.sortFieldAvailability[field],
+    );
   }
 
   private get titleSelectorBar() {

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -4,7 +4,7 @@ import { html } from 'lit';
 import type { IaDropdown } from '@internetarchive/ia-dropdown';
 import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import type { SortFilterBar } from '../../src/sort-filter-bar/sort-filter-bar';
-import type { SortField } from '../../src/models';
+import { SortField, defaultSortBarFields } from '../../src/models';
 
 import '../../src/sort-filter-bar/sort-filter-bar';
 
@@ -47,22 +47,159 @@ describe('Sort selector default buttons', async () => {
     expect(sortDirections?.querySelector('.sort-direction-icon')).to.exist;
   });
 
-  it('should not render relevance-sort selector if showRelevance is false', async () => {
-    el.showRelevance = false;
-    await el.updateComplete;
+  it('renders default set of sort options if not overridden', async () => {
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(3);
+    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Relevance');
+    expect(allSortSelectors[1]?.textContent?.trim()).to.equal('Title');
+    expect(allSortSelectors[2]?.textContent?.trim()).to.equal('Creator');
 
-    const defaultSortSelector =
-      desktopSortSelector?.querySelector('button.selected');
-    expect(defaultSortSelector?.textContent?.trim()).not.to.equal('Relevance');
-  });
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(2);
 
-  it('should render default relevance-sort selector', async () => {
-    el.showRelevance = true;
-    await el.updateComplete;
+    expect(allSortDropdowns[0]?.options.length).to.equal(2);
+    expect(allSortDropdowns[0]?.options.map(o => o.id)).to.deep.equal([
+      SortField.weeklyview,
+      SortField.alltimeview,
+    ]);
+    expect(allSortDropdowns[0]?.textContent?.trim()).to.equal('Weekly views');
 
+    expect(allSortDropdowns[1]?.options.length).to.equal(4);
+    expect(allSortDropdowns[1]?.options.map(o => o.id)).to.deep.equal([
+      SortField.date,
+      SortField.datearchived,
+      SortField.datereviewed,
+      SortField.dateadded,
+    ]);
+    expect(allSortDropdowns[1]?.textContent?.trim()).to.equal('Date published');
+
+    // Relevance selected by default
     const defaultSortSelector =
       desktopSortSelector?.querySelector('button.selected');
     expect(defaultSortSelector?.textContent?.trim()).to.equal('Relevance');
+  });
+
+  it('renders an overridden set of sort options if specified', async () => {
+    const customSortFields: Record<SortField, boolean> = {
+      ...defaultSortBarFields,
+      [SortField.relevance]: false,
+      [SortField.title]: false,
+      [SortField.datefavorited]: true,
+      [SortField.datearchived]: false,
+      [SortField.datereviewed]: false,
+    };
+
+    el.displayedSortFields = customSortFields;
+    await el.updateComplete;
+
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(1);
+    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Creator');
+
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(2);
+
+    expect(allSortDropdowns[0]?.options.length).to.equal(2);
+    expect(allSortDropdowns[0]?.options.map(o => o.id)).to.deep.equal([
+      SortField.weeklyview,
+      SortField.alltimeview,
+    ]);
+
+    expect(allSortDropdowns[1]?.options.length).to.equal(3);
+    expect(allSortDropdowns[1]?.options.map(o => o.id)).to.deep.equal([
+      SortField.datefavorited,
+      SortField.date,
+      SortField.dateadded,
+    ]);
+  });
+
+  it('renders a button instead of a dropdown if it would only have one option', async () => {
+    const customSortFields: Record<SortField, boolean> = {
+      ...defaultSortBarFields,
+      // Disable all default dates except Date Added
+      [SortField.date]: false,
+      [SortField.datearchived]: false,
+      [SortField.datereviewed]: false,
+    };
+
+    el.displayedSortFields = customSortFields;
+    await el.updateComplete;
+
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(4);
+    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Relevance');
+    expect(allSortSelectors[1]?.textContent?.trim()).to.equal('Title');
+    expect(allSortSelectors[2]?.textContent?.trim()).to.equal('Date added');
+    expect(allSortSelectors[3]?.textContent?.trim()).to.equal('Creator');
+
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(1);
+    expect(allSortDropdowns[0]?.id).to.equal('views-dropdown');
+  });
+
+  it('does not render a dropdown that would have zero available options', async () => {
+    const customSortFields: Record<SortField, boolean> = {
+      ...defaultSortBarFields,
+      // Disable all views sorts
+      [SortField.weeklyview]: false,
+      [SortField.alltimeview]: false,
+    };
+
+    el.displayedSortFields = customSortFields;
+    await el.updateComplete;
+
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(3);
+
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(1);
+    expect(allSortDropdowns[0]?.id).to.equal('date-dropdown'); // No views dropdown preset
+  });
+
+  it('allows changing the default views sort shown', async () => {
+    el.defaultViewSort = SortField.alltimeview;
+    await el.updateComplete;
+
+    const viewsDropdown = el.shadowRoot?.querySelector(
+      '#views-dropdown',
+    ) as IaDropdown;
+    expect(viewsDropdown).to.exist;
+    expect(viewsDropdown.textContent?.trim()).to.equal('All-time views');
+  });
+
+  it('allows changing the default date sort shown', async () => {
+    el.defaultDateSort = SortField.datereviewed;
+    await el.updateComplete;
+
+    const dateDropdown = el.shadowRoot?.querySelector(
+      '#date-dropdown',
+    ) as IaDropdown;
+    expect(dateDropdown).to.exist;
+    expect(dateDropdown.textContent?.trim()).to.equal('Date reviewed');
   });
 
   it('should render default view-sort selector', async () => {
@@ -158,7 +295,10 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('handles click event on relevance selector', async () => {
-    el.showRelevance = true;
+    el.displayedSortFields = {
+      ...el.displayedSortFields,
+      [SortField.relevance]: true,
+    };
     el.selectedSort = 'title' as SortField;
     await el.updateComplete;
 

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -4,7 +4,7 @@ import { html } from 'lit';
 import type { IaDropdown } from '@internetarchive/ia-dropdown';
 import { SharedResizeObserver } from '@internetarchive/shared-resize-observer';
 import type { SortFilterBar } from '../../src/sort-filter-bar/sort-filter-bar';
-import { SortField, defaultSortBarFields } from '../../src/models';
+import { SortField, defaultSortAvailability } from '../../src/models';
 
 import '../../src/sort-filter-bar/sort-filter-bar';
 
@@ -86,8 +86,8 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('renders an overridden set of sort options if specified', async () => {
-    const customSortFields: Record<SortField, boolean> = {
-      ...defaultSortBarFields,
+    const customSortAvailability: Record<SortField, boolean> = {
+      ...defaultSortAvailability,
       [SortField.relevance]: false,
       [SortField.title]: false,
       [SortField.datefavorited]: true,
@@ -95,7 +95,7 @@ describe('Sort selector default buttons', async () => {
       [SortField.datereviewed]: false,
     };
 
-    el.displayedSortFields = customSortFields;
+    el.sortFieldAvailability = customSortAvailability;
     await el.updateComplete;
 
     const allSortSelectors = desktopSortSelector?.querySelectorAll(
@@ -126,15 +126,15 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('renders a button instead of a dropdown if it would only have one option', async () => {
-    const customSortFields: Record<SortField, boolean> = {
-      ...defaultSortBarFields,
+    const customSortAvailability: Record<SortField, boolean> = {
+      ...defaultSortAvailability,
       // Disable all default dates except Date Added
       [SortField.date]: false,
       [SortField.datearchived]: false,
       [SortField.datereviewed]: false,
     };
 
-    el.displayedSortFields = customSortFields;
+    el.sortFieldAvailability = customSortAvailability;
     await el.updateComplete;
 
     const allSortSelectors = desktopSortSelector?.querySelectorAll(
@@ -156,14 +156,14 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('does not render a dropdown that would have zero available options', async () => {
-    const customSortFields: Record<SortField, boolean> = {
-      ...defaultSortBarFields,
+    const customSortAvailability: Record<SortField, boolean> = {
+      ...defaultSortAvailability,
       // Disable all views sorts
       [SortField.weeklyview]: false,
       [SortField.alltimeview]: false,
     };
 
-    el.displayedSortFields = customSortFields;
+    el.sortFieldAvailability = customSortAvailability;
     await el.updateComplete;
 
     const allSortSelectors = desktopSortSelector?.querySelectorAll(
@@ -295,8 +295,8 @@ describe('Sort selector default buttons', async () => {
   });
 
   it('handles click event on relevance selector', async () => {
-    el.displayedSortFields = {
-      ...el.displayedSortFields,
+    el.sortFieldAvailability = {
+      ...el.sortFieldAvailability,
       [SortField.relevance]: true,
     };
     el.selectedSort = 'title' as SortField;

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -88,11 +88,11 @@ describe('Sort selector default buttons', async () => {
   it('renders an overridden set of sort options if specified', async () => {
     const customSortAvailability: Record<SortField, boolean> = {
       ...defaultSortAvailability,
-      [SortField.relevance]: false,
       [SortField.title]: false,
       [SortField.datefavorited]: true,
       [SortField.datearchived]: false,
       [SortField.datereviewed]: false,
+      [SortField.creator]: false,
     };
 
     el.sortFieldAvailability = customSortAvailability;
@@ -103,7 +103,7 @@ describe('Sort selector default buttons', async () => {
     ) as NodeListOf<HTMLButtonElement>;
     expect(allSortSelectors).to.exist;
     expect(allSortSelectors.length).to.equal(1);
-    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Creator');
+    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Relevance');
 
     const allSortDropdowns = desktopSortSelector?.querySelectorAll(
       'ia-dropdown',
@@ -125,7 +125,34 @@ describe('Sort selector default buttons', async () => {
     ]);
   });
 
-  it('renders a button instead of a dropdown if it would only have one option', async () => {
+  it('renders a views button instead of a dropdown if it would only have one option', async () => {
+    const customSortAvailability: Record<SortField, boolean> = {
+      ...defaultSortAvailability,
+      // Disable weekly views (but keep All-time Views)
+      [SortField.weeklyview]: false,
+    };
+
+    el.sortFieldAvailability = customSortAvailability;
+    await el.updateComplete;
+
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(4);
+    expect(allSortSelectors[0]?.textContent?.trim()).to.equal('Relevance');
+    expect(allSortSelectors[1]?.textContent?.trim()).to.equal('All-time views');
+    expect(allSortSelectors[2]?.textContent?.trim()).to.equal('Title');
+    expect(allSortSelectors[3]?.textContent?.trim()).to.equal('Creator');
+
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(1);
+  });
+
+  it('renders a date button instead of a dropdown if it would only have one option', async () => {
     const customSortAvailability: Record<SortField, boolean> = {
       ...defaultSortAvailability,
       // Disable all default dates except Date Added
@@ -152,13 +179,12 @@ describe('Sort selector default buttons', async () => {
     ) as NodeListOf<IaDropdown>;
     expect(allSortDropdowns).to.exist;
     expect(allSortDropdowns.length).to.equal(1);
-    expect(allSortDropdowns[0]?.id).to.equal('views-dropdown');
   });
 
-  it('does not render a dropdown that would have zero available options', async () => {
+  it('does not render a views dropdown that would have zero available options', async () => {
     const customSortAvailability: Record<SortField, boolean> = {
       ...defaultSortAvailability,
-      // Disable all views sorts
+      // Disable all view sorts
       [SortField.weeklyview]: false,
       [SortField.alltimeview]: false,
     };
@@ -177,7 +203,34 @@ describe('Sort selector default buttons', async () => {
     ) as NodeListOf<IaDropdown>;
     expect(allSortDropdowns).to.exist;
     expect(allSortDropdowns.length).to.equal(1);
-    expect(allSortDropdowns[0]?.id).to.equal('date-dropdown'); // No views dropdown preset
+    expect(allSortDropdowns[0].options?.[0]?.id).to.equal(SortField.date);
+  });
+
+  it('does not render a date dropdown that would have zero available options', async () => {
+    const customSortAvailability: Record<SortField, boolean> = {
+      ...defaultSortAvailability,
+      // Disable all date sorts
+      [SortField.date]: false,
+      [SortField.dateadded]: false,
+      [SortField.datearchived]: false,
+      [SortField.datereviewed]: false,
+    };
+
+    el.sortFieldAvailability = customSortAvailability;
+    await el.updateComplete;
+
+    const allSortSelectors = desktopSortSelector?.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+    expect(allSortSelectors).to.exist;
+    expect(allSortSelectors.length).to.equal(3);
+
+    const allSortDropdowns = desktopSortSelector?.querySelectorAll(
+      'ia-dropdown',
+    ) as NodeListOf<IaDropdown>;
+    expect(allSortDropdowns).to.exist;
+    expect(allSortDropdowns.length).to.equal(1);
+    expect(allSortDropdowns[0].options?.[0]?.id).to.equal(SortField.weeklyview);
   });
 
   it('allows changing the default views sort shown', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "dom.iterable"],
     "strict": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
TV searches do not require all the same sort options available, in particular since many of the date options are either not relevant or essentially the same for TV items.

This PR generalizes how the sort bar component is configured a bit, so that we can easily modify what sort options are available in bulk rather than via individual flags, and then ensures it is configured appropriately in the cases that require non-default sort options.