### PR TITLE
Allow `facetPaneVisible` prop to function without smart facets

### DIFF
--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -16,7 +16,6 @@ import type { AnalyticsManagerInterface } from '@internetarchive/analytics-manag
 import type { CollectionBrowser } from '../src/collection-browser';
 
 import '../src/collection-browser';
-import { StringField } from '@internetarchive/iaux-item-metadata';
 
 @customElement('app-root')
 export class AppRoot extends LitElement {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -490,6 +490,7 @@ export class AppRoot extends LitElement {
       </div>
       <div id="collection-browser-container">
         <collection-browser
+          facetPaneVisible
           .baseNavigationUrl=${'https://archive.org'}
           .baseImageUrl=${'https://archive.org'}
           .searchService=${this.searchService}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -236,7 +236,7 @@ export class CollectionBrowser
    */
   @property({ type: String }) facetLoadStrategy: FacetLoadStrategy = 'eager';
 
-  @property({ type: Boolean }) facetPaneVisible = false;
+  @property({ type: Boolean, reflect: true }) facetPaneVisible = false;
 
   @property({ type: Boolean }) clearResultsOnEmptyQuery = false;
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -675,14 +675,10 @@ export class CollectionBrowser
    */
   private get desktopLeftColumnTemplate(): TemplateResult {
     return html`
-      <div
-        id="left-column"
-        class="column"
-        ?hidden=${this.showSmartFacetBar && !this.facetPaneVisible}
-      >
+      <div id="left-column" class="column" ?hidden=${!this.facetPaneVisible}>
         ${this.facetTopViewSlot}
         <div id="facets-header-container">
-          <h2 id="facets-header" class="sr-only">Filters</h2>
+          <h2 id="facets-header" class="sr-only">${msg('Filters')}</h2>
           ${this.resultsCountTemplate} ${this.clearFiltersBtnTemplate(false)}
         </div>
         <div id="facets-container" aria-labelledby="facets-header">
@@ -736,7 +732,7 @@ export class CollectionBrowser
   private get rightColumnTemplate(): TemplateResult {
     const rightColumnClasses = classMap({
       column: true,
-      'full-width': this.showSmartFacetBar && !this.facetPaneVisible,
+      'full-width': !this.facetPaneVisible,
       'smart-results-spacing': !!this.showSmartResults,
     });
 


### PR DESCRIPTION
The `facetPaneVisible` property currently only has an effect when `showSmartFacetBar` is enabled. However, there is little reason why these two properties need to be coupled that way. This PR allows `facetPaneVisible` to take effect regardless of whether smart facets are shown.