### PR TITLE
WEBDEV-8332 Only show tile info buttons when hover panes are enabled

### DIFF
--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -227,7 +227,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
 
   /** @inheritdoc */
   toggleHoverPane(options: ToggleHoverPaneOptions): void {
-    if (this.hoverPaneState === 'shown') {
+    if (this.hoverPaneState !== 'hidden') {
       this.fadeOutHoverPane();
       this.forceTouchBackdrop = false;
     } else {
@@ -546,6 +546,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     if (this.hoverPaneState !== 'hidden') {
       this.fadeOutHoverPane();
     }
+    e.preventDefault();
     e.stopPropagation();
   };
 

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -218,6 +218,15 @@ export class TileDispatcher
     return window.matchMedia('(hover: hover)').matches;
   }
 
+  /**
+   * Whether the info button should be shown on this tile.
+   * Only shown on touch/non-hover devices where a hover pane is available,
+   * so the button always has something to toggle.
+   */
+  private get shouldShowInfoButton(): boolean {
+    return !this.isHoverEnabled && this.shouldPrepareHoverPane;
+  }
+
   /** @inheritdoc */
   getHoverPane(): TileHoverPane | undefined {
     return this.hoverPane;
@@ -326,7 +335,7 @@ export class TileDispatcher
               .suppressBlurring=${this.suppressBlurring}
               .isManageView=${this.isManageView}
               .layoutType=${this.layoutType}
-              ?showInfoButton=${!this.isHoverEnabled}
+              ?showInfoButton=${this.shouldShowInfoButton}
               @infoButtonPressed=${this.tileInfoButtonPressed}
             >
             </collection-tile>`;
@@ -340,7 +349,7 @@ export class TileDispatcher
               .creatorFilter=${creatorFilter}
               .suppressBlurring=${this.suppressBlurring}
               .isManageView=${this.isManageView}
-              ?showInfoButton=${!this.isHoverEnabled}
+              ?showInfoButton=${this.shouldShowInfoButton}
               @infoButtonPressed=${this.tileInfoButtonPressed}
             >
             </account-tile>`;
@@ -373,7 +382,7 @@ export class TileDispatcher
               .isManageView=${this.isManageView}
               .layoutType=${this.layoutType}
               ?showTvClips=${this.showTvClips}
-              ?showInfoButton=${!this.isHoverEnabled}
+              ?showInfoButton=${this.shouldShowInfoButton}
               ?useLocalTime=${this.useLocalTime}
               @infoButtonPressed=${this.tileInfoButtonPressed}
             >

--- a/test/tiles/tile-dispatcher.test.ts
+++ b/test/tiles/tile-dispatcher.test.ts
@@ -213,6 +213,23 @@ describe('Tile Dispatcher', () => {
       await el.updateComplete;
       expect(el.getHoverPane()).not.to.exist;
     });
+
+    it('should not show info button when hover pane is not enabled', async () => {
+      const el = await fixture<TileDispatcher>(html`
+        <tile-dispatcher
+          .tileDisplayMode=${'grid'}
+          .model=${{ mediatype: 'texts' }}
+          .enableHoverPane=${false}
+        >
+        </tile-dispatcher>
+      `);
+
+      const itemTile = el.shadowRoot?.querySelector('item-tile') as ItemTile;
+      expect(itemTile).to.exist;
+
+      const infoButton = itemTile.shadowRoot?.querySelector('.info-button');
+      expect(infoButton).to.not.exist;
+    });
   });
 
   describe('Accessibility', () => {


### PR DESCRIPTION
In contexts without hover capability (e.g., mobile screen), our tiles include a small "info" button in the corner which can be tapped to bring up the info popup that would otherwise appear on hover. However, currently even when the hover panes are disabled, we still show the info buttons, which do nothing when pressed. There is also a bug affecting Safari, where pressing the info button twice does not close the popup like expected. This PR ensures that we only show the info buttons when they would actually do something, and fixes the Safari bug.