### PR TITLE
WEBDEV-8108 Fix bug where stale filters are applied to new search queries in some cases

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -605,6 +605,43 @@ export class CollectionBrowser
     if (changed.has('searchType') && this.searchType === SearchType.TV) {
       this.applyDefaultTVSearchSort();
     }
+
+    // If we need to clear filters due to a query change or other reset, we do so *before* any
+    // updates happen, to prevent unnecessary update cycles and ensure there's a clean slate
+    // for any search requests that fire.
+    if (
+      changed.has('baseQuery') ||
+      changed.has('identifiers') ||
+      changed.has('searchType') ||
+      changed.has('withinCollection')
+    ) {
+      // Unless this query/search type update is from the initial page load or the
+      // result of hitting the back button,
+      // we need to clear any existing filters since they may no longer be valid for
+      // the new set of search results.
+      if (!this.historyPopOccurred && this.initialQueryChangeHappened) {
+        // Ordinarily, we leave the sort param unchanged between searches.
+        // However, if we are changing the target collection itself, we want the sort cleared too,
+        // since different collections may have different sorting options available.
+        const shouldClearSort =
+          changed.has('withinCollection') &&
+          !changed.has('selectedSort') &&
+          !changed.has('sortDirection');
+
+        // Otherwise, only clear filters that haven't been simultaneously applied in this update
+        this.clearFilters({
+          sort: shouldClearSort,
+          facets: !changed.has('selectedFacets'),
+          dateRange: !(
+            changed.has('minSelectedDate') || changed.has('maxSelectedDate')
+          ),
+          letterFilters: !(
+            changed.has('selectedTitleFilter') ||
+            changed.has('selectedCreatorFilter')
+          ),
+        });
+      }
+    }
   }
 
   render() {
@@ -1724,40 +1761,6 @@ export class CollectionBrowser
       changed.has('loggedIn')
     ) {
       this.infiniteScroller?.reload();
-    }
-
-    if (
-      changed.has('baseQuery') ||
-      changed.has('identifiers') ||
-      changed.has('searchType') ||
-      changed.has('withinCollection')
-    ) {
-      // Unless this query/search type update is from the initial page load or the
-      // result of hitting the back button,
-      // we need to clear any existing filters since they may no longer be valid for
-      // the new set of search results.
-      if (!this.historyPopOccurred && this.initialQueryChangeHappened) {
-        // Ordinarily, we leave the sort param unchanged between searches.
-        // However, if we are changing the target collection itself, we want the sort cleared too,
-        // since different collections may have different sorting options available.
-        const shouldClearSort =
-          changed.has('withinCollection') &&
-          !changed.has('selectedSort') &&
-          !changed.has('sortDirection');
-
-        // Otherwise, only clear filters that haven't been simultaneously applied in this update
-        this.clearFilters({
-          sort: shouldClearSort,
-          facets: !changed.has('selectedFacets'),
-          dateRange: !(
-            changed.has('minSelectedDate') || changed.has('maxSelectedDate')
-          ),
-          letterFilters: !(
-            changed.has('selectedTitleFilter') ||
-            changed.has('selectedCreatorFilter')
-          ),
-        });
-      }
     }
 
     if (changed.has('profileElement')) {

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -1906,6 +1906,111 @@ describe('Collection Browser', () => {
     expect(el.maxSelectedDate).not.to.exist;
   });
 
+  it('does not include stale facets in the search request when query changes', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    // Perform an initial search with a facet applied
+    const selectedFacets = getDefaultSelectedFacets();
+    selectedFacets.collection.radio = {
+      count: 1,
+      key: 'radio',
+      state: 'selected',
+    } as FacetBucket;
+    el.baseQuery = 'cookies';
+    el.selectedFacets = selectedFacets;
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    // The initial search should include the facet filter
+    expect(searchService.searchParams?.filters?.collection?.radio).to.equal(
+      FilterConstraint.INCLUDE,
+    );
+
+    // Ensure that the first search after the query change doesn't have stale facets
+    const searchSpy = sinon.spy(searchService, 'search');
+    el.baseQuery = 'cookies AND NOT collection:radio';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    const firstCall = searchSpy.firstCall;
+    expect(firstCall.args[0].query).to.equal(
+      'cookies AND NOT collection:radio',
+    );
+    expect(firstCall.args[0].filters?.collection).not.to.exist;
+
+    searchSpy.restore();
+  });
+
+  it('does not include stale date range in the search request when query changes', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    // Perform an initial search with a date range applied
+    el.baseQuery = 'foo';
+    el.minSelectedDate = '2000';
+    el.maxSelectedDate = '2010';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.year?.['2000']).to.equal(
+      FilterConstraint.GREATER_OR_EQUAL,
+    );
+    expect(searchService.searchParams?.filters?.year?.['2010']).to.equal(
+      FilterConstraint.LESS_OR_EQUAL,
+    );
+
+    // Change the query, which should clear the date range before searching
+    el.baseQuery = 'bar';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.year).not.to.exist;
+    expect(el.minSelectedDate).not.to.exist;
+    expect(el.maxSelectedDate).not.to.exist;
+  });
+
+  it('does not include stale letter filters in the search request when query changes', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    // Perform an initial search with a letter filter applied
+    el.baseQuery = 'first-creator';
+    el.selectedSort = 'creator' as SortField;
+    el.sortDirection = 'asc';
+    el.selectedCreatorFilter = 'X';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await nextTick();
+
+    expect(searchService.searchParams?.filters?.firstCreator?.X).to.equal(
+      FilterConstraint.INCLUDE,
+    );
+
+    // Change the query, which should clear the letter filter before searching.
+    // Check the first search call to ensure stale filters aren't sent initially.
+    const searchSpy = sinon.spy(searchService, 'search');
+    el.baseQuery = 'bar';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await nextTick();
+
+    // The very first search after the query change should not include the old filter
+    const firstCall = searchSpy.firstCall;
+    expect(firstCall.args[0].filters?.firstCreator).not.to.exist;
+
+    searchSpy.restore();
+  });
+
   it('correctly retrieves web archive hits', async () => {
     const searchService = new MockSearchService();
     const el = await fixture<CollectionBrowser>(


### PR DESCRIPTION
When changing the search query, any previously-applied filters are supposed to be cleared before performing the new search. However, currently a bug exists where this does not happen in all cases, causing search requests to fire with stale filters still applied, typically followed immediately by a second request with no filters. This happens because the filters are not being cleared until after an update cycle has already completed (in `updated()`). This PR moves the `clearFilters()` call to `willUpdate()` instead, so that filters will always be cleared _before_ the search request fires.