### PR TITLE
WEBDEV-8186 Implement new single-dropdown sort bar

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2248,12 +2248,8 @@ export class CollectionBrowser
     this.displayMode = restorationState.displayMode;
     if (!this.suppressURLSinParam && restorationState.searchType != null)
       this.searchType = restorationState.searchType;
-    this.selectedSort =
-      restorationState.selectedSort ??
-      this.defaultSortField ??
-      SortField.default;
-    this.sortDirection =
-      restorationState.sortDirection ?? this.defaultSortDirection ?? null;
+    this.selectedSort = restorationState.selectedSort ?? SortField.default;
+    this.sortDirection = restorationState.sortDirection ?? null;
     this.selectedTitleFilter = restorationState.selectedTitleFilter ?? null;
     this.selectedCreatorFilter = restorationState.selectedCreatorFilter ?? null;
     this.selectedFacets = restorationState.selectedFacets;

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1633,7 +1633,6 @@ export class CollectionBrowser
     dataSource: CollectionBrowserDataSourceInterface,
     queryState: CollectionBrowserQueryState,
   ): Promise<void> {
-    log('Installing data source & query state in CB:', dataSource, queryState);
     if (this.dataSource) this.removeController(this.dataSource);
     this.dataSource = dataSource;
     this.addController(this.dataSource);

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1761,6 +1761,17 @@ export class CollectionBrowser
       this.applyDefaultProfileSort();
     }
 
