### PR TITLE
WEBDEV-8362 TV facet adjustments: remove Person group and rename Commercials

### DIFF
--- a/src/collection-facets.ts
+++ b/src/collection-facets.ts
@@ -42,7 +42,7 @@ import {
   FacetBucket,
   defaultFacetDisplayOrder,
   facetTitles,
-  lendingFacetDisplayNames,
+  customFacetDisplayNames,
   lendingFacetKeysVisibility,
   LendingFacetKey,
   suppressedCollections,
@@ -612,10 +612,12 @@ export class CollectionFacets extends LitElement {
         const buckets: FacetBucket[] = Object.entries(selectedFacets).map(
           ([value, facetData]) => {
             let displayText: string = value;
-            // for lending facets, convert the key to a readable format
-            if (option === 'lending') {
-              displayText =
-                lendingFacetDisplayNames[value as LendingFacetKey] ?? value;
+            // For certain facet types/keys, we use a custom readable display name
+            const currentGroupCustomNames = customFacetDisplayNames[
+              option
+            ] as Record<string, string>;
+            if (currentGroupCustomNames) {
+              displayText = currentGroupCustomNames[value] ?? value;
             }
             return {
               displayText,
@@ -667,11 +669,12 @@ export class CollectionFacets extends LitElement {
       const facetBuckets: FacetBucket[] = castedBuckets.map(bucket => {
         const bucketKey = bucket.key;
         let displayText = `${bucket.key}`;
-        // for lending facets, convert the bucket key to a readable format
-        if (option === 'lending') {
-          displayText =
-            lendingFacetDisplayNames[bucket.key as LendingFacetKey] ??
-            `${bucket.key}`;
+        // For certain facet types/keys, we use a custom readable display name
+        const currentGroupCustomNames = customFacetDisplayNames[
+          option
+        ] as Record<string, string>;
+        if (currentGroupCustomNames) {
+          displayText = currentGroupCustomNames[bucket.key] ?? `${bucket.key}`;
         }
         return {
           displayText,

--- a/src/mediatype/mediatype-config.ts
+++ b/src/mediatype/mediatype-config.ts
@@ -116,7 +116,7 @@ export const mediatypeConfig: Record<MediatypeConfigKey, MediatypeConfig> = {
   tvCommercial: {
     color: '#84b648',
     icon: tvCommercialIcon,
-    text: 'TV Commercial',
+    text: 'TV Political Ad',
   },
   tvFactCheck: {
     color: '#f1644b',

--- a/src/models.ts
+++ b/src/models.ts
@@ -825,14 +825,35 @@ export const lendingFacetKeysVisibility: Record<LendingFacetKey, boolean> = {
 };
 
 /**
- * Maps valid, visible lending keys to their facet sidebar display text
+ * Most facet options allow any string as keys, while some others can only take on a
+ * limited set of strings. This type just defines those restrictions for the specific
+ * facet types where they apply.
  */
-export const lendingFacetDisplayNames: Partial<
-  Record<LendingFacetKey, string>
-> = {
-  is_lendable: 'Lending Library',
-  available_to_borrow: 'Borrow 14 Days',
-  is_readable: 'Always Available',
+export type AllowedFacetKey<T extends FacetOption> = T extends 'lending'
+  ? LendingFacetKey
+  : T extends 'clip_type'
+    ? TvClipFilterType
+    : string;
+
+/**
+ * A type mapping FacetOptions to objects that define custom display names for some
+ * or all of their valid keys.
+ */
+export type FacetDisplayNameMap = {
+  [K in FacetOption]?: Partial<Record<AllowedFacetKey<K>, string>>;
+};
+
+export const customFacetDisplayNames: FacetDisplayNameMap = {
+  lending: {
+    is_lendable: 'Lending Library',
+    available_to_borrow: 'Borrow 14 Days',
+    is_readable: 'Always Available',
+  },
+  clip_type: {
+    quote: 'Quote',
+    commercial: 'Political Ad',
+    'fact check': 'Fact Check',
+  },
 };
 
 /**

--- a/src/models.ts
+++ b/src/models.ts
@@ -736,7 +736,7 @@ export const tvFacetDisplayOrder: FacetOption[] = [
   'creator',
   'year',
   'subject',
-  'person',
+  // 'person', Omitting the Person facet group for now, though it may be re-added later with new semantics
   'language',
   'clip_type',
 ];

--- a/test/tiles/tile-mediatype-icon.test.ts
+++ b/test/tiles/tile-mediatype-icon.test.ts
@@ -45,7 +45,7 @@ describe('Mediatype Icon', () => {
     expect(iconDiv.title).to.equal('TV');
   });
 
-  it('renders TV Commercial mediatype for TV items with ad ids', async () => {
+  it('renders TV Political Ad mediatype for TV items with ad ids', async () => {
     model.mediatype = 'movies';
     model.collections = ['tvnews'];
     model.adIds = ['foo'];
@@ -54,10 +54,10 @@ describe('Mediatype Icon', () => {
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
-    expect(iconDiv.title).to.equal('TV Commercial');
+    expect(iconDiv.title).to.equal('TV Political Ad');
   });
 
-  it('renders TV Commercial mediatype for TV items in tv_ads collection', async () => {
+  it('renders TV Political Ad mediatype for TV items in tv_ads collection', async () => {
     model.mediatype = 'movies';
     model.collections = ['tvnews', 'tv_ads'];
     const el = await fixture<TileMediatypeIcon>(html`
@@ -65,7 +65,7 @@ describe('Mediatype Icon', () => {
     `);
 
     const iconDiv = el.shadowRoot?.querySelector('#icon') as HTMLDivElement;
-    expect(iconDiv.title).to.equal('TV Commercial');
+    expect(iconDiv.title).to.equal('TV Political Ad');
   });
 
   it('renders TV Fact Check mediatype for TV search results with fact check URLs', async () => {


### PR DESCRIPTION
The `Person` facet shown for TV search results only represents a small portion of data captured nearly a decade ago, and is of diminishing utility. This PR hides it to remove clutter, with a note that we may eventually add it back in with more relevant semantics.

The `Clip Type` TV facet currently includes a `Commercial` entry, which this PR additionally renames to `Political Ad` for greater clarity, simultaneously updating the labels on corresponding mediatype icons for consistency.