### PR TITLE
WEBDEV-7768 Search beta: Tile box shadow customization & smart facet adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@internetarchive/field-parsers": "^1.0.0",
     "@internetarchive/histogram-date-range": "^1.4.0",
     "@internetarchive/ia-activity-indicator": "^0.0.6",
-    "@internetarchive/ia-dropdown": "1.3.11-alpha-webdev-7768.0",
+    "@internetarchive/ia-dropdown": "^1.4.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",
     "@internetarchive/modal-manager": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@internetarchive/field-parsers": "^1.0.0",
     "@internetarchive/histogram-date-range": "^1.4.0",
     "@internetarchive/ia-activity-indicator": "^0.0.6",
-    "@internetarchive/ia-dropdown": "^1.3.10",
+    "@internetarchive/ia-dropdown": "1.3.11-alpha-webdev-7768.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",
     "@internetarchive/modal-manager": "^2.0.1",

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -511,6 +511,10 @@ export class CollectionBrowser
       this.sortDirection = null;
       this.selectedSort = SortField.default;
     }
+
+    if (this.smartFacetBar) {
+      this.smartFacetBar.deselectAll();
+    }
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -7,6 +7,7 @@ import {
   nothing,
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { msg } from '@lit/localize';
 
@@ -162,7 +163,15 @@ export class CollectionBrowser
    */
   @property({ type: Object }) internalFilters?: SelectedFacets;
 
+  /**
+   * Whether to show smart facets (bubbles) along the top of the component
+   */
   @property({ type: Boolean }) showSmartFacetBar = false;
+
+  /**
+   * Sets the label that is shown in front of the smart facets, if present.
+   */
+  @property({ type: String }) smartFacetBarLabel?: string;
 
   /**
    * Whether to show the date picker (above the facets)
@@ -550,6 +559,7 @@ export class CollectionBrowser
             .selectedFacets=${this.selectedFacets}
             .collectionTitles=${this.dataSource.collectionTitles}
             .filterToggleActive=${this.facetPaneVisible}
+            .label=${this.smartFacetBarLabel}
             @facetsChanged=${this.facetsChanged}
             @filtersToggled=${() => {
               this.facetPaneVisible = !this.facetPaneVisible;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2516,7 +2516,7 @@ export class CollectionBrowser
         .mobile #left-column {
           width: 100%;
           min-width: 0;
-          padding: 0;
+          padding: 5px 0;
           border: 0;
         }
 
@@ -2589,9 +2589,8 @@ export class CollectionBrowser
         }
 
         .mobile #results-total {
-          float: right;
-          margin-bottom: 0;
-          margin-right: 5px;
+          position: absolute;
+          right: 10px;
         }
 
         #big-results-count {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -557,6 +557,7 @@ export class CollectionBrowser
             .aggregations=${this.dataSource.aggregations}
             .selectedFacets=${this.selectedFacets}
             .collectionTitles=${this.dataSource.collectionTitles}
+            .filterToggleShown=${!this.mobileView}
             .filterToggleActive=${this.facetPaneVisible}
             .label=${this.smartFacetBarLabel}
             @facetsChanged=${this.facetsChanged}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -7,7 +7,6 @@ import {
   nothing,
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { msg } from '@lit/localize';
 

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -9,7 +9,6 @@ import {
 } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { customElement, property, state } from 'lit/decorators.js';
-import { msg } from '@lit/localize';
 import type { Aggregation, Bucket } from '@internetarchive/search-service';
 import type { CollectionTitles } from '../../data-source/models';
 import type {

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -51,6 +51,8 @@ export class SmartFacetBar extends LitElement {
   @property({ type: Object })
   collectionTitles?: CollectionTitles;
 
+  @property({ type: Boolean }) filterToggleShown = false;
+
   @property({ type: Boolean }) filterToggleActive = false;
 
   @property({ type: String }) label?: string;
@@ -164,7 +166,9 @@ export class SmartFacetBar extends LitElement {
     `;
   }
 
-  private get filtersToggleTemplate(): TemplateResult {
+  private get filtersToggleTemplate(): TemplateResult | typeof nothing {
+    if (!this.filterToggleShown) return nothing;
+
     return html`
       <button
         id="filters-toggle"

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -158,7 +158,7 @@ export class SmartFacetBar extends LitElement {
         .facetInfo=${facets}
         .labelPrefix=${fieldPrefixes[facets[0].facets[0].facetType]}
         .activeFacetRef=${facets[0].facets[0]}
-        @facetClick=${this.facetDropdownClicked}
+        @facetClick=${this.dropdownOptionClicked}
         @dropdownClick=${this.onDropdownClick}
       ></smart-facet-dropdown>
     `;
@@ -289,12 +289,22 @@ export class SmartFacetBar extends LitElement {
       ];
     }
 
-    // Update the selected facets
-    for (const facet of details) {
+    this.updateSelectedFacets(
+      details.map(facet => ({ ...facet, state: newState })),
+    );
+  }
+
+  /**
+   * Updates the selected facet buckets for each of the given facets,
+   * and emits a `facetsChanged` event to notify parent components of
+   * the new state.
+   */
+  private updateSelectedFacets(facets: FacetEventDetails[]): void {
+    for (const facet of facets) {
       this.selectedFacets = updateSelectedFacetBucket(
         this.selectedFacets,
         facet.facetType,
-        { ...facet.bucket, state: newState },
+        facet.bucket,
         true,
       );
     }
@@ -305,11 +315,17 @@ export class SmartFacetBar extends LitElement {
     this.dispatchEvent(event);
   }
 
+  /**
+   * Handler for when a smart facet button is clicked
+   */
   private facetClicked(e: CustomEvent<SmartFacetEvent>): void {
     this.toggleSmartFacet(e.detail.smartFacet, e.detail.details);
   }
 
-  private facetDropdownClicked(e: CustomEvent<SmartFacetEvent>): void {
+  /**
+   * Handler for when an option in a smart facet dropdown is selected
+   */
+  private dropdownOptionClicked(e: CustomEvent<SmartFacetEvent>): void {
     const existingFacet = this.smartFacets.find(
       sf => sf.length === 1 && smartFacetEquals(sf[0], e.detail.smartFacet),
     );
@@ -325,19 +341,7 @@ export class SmartFacetBar extends LitElement {
       ...this.smartFacets,
     ];
 
-    for (const facet of e.detail.details) {
-      this.selectedFacets = updateSelectedFacetBucket(
-        this.selectedFacets,
-        facet.facetType,
-        facet.bucket,
-        true,
-      );
-    }
-
-    const event = new CustomEvent<SelectedFacets>('facetsChanged', {
-      detail: this.selectedFacets,
-    });
-    this.dispatchEvent(event);
+    this.updateSelectedFacets(e.detail.details);
   }
 
   private onDropdownClick(e: CustomEvent<SmartFacetDropdown>): void {
@@ -401,7 +405,7 @@ export class SmartFacetBar extends LitElement {
 
       #filters-label {
         font-size: 1.4rem;
-        font-weight: bold;
+        font-weight: var(--smartFacetLabelFontWeight, normal);
         margin: 0 -5px 0 0;
       }
     `;

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -49,6 +49,8 @@ export class SmartFacetBar extends LitElement {
 
   @property({ type: Boolean }) filterToggleActive = false;
 
+  @property({ type: String }) label?: string;
+
   @state() private heuristicRecs: SmartFacet[] = [];
 
   @state() private smartFacets: SmartFacet[][] = [];
@@ -62,11 +64,12 @@ export class SmartFacetBar extends LitElement {
   render() {
     if (!this.query) return nothing;
 
+    const shouldShowLabel = !!this.label && this.smartFacets.length > 0;
     return html`
       <div id="smart-facets-container">
         ${this.filtersToggleTemplate}
-        ${this.smartFacets.length > 0
-          ? html`<p id="filters-label">${msg('Browse:')}</p>`
+        ${shouldShowLabel
+          ? html`<p id="filters-label">${this.label}</p>`
           : nothing}
         ${repeat(
           this.smartFacets,
@@ -368,6 +371,7 @@ export class SmartFacetBar extends LitElement {
       }
 
       #filters-label {
+        font-size: 1.4rem;
         font-weight: bold;
         margin: 0 -5px 0 0;
       }

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -161,7 +161,7 @@ export class SmartFacetBar extends LitElement {
         .labelPrefix=${fieldPrefixes[facets[0].facets[0].facetType]}
         .activeFacetRef=${facets[0].facets[0]}
         @facetClick=${this.dropdownOptionClicked}
-        @dropdownClick=${this.onDropdownClick}
+        @dropdownClick=${this.dropdownClicked}
       ></smart-facet-dropdown>
     `;
   }
@@ -294,7 +294,13 @@ export class SmartFacetBar extends LitElement {
     }
 
     this.updateSelectedFacets(
-      details.map(facet => ({ ...facet, state: newState })),
+      details.map(facet => ({
+        ...facet,
+        bucket: {
+          ...facet.bucket,
+          state: newState,
+        },
+      })),
     );
   }
 
@@ -327,7 +333,7 @@ export class SmartFacetBar extends LitElement {
   }
 
   /**
-   * Handler for when an option in a smart facet dropdown is selected
+   * Handler for when an option in a smart facet dropdown menu is selected
    */
   private dropdownOptionClicked(e: CustomEvent<SmartFacetEvent>): void {
     const existingFacet = this.smartFacets.find(
@@ -348,7 +354,10 @@ export class SmartFacetBar extends LitElement {
     this.updateSelectedFacets(e.detail.details);
   }
 
-  private onDropdownClick(e: CustomEvent<SmartFacetDropdown>): void {
+  /**
+   * Handler for when any dropdown is clicked (whether button, caret, or menu item)
+   */
+  private dropdownClicked(e: CustomEvent<SmartFacetDropdown>): void {
     log('smart bar: onDropdownClick', e.detail);
     this.shadowRoot
       ?.querySelectorAll('smart-facet-dropdown')
@@ -373,9 +382,11 @@ export class SmartFacetBar extends LitElement {
       #smart-facets-container {
         display: flex;
         align-items: center;
-        flex-wrap: wrap;
         gap: 5px 10px;
         padding: 10px 0;
+        white-space: nowrap;
+        overflow: scroll hidden;
+        scrollbar-width: none;
       }
 
       #filters-toggle {

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -65,6 +65,9 @@ export class SmartFacetBar extends LitElement {
     return html`
       <div id="smart-facets-container">
         ${this.filtersToggleTemplate}
+        ${this.smartFacets.length > 0
+          ? html`<p id="filters-label">${msg('Browse:')}</p>`
+          : nothing}
         ${repeat(
           this.smartFacets,
           f =>
@@ -362,6 +365,11 @@ export class SmartFacetBar extends LitElement {
 
       #filters-toggle.active > svg {
         filter: invert(1);
+      }
+
+      #filters-label {
+        font-weight: bold;
+        margin: 0 -5px 0 0;
       }
     `;
   }

--- a/src/collection-facets/smart-facets/smart-facet-bar.ts
+++ b/src/collection-facets/smart-facets/smart-facet-bar.ts
@@ -118,6 +118,15 @@ export class SmartFacetBar extends LitElement {
     this.updateSmartFacets();
   }
 
+  deselectAll(): void {
+    for (const sf of this.smartFacets) {
+      for (const facet of sf) {
+        facet.selected = false;
+      }
+    }
+    this.requestUpdate();
+  }
+
   private async updateSmartFacets(): Promise<void> {
     log('updating smart facets');
     if (this.query) {

--- a/src/collection-facets/smart-facets/smart-facet-dropdown.ts
+++ b/src/collection-facets/smart-facets/smart-facet-dropdown.ts
@@ -35,6 +35,7 @@ export class SmartFacetDropdown extends LitElement {
           closeOnEscape
           closeOnBackdropClick
           includeSelectedOption
+          usePopover
           .options=${this.dropdownOptions}
           .selectedOption=${this.activeDropdownOption}
           .openViaButton=${false}

--- a/src/collection-facets/smart-facets/smart-facet-dropdown.ts
+++ b/src/collection-facets/smart-facets/smart-facet-dropdown.ts
@@ -41,7 +41,10 @@ export class SmartFacetDropdown extends LitElement {
           @optionSelected=${this.optionSelected}
           @click=${this.onDropdownClick}
         >
-          <span class="dropdown-label" slot="dropdown-label"
+          <span
+            class="dropdown-label"
+            slot="dropdown-label"
+            @click=${this.defaultOptionSelected}
             >${this.labelPrefix ?? nothing} ${displayText}</span
           >
         </ia-dropdown>
@@ -76,13 +79,31 @@ export class SmartFacetDropdown extends LitElement {
     );
   }
 
+  /**
+   * Handler for when the default option on the dropdown button is clicked
+   */
+  private defaultOptionSelected(): void {
+    this.handleSelection(this.activeFacetRef?.bucketKey);
+  }
+
+  /**
+   * Handler for when an option in the dropdown menu is selected
+   */
   private optionSelected(e: CustomEvent<{ option: optionInterface }>): void {
-    if (!this.facetInfo || !this.activeFacetRef) return;
+    this.handleSelection(e.detail.option.id);
+  }
+
+  /**
+   * Responds to a dropdown selection by emitting a `facetClick` event with
+   * the appropriate facet details.
+   */
+  private handleSelection(bucketKey?: string): void {
+    if (!bucketKey || !this.facetInfo || !this.activeFacetRef) return;
 
     let selectedSmartFacet;
     for (const smartFacet of this.facetInfo) {
       const selectedRef = smartFacet.facets.find(
-        b => b.bucketKey === e.detail.option.id,
+        b => b.bucketKey === bucketKey,
       );
       if (selectedRef) {
         this.activeFacetRef = selectedRef;

--- a/src/collection-facets/smart-facets/smart-facet-dropdown.ts
+++ b/src/collection-facets/smart-facets/smart-facet-dropdown.ts
@@ -31,13 +31,13 @@ export class SmartFacetDropdown extends LitElement {
         <ia-dropdown
           class="dropdown"
           displayCaret
-          openViaButton
           closeOnSelect
           closeOnEscape
           closeOnBackdropClick
           includeSelectedOption
           .options=${this.dropdownOptions}
           .selectedOption=${this.activeDropdownOption}
+          .openViaButton=${false}
           @optionSelected=${this.optionSelected}
           @click=${this.onDropdownClick}
         >

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -16,7 +16,7 @@ export const baseTileStyles = css`
     background-color: ${tileBackgroundColor};
     border: 1px #2c2c2c;
     border-radius: ${tileCornerRadius};
-    box-shadow: 1px 1px 2px 0;
+    /*box-shadow: 1px 1px 2px 0;*/
     box-sizing: border-box;
     height: 100%;
     display: flex;

--- a/src/tiles/grid/styles/tile-grid-shared-styles.ts
+++ b/src/tiles/grid/styles/tile-grid-shared-styles.ts
@@ -16,7 +16,7 @@ export const baseTileStyles = css`
     background-color: ${tileBackgroundColor};
     border: 1px #2c2c2c;
     border-radius: ${tileCornerRadius};
-    /*box-shadow: 1px 1px 2px 0;*/
+    box-shadow: var(--tileBoxShadow, 1px 1px 2px 0);
     box-sizing: border-box;
     height: 100%;
     display: flex;

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -433,7 +433,7 @@ export class TileDispatcher
       }
 
       #container.hoverable:hover {
-        box-shadow: 0 0 6px 2px rgba(8, 8, 32, 0.8);
+        box-shadow: 0 0 10px 0px rgba(8, 8, 32, 0.15);
         transition: box-shadow 0.1s ease;
       }
 

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -433,7 +433,7 @@ export class TileDispatcher
       }
 
       #container.hoverable:hover {
-        box-shadow: 0 0 10px 0px rgba(8, 8, 32, 0.15);
+        box-shadow: var(--tileHoverBoxShadow, 0 0 6px 2px rgba(8, 8, 32, 0.8));
         transition: box-shadow 0.1s ease;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,10 +334,10 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/ia-dropdown@^1.3.10":
-  version "1.3.10"
-  resolved "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-1.3.10.tgz"
-  integrity sha512-+xGgyfE0O4cV+w4rk61yA5av5KeSqCmojukp6ePbrluIYBIH2UCtfDcfCEQFVsnNSs8AesJOkUb0q3jaW0M4cQ==
+"@internetarchive/ia-dropdown@1.3.11-alpha-webdev-7768.0":
+  version "1.3.11-alpha-webdev-7768.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-1.3.11-alpha-webdev-7768.0.tgz#91fa0d7f3f86bbbf70439fb65466ecfa65e57e0d"
+  integrity sha512-G+v5GyZob+AfHobHe/2VJWakgfI6ewXZLJG+2BNrC8UxC5e8/MzNjd2fLuQkPfClMEc48uWnA1gcEMmsKGmWZQ==
   dependencies:
     lit "^2.8.0"
 
@@ -5080,16 +5080,7 @@ streamx@^2.15.0, streamx@^2.21.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5155,14 +5146,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5611,7 +5595,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5624,15 +5608,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,10 +334,10 @@
   dependencies:
     lit "^2.8.0"
 
-"@internetarchive/ia-dropdown@1.3.11-alpha-webdev-7768.0":
-  version "1.3.11-alpha-webdev-7768.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-1.3.11-alpha-webdev-7768.0.tgz#91fa0d7f3f86bbbf70439fb65466ecfa65e57e0d"
-  integrity sha512-G+v5GyZob+AfHobHe/2VJWakgfI6ewXZLJG+2BNrC8UxC5e8/MzNjd2fLuQkPfClMEc48uWnA1gcEMmsKGmWZQ==
+"@internetarchive/ia-dropdown@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/ia-dropdown/-/ia-dropdown-1.4.0.tgz#0b9fc39182b4c11d54a8b4e7862a008b5ff2fd2e"
+  integrity sha512-PQ/xuC0PJIQOTAv1zI0oVwFcB86YuYVcV3969LXXXPCRhgA95SNQ2UHFE9c00sa/fwixp2Dzej/HBGoWAZugcQ==
   dependencies:
     lit "^2.8.0"
 


### PR DESCRIPTION
Two changes in preparation for the new search beta:
- Box shadows on tiles are currently always dark and thick. To allow more flexibility in how tiles are displayed in various contexts, this PR exposes two CSS vars that allow them to be customized more easily.
- The smart facets regain a text label, which is now customizable from outside the component.
- Clicking the default label of a smart facet dropdown now selects it immediately, rather than opening the dropdown menu (consistent with how the sort bar dropdowns function). Dropdown menus can still be opened by clicking the arrow.