+    if (changed.has('withinCollection') && this.withinCollection) {
+      // Set a sensible default collection sort while we load results, which we will later
+      // adjust based on any sort-by metadata once the response arrives.
+      if (!this.baseQuery) {
+        this.defaultSortField = this.withinCollection.startsWith('fav-')
+          ? SortField.datefavorited
+          : SortField.weeklyview;
+        this.defaultSortDirection = 'desc';
+      }
+    }
+
     if (changed.has('baseQuery')) {
       this.emitBaseQueryChanged();
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -858,21 +858,14 @@ export class CollectionBrowser
     if (this.suppressSortBar) return nothing;
 
     // Determine the set of sortable fields that should be shown in the sort bar
-    let defaultViewSort = SortField.weeklyview;
-    let defaultDateSort = SortField.date;
     let sortFieldAvailability = defaultSortAvailability;
 
-    // We adjust the sort options for a couple of special cases...
+    // We adjust the available sort options for a couple of special cases...
     if (this.withinCollection?.startsWith('fav-')) {
-      // When viewing a fav- collection, we include the Date Favorited option and show
-      // it as the default in the date dropdown.
-      defaultDateSort = SortField.datefavorited;
+      // When viewing a fav- collection, we include the Date Favorited option as the default
       sortFieldAvailability = favoritesSortAvailability;
     } else if (!this.withinCollection && this.searchType === SearchType.TV) {
-      // When viewing TV search results, we default the views dropdown to All-time Views
-      // and exclude several of the usual date sort options.
-      defaultViewSort = SortField.alltimeview;
-      defaultDateSort = SortField.datearchived;
+      // When viewing TV search results, we exclude several of the usual date sort options.
       sortFieldAvailability = tvSortAvailability;
     }
 
@@ -883,8 +876,6 @@ export class CollectionBrowser
       <sort-filter-bar
         .defaultSortField=${this.defaultSortField}
         .defaultSortDirection=${this.defaultSortDirection}
-        .defaultViewSort=${defaultViewSort}
-        .defaultDateSort=${defaultDateSort}
         .selectedSort=${this.selectedSort}
         .sortDirection=${this.sortDirection}
         .sortFieldAvailability=${sortFieldAvailability}
@@ -892,7 +883,6 @@ export class CollectionBrowser
         .selectedTitleFilter=${this.selectedTitleFilter}
         .selectedCreatorFilter=${this.selectedCreatorFilter}
         .prefixFilterCountMap=${this.dataSource.prefixFilterCountMap}
-        .resizeObserver=${this.resizeObserver}
         .enableSortOptionsSlot=${this.enableSortOptionsSlot}
         .suppressDisplayModes=${this.suppressDisplayModes}
         @sortChanged=${this.userChangedSort}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -75,7 +75,6 @@ import { updateSelectedFacetBucket } from './utils/facet-utils';
 import chevronIcon from './assets/img/icons/chevron';
 import { srOnlyStyle } from './styles/sr-only';
 import { sha1 } from './utils/sha1';
-import { log } from './utils/log';
 import type { PlaceholderType } from './empty-placeholder';
 import type { ManageBar } from './manage/manage-bar';
 import type { SmartFacetBar } from './collection-facets/smart-facets/smart-facet-bar';

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1118,15 +1118,20 @@ export class CollectionBrowserDataSource
 
     let sortParams = this.host.sortParam ? [this.host.sortParam] : [];
     // TODO eventually the PPS should handle these defaults natively
-    const isDefaultProfileSort =
-      withinProfile && this.host.selectedSort === SortField.default;
-    if (isDefaultProfileSort && this.host.defaultSortField) {
+    const isDefaultSort = this.host.selectedSort === SortField.default;
+    const isTVSearch = this.host.searchType === SearchType.TV;
+    const isDefaultTVSort = isTVSearch && isDefaultSort;
+    const isDefaultProfileSort = withinProfile && isDefaultSort;
+    if (
+      (isDefaultProfileSort || isDefaultTVSort) &&
+      this.host.defaultSortField
+    ) {
       const sortOption = SORT_OPTIONS[this.host.defaultSortField];
       if (sortOption.searchServiceKey) {
         sortParams = [
           {
             field: sortOption.searchServiceKey,
-            direction: 'desc',
+            direction: this.host.defaultSortDirection ?? 'desc',
           },
         ];
       }

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -250,7 +250,6 @@ export class CollectionBrowserDataSource
    * @inheritdoc
    */
   reset(): void {
-    log('Resetting CB data source');
     this.pages = {};
     this.aggregations = {};
     this.histogramAggregation = undefined;

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -32,7 +32,6 @@ import {
 import type { CollectionBrowserDataSourceInterface } from './collection-browser-data-source-interface';
 import type { CollectionBrowserSearchInterface } from './collection-browser-query-state';
 import { sha1 } from '../utils/sha1';
-import { log } from '../utils/log';
 import { mergeSelectedFacets } from '../utils/facet-utils';
 
 export class CollectionBrowserDataSource

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -39,6 +39,7 @@ export interface CollectionBrowserSearchInterface
   isTVCollection: boolean;
   readonly sortParam: SortParam | null;
   readonly defaultSortField: SortField | null;
+  readonly defaultSortDirection: SortDirection | null;
   readonly facetLoadStrategy: FacetLoadStrategy;
   readonly initialPageNumber: number;
   readonly maxPagesToManage: number;

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -566,6 +566,7 @@ export class SortFilterBar extends LitElement {
           display: flex;
           justify-content: flex-start;
           align-items: center;
+          padding-bottom: 1px;
           border-bottom: 1px solid #2c2c2c;
           font-size: 1.4rem;
         }
@@ -602,10 +603,16 @@ export class SortFilterBar extends LitElement {
         }
 
         .sort-direction-selector {
-          padding: 0;
-          border: none;
+          display: flex;
+          justify-content: center;
+          width: 30px;
+          margin: 0 5px 0 3px;
+          padding: 7px 8px;
+          max-height: fit-content;
+          border-radius: 5px;
+          background: white;
+          border: 1px solid rgb(25, 72, 128);
           appearance: none;
-          background: transparent;
           cursor: pointer;
         }
 
@@ -621,8 +628,8 @@ export class SortFilterBar extends LitElement {
           border: none;
           padding: 0;
           outline: inherit;
-          width: 14px;
-          height: 14px;
+          width: 12px;
+          height: 12px;
         }
 
         .sort-direction-icon > svg {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -446,7 +446,7 @@ export class SortFilterBar extends LitElement {
     this.emitCreatorLetterChangedEvent();
   }
 
-  private setSortDirection(sortDirection: SortDirection) {
+  setSortDirection(sortDirection: SortDirection) {
     this.sortDirection = sortDirection;
     this.emitSortChangedEvent();
   }
@@ -474,7 +474,7 @@ export class SortFilterBar extends LitElement {
     this.toggleSortDirection();
   }
 
-  private setSelectedSort(sort: SortField) {
+  setSelectedSort(sort: SortField) {
     this.selectedSort = sort;
     // Apply this field's default sort direction
     const sortOption = SORT_OPTIONS[sort];

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -17,6 +17,7 @@ import {
   PrefixFilterType,
   SORT_OPTIONS,
   SortField,
+  SortOption,
 } from '../models';
 
 import { sortUpIcon } from './img/sort-toggle-up';
@@ -466,9 +467,15 @@ export class SortFilterBar extends LitElement {
 
   /** The current sort field, or the default one if no explicit sort is set */
   private get finalizedSortField(): SortField {
-    return this.selectedSort === SortField.default
-      ? this.defaultSortField
-      : this.selectedSort;
+    const resolvedField =
+      this.selectedSort === SortField.default
+        ? this.defaultSortField
+        : this.selectedSort;
+    if (this.sortFieldAvailability[resolvedField]) return resolvedField;
+
+    // Fall back to the first available sort option shown in the sort bar, if
+    // the requested one isn't available
+    return this.firstAvailableOption?.field ?? resolvedField;
   }
 
   /** The current sort direction, or the default one if no explicit direction is set */
@@ -476,6 +483,13 @@ export class SortFilterBar extends LitElement {
     return this.sortDirection === null
       ? this.defaultSortDirection
       : this.sortDirection;
+  }
+
+  /** The first option shown in the sort dropdown, or undefined if none are available */
+  private get firstAvailableOption(): SortOption | undefined {
+    return Object.values(SORT_OPTIONS).find(
+      opt => opt.shownInSortBar && this.sortFieldAvailability[opt.field],
+    );
   }
 
   /** Whether the sort direction button should be enabled for the current sort */

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -323,9 +323,6 @@ export class SortFilterBar extends LitElement {
   private getDropdownOption(sortField: SortField): optionInterface {
     return {
       id: sortField,
-      selectedHandler: () => {
-        this.selectDropdownSortField(sortField);
-      },
       label: html`
         <span class="dropdown-option-label">
           ${SORT_OPTIONS[sortField].displayName}
@@ -421,12 +418,6 @@ export class SortFilterBar extends LitElement {
     if (!this.sortOptionsDropdown) return;
     this.sortOptionsDropdown.open = false;
     this.sortOptionsDropdown.classList.remove('open');
-  }
-
-  private selectDropdownSortField(sortField: SortField) {
-    // When a dropdown sort option is selected, we additionally need to clear the backdrop
-    this.dropdownBackdropVisible = false;
-    this.setSelectedSort(sortField);
   }
 
   setSortDirection(sortDirection: SortDirection) {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -11,8 +11,6 @@ import { msg } from '@lit/localize';
 import type { IaDropdown, optionInterface } from '@internetarchive/ia-dropdown';
 import type { SortDirection } from '@internetarchive/search-service';
 import {
-  ALL_DATE_SORT_FIELDS,
-  ALL_VIEWS_SORT_FIELDS,
   CollectionDisplayMode,
   defaultSortAvailability,
   PrefixFilterCounts,
@@ -187,7 +185,7 @@ export class SortFilterBar extends LitElement {
 
   private boundSortBarSelectorEscapeListener = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      this.closeDropdowns();
+      this.closeDropdown();
     }
   };
 
@@ -283,8 +281,6 @@ export class SortFilterBar extends LitElement {
    *  selected appearance
    * @param options.onOptionSelected A handler for optionSelected events coming from the dropdown
    * @param options.onDropdownClick A handler for click events on the dropdown
-   * @param options.onLabelInteraction A handler for click events and Enter/Space keydown events
-   *  on the dropdown's label
    */
   private getSortDropdown(options: {
     displayName: string;
@@ -294,7 +290,6 @@ export class SortFilterBar extends LitElement {
     selected: boolean;
     onOptionSelected?: (e: CustomEvent<{ option: optionInterface }>) => void;
     onDropdownClick?: (e: PointerEvent) => void;
-    onLabelInteraction?: (e: Event) => void;
   }): TemplateResult {
     return html`
       <ia-dropdown
@@ -313,14 +308,6 @@ export class SortFilterBar extends LitElement {
           class="dropdown-label"
           slot="dropdown-label"
           data-title=${options.displayName}
-          @click=${options.onLabelInteraction ?? nothing}
-          @keydown=${options.onLabelInteraction
-            ? (e: KeyboardEvent) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  options.onLabelInteraction?.(e);
-                }
-              }
-            : nothing}
         >
           ${options.displayName}
         </span>
@@ -417,14 +404,14 @@ export class SortFilterBar extends LitElement {
     return html`
       <div
         id="sort-selector-backdrop"
-        @keyup=${this.closeDropdowns}
-        @click=${this.closeDropdowns}
+        @keyup=${this.closeDropdown}
+        @click=${this.closeDropdown}
       ></div>
     `;
   }
 
-  /** Closes all of the sorting dropdown components' menus */
-  private closeDropdowns() {
+  /** Closes the sorting dropdown component's menus */
+  private closeDropdown() {
     this.dropdownBackdropVisible = false;
 
     if (!this.sortOptionsDropdown) return;
@@ -436,14 +423,6 @@ export class SortFilterBar extends LitElement {
     // When a dropdown sort option is selected, we additionally need to clear the backdrop
     this.dropdownBackdropVisible = false;
     this.setSelectedSort(sortField);
-  }
-
-  private clearAlphaBarFilters() {
-    this.alphaSelectorVisible = null;
-    this.selectedTitleFilter = null;
-    this.selectedCreatorFilter = null;
-    this.emitTitleLetterChangedEvent();
-    this.emitCreatorLetterChangedEvent();
   }
 
   setSortDirection(sortDirection: SortDirection) {
@@ -499,63 +478,6 @@ export class SortFilterBar extends LitElement {
   /** Whether the sort direction button should be enabled for the current sort */
   private get canChangeSortDirection(): boolean {
     return SORT_OPTIONS[this.finalizedSortField].canSetDirection;
-  }
-
-  /**
-   * There are four date sort options.
-   *
-   * This checks to see if the current sort is one of them.
-   *
-   * @readonly
-   * @private
-   * @type {boolean}
-   * @memberof SortFilterBar
-   */
-  private get dateOptionSelected(): boolean {
-    const dateSortFields: SortField[] = [
-      SortField.datefavorited,
-      SortField.datearchived,
-      SortField.date,
-      SortField.datereviewed,
-      SortField.dateadded,
-    ];
-    return dateSortFields.includes(this.finalizedSortField);
-  }
-
-  /**
-   * There are two view sort options.
-   *
-   * This checks to see if the current sort is one of them.
-   *
-   * @readonly
-   * @private
-   * @type {boolean}
-   * @memberof SortFilterBar
-   */
-  private get viewOptionSelected(): boolean {
-    const viewSortFields: SortField[] = [
-      SortField.alltimeview,
-      SortField.weeklyview,
-    ];
-    return viewSortFields.includes(this.finalizedSortField);
-  }
-
-  /**
-   * Array of all the views sorts that should be shown
-   */
-  private get availableViewsFields(): SortField[] {
-    return ALL_VIEWS_SORT_FIELDS.filter(
-      field => this.sortFieldAvailability[field],
-    );
-  }
-
-  /**
-   * Array of all the date sorts that should be shown
-   */
-  private get availableDateFields(): SortField[] {
-    return ALL_DATE_SORT_FIELDS.filter(
-      field => this.sortFieldAvailability[field],
-    );
   }
 
   private get titleSelectorBar() {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -7,7 +7,7 @@ import {
   TemplateResult,
 } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { msg } from '@lit/localize';
+import { msg, str } from '@lit/localize';
 import type { IaDropdown, optionInterface } from '@internetarchive/ia-dropdown';
 import type { SortDirection } from '@internetarchive/search-service';
 import {
@@ -211,16 +211,19 @@ export class SortFilterBar extends LitElement {
   /** Template to render the sort direction toggle button */
   private get sortDirectionSelectorTemplate(): TemplateResult {
     const oppositeSortDirectionReadable =
-      this.sortDirection === 'asc' ? 'descending' : 'ascending';
-    const srLabel = `Change to ${oppositeSortDirectionReadable} sort`;
+      this.sortDirection === 'asc' ? msg('descending') : msg('ascending');
+    const buttonLabel = this.canChangeSortDirection
+      ? msg(str`Change to ${oppositeSortDirectionReadable} sort`)
+      : msg('Directions are not available for the current sort option');
 
     return html`
       <button
         class="sort-direction-selector"
+        title=${buttonLabel}
         ?disabled=${!this.canChangeSortDirection}
         @click=${this.handleSortDirectionClicked}
       >
-        <span class="sr-only">${srLabel}</span>
+        <span class="sr-only">${buttonLabel}</span>
         ${this.sortDirectionIcon}
       </button>
     `;

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -555,6 +555,8 @@ export class SortFilterBar extends LitElement {
   }
 
   static get styles() {
+    const disabledIconColor = css`#bbbbbb`;
+
     return [
       srOnlyStyle,
       css`
@@ -599,14 +601,14 @@ export class SortFilterBar extends LitElement {
           display: flex;
           align-self: stretch;
           flex: 0;
-          margin: 0 5px;
+          margin: 0 3px;
         }
 
         .sort-direction-selector {
           display: flex;
           justify-content: center;
           width: 30px;
-          margin: 0 5px 0 3px;
+          margin: 0 5px 0 0;
           padding: 7px 8px;
           max-height: fit-content;
           border-radius: 5px;
@@ -617,7 +619,8 @@ export class SortFilterBar extends LitElement {
         }
 
         .sort-direction-selector:disabled {
-          cursor: default;
+          cursor: not-allowed;
+          border-color: ${disabledIconColor};
         }
 
         .sort-direction-icon {
@@ -670,7 +673,7 @@ export class SortFilterBar extends LitElement {
           appearance: none;
           cursor: pointer;
           -webkit-appearance: none;
-          fill: #bbbbbb;
+          fill: ${disabledIconColor};
         }
 
         #display-style-selector button.active {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -970,7 +970,7 @@ describe('Collection Browser', () => {
       </collection-browser>`,
     );
 
-    expect(el.selectedSort).to.equal(SortField.relevance);
+    expect(el.selectedSort).to.equal(SortField.default);
 
     el.baseQuery = 'foo';
     await el.updateComplete;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -978,31 +978,20 @@ describe('Collection Browser', () => {
 
     const sortBar = el.shadowRoot?.querySelector(
       '#content-container sort-filter-bar',
-    );
-    const sortSelector = sortBar?.shadowRoot?.querySelector(
-      '#desktop-sort-selector',
-    );
-    expect(sortSelector, 'sort bar').to.exist;
+    ) as SortFilterBar;
+    expect(sortBar, 'sort bar').to.exist;
 
-    // Click the title sorter
-    Array.from(sortSelector!.children)
-      .find(child => child.textContent?.trim() === 'Title')
-      ?.querySelector('button')
-      ?.click();
-
+    // Switch to title sort
+    sortBar.setSelectedSort(SortField.title);
     await el.updateComplete;
-
     expect(el.selectedSort).to.equal(SortField.title);
+    expect(el.sortDirection).to.equal('asc'); // Default for title sort
 
-    // Click the creator sorter
-    Array.from(sortSelector!.children)
-      .find(child => child.textContent?.trim() === 'Creator')
-      ?.querySelector('button')
-      ?.click();
-
+    // Switch to descending sort order
+    sortBar.setSortDirection('desc');
     await el.updateComplete;
-
-    expect(el.selectedSort).to.equal(SortField.creator);
+    expect(el.selectedSort).to.equal(SortField.title);
+    expect(el.sortDirection).to.equal('desc');
   });
 
   it('sets sort filter properties when user selects title filter', async () => {

--- a/test/sort-filter-bar/sort-filter-bar.test.ts
+++ b/test/sort-filter-bar/sort-filter-bar.test.ts
@@ -88,6 +88,20 @@ describe('Sort dropdown behavior', () => {
     expect(label?.textContent?.trim()).to.equal('All-time views');
   });
 
+  it('falls back to first available sort when default is unavailable', async () => {
+    el.selectedSort = SortField.default;
+    el.defaultSortField = SortField.relevance;
+    el.sortFieldAvailability = {
+      ...defaultSortAvailability,
+      [SortField.relevance]: false,
+    };
+    await el.updateComplete;
+
+    const label = sortDropdown?.querySelector('.dropdown-label');
+    // No relevance, so fall back to the first one in the list
+    expect(label?.textContent?.trim()).to.equal('All-time views');
+  });
+
   it('changes selected sort when dropdown option selected', async () => {
     expect(sortDropdown).to.exist;
 


### PR DESCRIPTION
Currently the layout of the sort bar at large widths is to split out several different groups of sort options, only collapsing them to a single dropdown below a mobile breakpoint. However, for improved clarity and consistency, we will be switching to a single-dropdown approach in all cases.

This PR removes the old grouped desktop layout and renders the single-dropdown layout for all cases (as in the old mobile version). Moreover, the design of the sort direction toggle is adjusted to make it clearer that it is interactive.