### PR TITLE
WEBDEV-8185 Refactor to extract default sort management

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,10 @@ export {
   FacetOption,
   SelectedFacets,
   getDefaultSelectedFacets,
+  sortOptionFromAPIString,
+  resolveCollectionDefaultSort,
+  SORT_OPTIONS,
+  defaultProfileElementSorts,
 } from './src/models';
 export { CollectionBrowserLoadingTile } from './src/tiles/collection-browser-loading-tile';
 export { CollectionTile } from './src/tiles/grid/collection-tile';

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ export { SortFilterBar } from './src/sort-filter-bar/sort-filter-bar';
 export {
   CollectionDisplayMode,
   SortField,
+  ExplicitSortField,
   TileModel,
   FacetOption,
   SelectedFacets,

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -36,6 +36,7 @@ import type { IAComboBox } from '@internetarchive/elements/ia-combo-box/ia-combo
 import {
   SelectedFacets,
   SortField,
+  type ExplicitSortField,
   CollectionBrowserContext,
   getDefaultSelectedFacets,
   TileModel,
@@ -151,10 +152,8 @@ export class CollectionBrowser
 
   @property({ type: String }) sortDirection: SortDirection | null = null;
 
-  @property({ type: String }) defaultSortField: Exclude<
-    SortField,
-    SortField.default
-  > = SortField.relevance;
+  @property({ type: String }) defaultSortField: ExplicitSortField =
+    SortField.relevance;
 
   @property({ type: String }) defaultSortDirection: SortDirection | null = null;
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1645,6 +1645,12 @@ export class CollectionBrowser
     this.maxSelectedDate = queryState.maxSelectedDate;
     this.selectedSort = queryState.selectedSort ?? SortField.default;
     this.sortDirection = queryState.sortDirection;
+    if (queryState.defaultSortField) {
+      this.defaultSortField = queryState.defaultSortField;
+    }
+    if (queryState.defaultSortDirection !== undefined) {
+      this.defaultSortDirection = queryState.defaultSortDirection;
+    }
     this.selectedTitleFilter = queryState.selectedTitleFilter;
     this.selectedCreatorFilter = queryState.selectedCreatorFilter;
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -42,9 +42,7 @@ import {
   TileModel,
   CollectionDisplayMode,
   FacetEventDetails,
-  sortOptionFromAPIString,
   SORT_OPTIONS,
-  defaultProfileElementSorts,
   FacetLoadStrategy,
   defaultFacetDisplayOrder,
   tvFacetDisplayOrder,
@@ -600,10 +598,6 @@ export class CollectionBrowser
 
   willUpdate(changed: PropertyValues): void {
     this.setPlaceholderType();
-
-    if (changed.has('searchType') && this.searchType === SearchType.TV) {
-      this.applyDefaultTVSearchSort();
-    }
   }
 
   render() {
@@ -1761,21 +1755,6 @@ export class CollectionBrowser
       }
     }
 
-    if (changed.has('profileElement')) {
-      this.applyDefaultProfileSort();
-    }
-
-    if (changed.has('withinCollection') && this.withinCollection) {
-      // Set a sensible default collection sort while we load results, which we will later
-      // adjust based on any sort-by metadata once the response arrives.
-      if (!this.baseQuery) {
-        this.defaultSortField = this.withinCollection.startsWith('fav-')
-          ? SortField.datefavorited
-          : SortField.weeklyview;
-        this.defaultSortDirection = 'desc';
-      }
-    }
-
     if (changed.has('baseQuery')) {
       this.emitBaseQueryChanged();
     }
@@ -2241,11 +2220,6 @@ export class CollectionBrowser
       this.infiniteScroller.reload();
     }
 
-    if (this.withinCollection && this.baseQuery?.trim()) {
-      this.defaultSortField = SortField.relevance;
-      this.defaultSortDirection = null;
-    }
-
     if (!this.initialQueryChangeHappened && this.initialPageNumber > 1) {
       this.scrollToPage(this.initialPageNumber);
     }
@@ -2401,75 +2375,6 @@ export class CollectionBrowser
     if (this.infiniteScroller) {
       this.infiniteScroller.itemCount = count;
     }
-  }
-
-  /**
-   * Applies the default sort options for the TV search results page
-   */
-  applyDefaultTVSearchSort(): void {
-    this.defaultSortField = SortField.datearchived;
-    this.defaultSortDirection = 'desc';
-  }
-
-  /**
-   * Applies any default sort option for the current collection, by checking
-   * for one in the collection's metadata. If none is found, defaults to sorting
-   * descending by:
-   *  - Date Favorited for fav-* collections
-   *  - Weekly views for all other collections
-   */
-  applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo): void {
-    if (this.baseQuery) {
-      // If there's a query set, then we default to relevance sorting regardless of
-      // the collection metadata-specified sort.
-      this.defaultSortField = SortField.relevance;
-      this.defaultSortDirection = null;
-      return;
-    }
-
-    // Favorite collections sort on Date Favorited by default.
-    // Other collections fall back to sorting on weekly views.
-    const baseDefaultSort: string =
-      collectionInfo?.public_metadata?.identifier?.startsWith('fav-')
-        ? '-favoritedate'
-        : '-week';
-
-    // The collection metadata may override the default sorting with something else
-    const metadataSort: string | undefined =
-      collectionInfo?.public_metadata?.['sort-by'];
-
-    // Prefer the metadata-specified sort if one exists
-    const defaultSortToApply = metadataSort ?? baseDefaultSort;
-
-    // Account for both -field and field:dir formats
-    let [field, dir] = defaultSortToApply.split(':');
-    if (field.startsWith('-')) {
-      field = field.slice(1);
-      dir = 'desc';
-    } else if (!['asc', 'desc'].includes(dir)) {
-      dir = 'asc';
-    }
-
-    const sortOption = sortOptionFromAPIString(field);
-    const sortField = sortOption.field;
-    if (sortField && sortField !== SortField.default) {
-      this.defaultSortField = sortField;
-      this.defaultSortDirection = dir as SortDirection;
-    }
-  }
-
-  /**
-   * Applies the default sort option for the current profile element
-   */
-  applyDefaultProfileSort(): void {
-    if (this.profileElement) {
-      const defaultSortField = defaultProfileElementSorts[this.profileElement];
-      this.defaultSortField = defaultSortField ?? SortField.weeklyview;
-    } else {
-      this.defaultSortField = SortField.weeklyview;
-    }
-
-    this.defaultSortDirection = 'desc';
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -2089,6 +2089,22 @@ export class CollectionBrowser
   }
 
   /**
+   * Emits a `collectionExtraInfoLoaded` event when the data source has received
+   * collection metadata from the backend. This allows parent components to react
+   * to the metadata (e.g., to update their default sort based on the collection's
+   * `sort-by` metadata field).
+   */
+  emitCollectionExtraInfoLoaded(
+    collectionExtraInfo?: CollectionExtraInfo,
+  ): void {
+    this.dispatchEvent(
+      new CustomEvent('collectionExtraInfoLoaded', {
+        detail: collectionExtraInfo,
+      }),
+    );
+  }
+
+  /**
    * Emits a `queryStateChanged` event indicating that one or more of this component's
    * properties have changed in a way that could affect the set of search results.
    */

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1198,6 +1198,7 @@ export class CollectionBrowserDataSource
       // which can be specified in metadata, or otherwise assumed to be week:desc
       if (this.activeOnHost) {
         this.host.applyDefaultCollectionSort(this.collectionExtraInfo);
+        this.host.emitCollectionExtraInfoLoaded(this.collectionExtraInfo);
       }
 
       if (this.collectionExtraInfo) {

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -1194,10 +1194,8 @@ export class CollectionBrowserDataSource
     if (withinCollection) {
       this.collectionExtraInfo = success.response.collectionExtraInfo;
 
-      // For collections, we want the UI to respect the default sort option
-      // which can be specified in metadata, or otherwise assumed to be week:desc
+      // Emit the collection metadata so the parent page can set default sort
       if (this.activeOnHost) {
-        this.host.applyDefaultCollectionSort(this.collectionExtraInfo);
         this.host.emitCollectionExtraInfoLoaded(this.collectionExtraInfo);
       }
 

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -6,7 +6,12 @@ import type {
   SortDirection,
   SortParam,
 } from '@internetarchive/search-service';
-import type { FacetLoadStrategy, SelectedFacets, SortField } from '../models';
+import type {
+  ExplicitSortField,
+  FacetLoadStrategy,
+  SelectedFacets,
+  SortField,
+} from '../models';
 import type { CollectionBrowserDataSourceInterface } from './collection-browser-data-source-interface';
 
 /**
@@ -27,6 +32,8 @@ export interface CollectionBrowserQueryState {
   selectedCreatorFilter: string | null;
   selectedSort?: SortField;
   sortDirection: SortDirection | null;
+  defaultSortField?: ExplicitSortField;
+  defaultSortDirection?: SortDirection | null;
 }
 
 /**

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -59,7 +59,6 @@ export interface CollectionBrowserSearchInterface
   setFacetsLoading(loading: boolean): void;
   setTotalResultCount(count: number): void;
   setTileCount(count: number): void;
-  applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo): void;
   emitCollectionExtraInfoLoaded(
     collectionExtraInfo?: CollectionExtraInfo,
   ): void;

--- a/src/data-source/collection-browser-query-state.ts
+++ b/src/data-source/collection-browser-query-state.ts
@@ -45,7 +45,7 @@ export interface CollectionBrowserSearchInterface
   searchService?: SearchServiceInterface;
   isTVCollection: boolean;
   readonly sortParam: SortParam | null;
-  readonly defaultSortField: SortField | null;
+  readonly defaultSortField: ExplicitSortField;
   readonly defaultSortDirection: SortDirection | null;
   readonly facetLoadStrategy: FacetLoadStrategy;
   readonly initialPageNumber: number;
@@ -60,6 +60,9 @@ export interface CollectionBrowserSearchInterface
   setTotalResultCount(count: number): void;
   setTileCount(count: number): void;
   applyDefaultCollectionSort(collectionInfo?: CollectionExtraInfo): void;
+  emitCollectionExtraInfoLoaded(
+    collectionExtraInfo?: CollectionExtraInfo,
+  ): void;
   emitEmptyResults(): void;
   emitSearchError(): void;
   emitQueryStateChanged(): void;

--- a/src/models.ts
+++ b/src/models.ts
@@ -323,6 +323,16 @@ export enum SortField {
 }
 
 /**
+ * A sort field other than the abstract "default" placeholder.
+ * This is useful because the "default" sort field is just an indicator to
+ * revert to an explicitly defined fallback value. So when defining default
+ * sort logic, this type should be preferred to avoid accidentally permitting
+ * that fallback to itself equal the "default" placeholder (which would be
+ * rather circular/ill-defined).
+ */
+export type ExplicitSortField = Exclude<SortField, SortField.default>;
+
+/**
  * Views-related sort fields
  */
 export const ALL_VIEWS_SORT_FIELDS = [
@@ -580,10 +590,7 @@ export const tvSortAvailability: Record<SortField, boolean> = {
   [SortField.dateadded]: false,
 };
 
-export const defaultProfileElementSorts: Record<
-  string,
-  Exclude<SortField, SortField.default>
-> = {
+export const defaultProfileElementSorts: Record<string, ExplicitSortField> = {
   uploads: SortField.datearchived,
   reviews: SortField.datereviewed,
   collections: SortField.datearchived,

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,6 +3,7 @@ import { msg } from '@lit/localize';
 import type { MediaType } from '@internetarchive/field-parsers';
 import {
   AggregationSortType,
+  CollectionExtraInfo,
   HitType,
   SearchReview,
   SearchResult,
@@ -561,6 +562,47 @@ export function sortOptionFromAPIString(sortName?: string | null): SortOption {
       opt.urlNames.some(name => sortName === name),
     ) ?? SORT_OPTIONS[SortField.unrecognized]
   );
+}
+
+/**
+ * Resolves the default sort option for a collection based on its metadata.
+ *
+ * - Favorite collections (`fav-*`) default to Date Favorited descending.
+ * - Other collections default to Weekly Views descending.
+ * - If the collection metadata specifies a `sort-by` field, that overrides the above.
+ *
+ * Supports both `-field` (dash prefix = desc) and `field:dir` metadata formats.
+ *
+ * Note: This does NOT handle the "relevance when a query is present" rule,
+ * which is managed separately by collection-browser itself.
+ */
+export function resolveCollectionDefaultSort(
+  collectionInfo?: CollectionExtraInfo,
+): { field: ExplicitSortField; direction: SortDirection } {
+  const isFav = collectionInfo?.public_metadata?.identifier?.startsWith('fav-');
+  const baseDefaultSort: string = isFav ? '-favoritedate' : '-week';
+  const metadataSort: string | undefined =
+    collectionInfo?.public_metadata?.['sort-by'];
+  const defaultSortToApply = metadataSort ?? baseDefaultSort;
+
+  // Account for both -field and field:dir formats
+  let [field, dir] = defaultSortToApply.split(':');
+  if (field.startsWith('-')) {
+    field = field.slice(1);
+    dir = 'desc';
+  } else if (!['asc', 'desc'].includes(dir)) {
+    dir = 'asc';
+  }
+
+  const sortOption = sortOptionFromAPIString(field);
+  const sortField = sortOption.field;
+  if (sortField && sortField !== SortField.default) {
+    return {
+      field: sortField as ExplicitSortField,
+      direction: dir as SortDirection,
+    };
+  }
+  return { field: SortField.weeklyview, direction: 'desc' };
 }
 
 export const defaultSortAvailability: Record<SortField, boolean> = {

--- a/src/sort-filter-bar/sort-filter-bar.ts
+++ b/src/sort-filter-bar/sort-filter-bar.ts
@@ -13,6 +13,7 @@ import type { SortDirection } from '@internetarchive/search-service';
 import {
   CollectionDisplayMode,
   defaultSortAvailability,
+  type ExplicitSortField,
   PrefixFilterCounts,
   PrefixFilterType,
   SORT_OPTIONS,
@@ -42,10 +43,8 @@ export class SortFilterBar extends LitElement {
   @property({ type: String }) defaultSortDirection: SortDirection | null = null;
 
   /** The default sort field to use if none is set */
-  @property({ type: String }) defaultSortField: Exclude<
-    SortField,
-    SortField.default
-  > = SortField.relevance;
+  @property({ type: String }) defaultSortField: ExplicitSortField =
+    SortField.relevance;
 
   /** The current sort direction (asc/desc), or null if none is set */
   @property({ type: String }) sortDirection: SortDirection | null = null;

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1313,20 +1313,19 @@ describe('Collection Browser', () => {
     );
   });
 
-  it('sets default sort from collection metadata', async () => {
+  it('sets default sort from externally-provided values', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
         .searchService=${searchService}
         .baseNavigationUrl=${''}
+        .withinCollection=${'test-collection'}
+        .defaultSortField=${SortField.title}
+        .defaultSortDirection=${'asc'}
       ></collection-browser>`,
     );
 
-    el.withinCollection = 'default-sort';
     await el.updateComplete;
-    await el.initialSearchComplete;
-    await el.updateComplete;
-    await aTimeout(50);
 
     const sortBar = el.shadowRoot?.querySelector(
       'sort-filter-bar',
@@ -1338,20 +1337,19 @@ describe('Collection Browser', () => {
     expect(sortBar.sortDirection).to.be.null;
   });
 
-  it('sets default sort from collection metadata in "-field" format', async () => {
+  it('reflects updated default sort field/direction on sort bar', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
         .searchService=${searchService}
         .baseNavigationUrl=${''}
+        .withinCollection=${'test-collection'}
+        .defaultSortField=${SortField.dateadded}
+        .defaultSortDirection=${'desc'}
       ></collection-browser>`,
     );
 
-    el.withinCollection = 'default-sort-concise';
     await el.updateComplete;
-    await el.initialSearchComplete;
-    await el.updateComplete;
-    await aTimeout(50);
 
     const sortBar = el.shadowRoot?.querySelector(
       'sort-filter-bar',
@@ -1363,60 +1361,34 @@ describe('Collection Browser', () => {
     expect(sortBar.sortDirection).to.be.null;
   });
 
-  it('falls back to weekly views default sorting on profiles when tab not set', async () => {
+  it('uses weekly views as default sort when set externally for profiles', async () => {
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
         .withinProfile=${'@foobar'}
+        .defaultSortField=${SortField.weeklyview}
+        .defaultSortDirection=${'desc'}
       ></collection-browser>`,
     );
 
-    el.applyDefaultProfileSort();
     expect(el.defaultSortParam).to.deep.equal({
       field: 'week',
       direction: 'desc',
     });
   });
 
-  it('uses relevance sort as default when a query is set', async () => {
+  it('uses date favorited sort as default when set externally for fav- collection', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(
       html`<collection-browser
         .searchService=${searchService}
         .baseNavigationUrl=${''}
+        .withinCollection=${'fav-sort'}
+        .defaultSortField=${SortField.datefavorited}
+        .defaultSortDirection=${'desc'}
       ></collection-browser>`,
     );
 
-    el.withinCollection = 'default-sort';
-    el.baseQuery = 'default-sort';
     await el.updateComplete;
-    await el.initialSearchComplete;
-    await el.updateComplete;
-    await aTimeout(50);
-
-    const sortBar = el.shadowRoot?.querySelector(
-      'sort-filter-bar',
-    ) as SortFilterBar;
-    expect(sortBar).to.exist;
-    expect(sortBar.defaultSortField).to.equal(SortField.relevance);
-    expect(sortBar.defaultSortDirection).to.be.null;
-    expect(sortBar.selectedSort).to.equal(SortField.default);
-    expect(sortBar.sortDirection).to.be.null;
-  });
-
-  it('uses date favorited sort as default when targeting fav- collection', async () => {
-    const searchService = new MockSearchService();
-    const el = await fixture<CollectionBrowser>(
-      html`<collection-browser
-        .searchService=${searchService}
-        .baseNavigationUrl=${''}
-      ></collection-browser>`,
-    );
-
-    el.withinCollection = 'fav-sort';
-    await el.updateComplete;
-    await el.initialSearchComplete;
-    await el.updateComplete;
-    await aTimeout(50);
 
     const sortBar = el.shadowRoot?.querySelector(
       'sort-filter-bar',


### PR DESCRIPTION
Currently, collection-browser manages default sort properties internally, based on factors like the type/context of the search performed and any `sort-by` metadata present in the search response. While this allows the parent page to be hands-off about the default sort, it leads to increasing complexity in the logic that collection-browser must handle itself to determine the appropriate behavior, and requires it to know more than is reasonable about how/where it is being used.

This PR inverts the responsibilities so that the parent page may independently set collection-browser's default sort depending on its own context and needs (e.g., what kind of page, what tab is selected), and removes much of collection-browser's own handling of that logic. Instead, collection-browser emits the appropriate events w/ more details for the parent page to react to with any sorting changes necessary (e.g., when new collection metadata is received).