### PR TITLE
WEBDEV-8257 Allow action buttons to be added to tiles

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ export { TileList } from './src/tiles/list/tile-list';
 export { TileListCompact } from './src/tiles/list/tile-list-compact';
 export { TileDispatcher } from './src/tiles/tile-dispatcher';
 export { LayoutType } from './src/tiles/models';
+export type { TileAction } from './src/tiles/models';
 export {
   SmartQueryHeuristic,
   KeywordFacetMap,

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -376,6 +376,16 @@ export class AppRoot extends LitElement {
               />
               <label for="enable-smart-facet-bar">Enable smart facet bar</label>
             </div>
+            <div class="checkbox-control">
+              <input
+                type="checkbox"
+                id="enable-tile-actions"
+                @click=${this.tileActionsCheckboxChanged}
+              />
+              <label for="enable-tile-actions"
+                >Enable tile action buttons</label
+              >
+            </div>
           </fieldset>
 
           <fieldset class="cb-visual-appearance">
@@ -517,6 +527,7 @@ export class AppRoot extends LitElement {
           @manageModeChanged=${this.manageModeChanged}
           @itemRemovalRequested=${this.handleItemRemovalRequest}
           @itemManagerRequested=${this.handleItemManagerRequest}
+          @tileActionClicked=${this.handleTileActionClicked}
         >
           ${this.toggleSlots
             ? html`<div slot="sortbar-left-slot">Sort Slot</div>`
@@ -736,6 +747,25 @@ export class AppRoot extends LitElement {
   private smartFacetBarCheckboxChanged(e: Event) {
     const target = e.target as HTMLInputElement;
     this.collectionBrowser.showSmartFacetBar = target.checked;
+  }
+
+  /**
+   * Handler for when the dev panel's "Enable tile action buttons" checkbox is changed.
+   */
+  private tileActionsCheckboxChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.collectionBrowser.tileActions = target.checked
+      ? [{ id: 'demo-action', label: 'Return' }]
+      : [];
+  }
+
+  /**
+   * Handler for tile action button clicks (logs to console for QA).
+   */
+  private handleTileActionClicked(
+    e: CustomEvent<{ actionId: string; model: unknown }>,
+  ) {
+    console.log('Tile action clicked:', e.detail.actionId, e.detail.model);
   }
 
   /**
@@ -983,6 +1013,11 @@ export class AppRoot extends LitElement {
       /* Same as production */
       max-width: 135rem;
       margin: auto;
+
+      /* Danger-style tile action buttons (matching iaux-book-actions) */
+      --tileActionColor: #fff;
+      --tileActionBg: #d9534f;
+      --tileActionHoverBg: rgba(229, 28, 38, 0.9);
     }
 
     #collection-browser-container {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -1082,11 +1082,6 @@ export class AppRoot extends LitElement {
       /* Same as production */
       max-width: 135rem;
       margin: auto;
-
-      /* Danger-style tile action buttons (matching iaux-book-actions) */
-      --tileActionColor: #fff;
-      --tileActionBg: #d9534f;
-      --tileActionHoverBg: rgba(229, 28, 38, 0.9);
     }
 
     #collection-browser-container {

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -381,6 +381,16 @@ export class AppRoot extends LitElement {
               />
               <label for="enable-smart-facet-bar">Enable smart facet bar</label>
             </div>
+            <div class="checkbox-control">
+              <input
+                type="checkbox"
+                id="enable-tile-actions"
+                @click=${this.tileActionsCheckboxChanged}
+              />
+              <label for="enable-tile-actions"
+                >Enable tile action buttons</label
+              >
+            </div>
           </fieldset>
 
           <fieldset class="cb-visual-appearance">
@@ -581,6 +591,7 @@ export class AppRoot extends LitElement {
           @manageModeChanged=${this.manageModeChanged}
           @itemRemovalRequested=${this.handleItemRemovalRequest}
           @itemManagerRequested=${this.handleItemManagerRequest}
+          @tileActionClicked=${this.handleTileActionClicked}
         >
           ${this.toggleSlots
             ? html`<div slot="sortbar-left-slot">Sort Slot</div>`
@@ -800,6 +811,25 @@ export class AppRoot extends LitElement {
   private smartFacetBarCheckboxChanged(e: Event) {
     const target = e.target as HTMLInputElement;
     this.collectionBrowser.showSmartFacetBar = target.checked;
+  }
+
+  /**
+   * Handler for when the dev panel's "Enable tile action buttons" checkbox is changed.
+   */
+  private tileActionsCheckboxChanged(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.collectionBrowser.tileActions = target.checked
+      ? [{ id: 'demo-action', label: 'Return' }]
+      : [];
+  }
+
+  /**
+   * Handler for tile action button clicks (logs to console for QA).
+   */
+  private handleTileActionClicked(
+    e: CustomEvent<{ actionId: string; model: unknown }>,
+  ) {
+    console.log('Tile action clicked:', e.detail.actionId, e.detail.model);
   }
 
   /**
@@ -1052,6 +1082,11 @@ export class AppRoot extends LitElement {
       /* Same as production */
       max-width: 135rem;
       margin: auto;
+
+      /* Danger-style tile action buttons (matching iaux-book-actions) */
+      --tileActionColor: #fff;
+      --tileActionBg: #d9534f;
+      --tileActionHoverBg: rgba(229, 28, 38, 0.9);
     }
 
     #collection-browser-container {

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -78,6 +78,7 @@ import { sha1 } from './utils/sha1';
 import type { PlaceholderType } from './empty-placeholder';
 import type { ManageBar } from './manage/manage-bar';
 import type { SmartFacetBar } from './collection-facets/smart-facets/smart-facet-bar';
+import type { TileAction } from './tiles/models';
 
 import '@internetarchive/elements/ia-combo-box/ia-combo-box';
 import './empty-placeholder';
@@ -296,6 +297,9 @@ export class CollectionBrowser
    * If item management UI active
    */
   @property({ type: Boolean }) isManageView = false;
+
+  /** Action buttons to display on each tile (grid mode only) */
+  @property({ type: Array }) tileActions: TileAction[] = [];
 
   @property({ type: String }) manageViewLabel = 'Select items to remove';
 
@@ -1758,7 +1762,8 @@ export class CollectionBrowser
       changed.has('displayMode') ||
       changed.has('baseNavigationUrl') ||
       changed.has('baseImageUrl') ||
-      changed.has('loggedIn')
+      changed.has('loggedIn') ||
+      changed.has('tileActions')
     ) {
       this.infiniteScroller?.reload();
     }
@@ -2551,6 +2556,7 @@ export class CollectionBrowser
         .loggedIn=${this.loggedIn}
         .suppressBlurring=${this.shouldSuppressTileBlurring}
         .isManageView=${this.isManageView}
+        .tileActions=${this.tileActions}
         ?showTvClips=${isTVSearch || isTVCollection}
         ?enableHoverPane=${true}
         ?useLocalTime=${shouldUseLocalTime}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -78,6 +78,7 @@ import { sha1 } from './utils/sha1';
 import type { PlaceholderType } from './empty-placeholder';
 import type { ManageBar } from './manage/manage-bar';
 import type { SmartFacetBar } from './collection-facets/smart-facets/smart-facet-bar';
+import type { TileAction } from './tiles/models';
 
 import '@internetarchive/elements/ia-combo-box/ia-combo-box';
 import './empty-placeholder';
@@ -296,6 +297,9 @@ export class CollectionBrowser
    * If item management UI active
    */
   @property({ type: Boolean }) isManageView = false;
+
+  /** Action buttons to display on each tile (grid mode only) */
+  @property({ type: Array }) tileActions: TileAction[] = [];
 
   @property({ type: String }) manageViewLabel = 'Select items to remove';
 
@@ -1730,7 +1734,8 @@ export class CollectionBrowser
       changed.has('displayMode') ||
       changed.has('baseNavigationUrl') ||
       changed.has('baseImageUrl') ||
-      changed.has('loggedIn')
+      changed.has('loggedIn') ||
+      changed.has('tileActions')
     ) {
       this.infiniteScroller?.reload();
     }
@@ -2523,6 +2528,7 @@ export class CollectionBrowser
         .loggedIn=${this.loggedIn}
         .suppressBlurring=${this.shouldSuppressTileBlurring}
         .isManageView=${this.isManageView}
+        .tileActions=${this.tileActions}
         ?showTvClips=${isTVSearch || isTVCollection}
         ?enableHoverPane=${true}
         ?useLocalTime=${shouldUseLocalTime}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1742,7 +1742,8 @@ export class CollectionBrowser
       changed.has('baseNavigationUrl') ||
       changed.has('baseImageUrl') ||
       changed.has('loggedIn') ||
-      changed.has('tileActions')
+      changed.has('tileActions') ||
+      changed.has('tileLayoutType')
     ) {
       this.infiniteScroller?.reload();
     }

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -78,7 +78,7 @@ import { sha1 } from './utils/sha1';
 import type { PlaceholderType } from './empty-placeholder';
 import type { ManageBar } from './manage/manage-bar';
 import type { SmartFacetBar } from './collection-facets/smart-facets/smart-facet-bar';
-import type { TileAction } from './tiles/models';
+import type { LayoutType, TileAction } from './tiles/models';
 
 import '@internetarchive/elements/ia-combo-box/ia-combo-box';
 import './empty-placeholder';
@@ -298,8 +298,14 @@ export class CollectionBrowser
    */
   @property({ type: Boolean }) isManageView = false;
 
-  /** Action buttons to display on each tile (grid mode only) */
+  /** Action buttons to display on each tile */
   @property({ type: Array }) tileActions: TileAction[] = [];
+
+  /**
+   * The simplified layout to apply to grid-mode tiles, if any. See
+   * `LayoutType` for available options. Has no effect on list display modes.
+   */
+  @property({ type: String }) tileLayoutType: LayoutType = 'default';
 
   @property({ type: String }) manageViewLabel = 'Select items to remove';
 
@@ -1585,6 +1591,7 @@ export class CollectionBrowser
           .mobileBreakpoint=${this.mobileBreakpoint}
           .loggedIn=${this.loggedIn}
           .suppressBlurring=${this.shouldSuppressTileBlurring}
+          .tileActions=${this.tileActions}
         >
         </tile-dispatcher>
       </div>
@@ -2529,6 +2536,7 @@ export class CollectionBrowser
         .suppressBlurring=${this.shouldSuppressTileBlurring}
         .isManageView=${this.isManageView}
         .tileActions=${this.tileActions}
+        .layoutType=${this.tileLayoutType}
         ?showTvClips=${isTVSearch || isTVCollection}
         ?enableHoverPane=${true}
         ?useLocalTime=${shouldUseLocalTime}

--- a/src/styles/tile-action-styles.ts
+++ b/src/styles/tile-action-styles.ts
@@ -7,10 +7,10 @@ import { css } from 'lit';
  * container's default flex behavior.
  *
  * Customizable via CSS custom properties:
- *  - `--tileActionColor` (default: #d9534f)
+ *  - `--tileActionColor` (defaults to --primaryErrorCTAFill, then #d9534f)
  *  - `--tileActionBg` (default: #fff)
- *  - `--tileActionBorderColor` (default: #d9534f)
- *  - `--tileActionHoverBg` (default: rgba(217, 83, 79, 0.1))
+ *  - `--tileActionBorderColor` (defaults to --primaryErrorCTAFill, then #d9534f)
+ *  - `--tileActionHoverBg` (defaults to --primaryErrorCTAFillRGB at 20% alpha)
  *  - `--tileActionHoverColor` (defaults to --tileActionColor)
  */
 export const tileActionStyles = css`
@@ -23,14 +23,15 @@ export const tileActionStyles = css`
   .tile-action-btn {
     flex: 1;
     padding: 6px 5px;
-    border: 2px solid var(--tileActionBorderColor, #d9534f);
+    border: 2px solid
+      var(--tileActionBorderColor, var(--primaryErrorCTAFill, #d9534f));
     border-radius: var(--tileActionBorderRadius, 0);
     /* Inherit from the surrounding tile rather than the UA default for <button> */
     font-family: inherit;
     font-size: 1.2rem;
     font-weight: bold;
     cursor: pointer;
-    color: var(--tileActionColor, #d9534f);
+    color: var(--tileActionColor, var(--primaryErrorCTAFill, #d9534f));
     background: var(--tileActionBg, #fff);
     transition:
       background 0.15s,
@@ -46,7 +47,13 @@ export const tileActionStyles = css`
   }
 
   .tile-action-btn:hover {
-    background: var(--tileActionHoverBg, rgba(217, 83, 79, 0.2));
-    color: var(--tileActionHoverColor, var(--tileActionColor, #d9534f));
+    background: var(
+      --tileActionHoverBg,
+      rgba(var(--primaryErrorCTAFillRGB, 229, 28, 38), 0.2)
+    );
+    color: var(
+      --tileActionHoverColor,
+      var(--tileActionColor, var(--primaryErrorCTAFill, #d9534f))
+    );
   }
 `;

--- a/src/styles/tile-action-styles.ts
+++ b/src/styles/tile-action-styles.ts
@@ -1,0 +1,52 @@
+import { css } from 'lit';
+
+/**
+ * Shared styles for tile action buttons rendered in grid, list-detail, and
+ * list-compact display modes. Layout positioning is handled by each tile
+ * component; these styles cover only the button appearance and the row
+ * container's default flex behavior.
+ *
+ * Customizable via CSS custom properties:
+ *  - `--tileActionColor` (default: #d9534f)
+ *  - `--tileActionBg` (default: #fff)
+ *  - `--tileActionBorderColor` (default: #d9534f)
+ *  - `--tileActionHoverBg` (default: rgba(217, 83, 79, 0.1))
+ *  - `--tileActionHoverColor` (defaults to --tileActionColor)
+ */
+export const tileActionStyles = css`
+  .tile-actions {
+    flex-shrink: 0;
+    display: flex;
+    gap: var(--tileActionGap, 0);
+  }
+
+  .tile-action-btn {
+    flex: 1;
+    padding: 6px 5px;
+    border: 2px solid var(--tileActionBorderColor, #d9534f);
+    border-radius: var(--tileActionBorderRadius, 0);
+    /* Inherit from the surrounding tile rather than the UA default for <button> */
+    font-family: inherit;
+    font-size: 1.2rem;
+    font-weight: bold;
+    cursor: pointer;
+    color: var(--tileActionColor, #d9534f);
+    background: var(--tileActionBg, #fff);
+    transition:
+      background 0.15s,
+      color 0.15s;
+  }
+
+  /*
+   * When buttons are flush against each other (no gap), overlap their shared
+   * edge by 1px so adjacent borders don't double up.
+   */
+  .tile-action-btn + .tile-action-btn {
+    margin-left: -1px;
+  }
+
+  .tile-action-btn:hover {
+    background: var(--tileActionHoverBg, rgba(217, 83, 79, 0.2));
+    color: var(--tileActionHoverColor, var(--tileActionColor, #d9534f));
+  }
+`;

--- a/src/tiles/base-tile-component.ts
+++ b/src/tiles/base-tile-component.ts
@@ -1,12 +1,16 @@
-import { LitElement, PropertyValues } from 'lit';
+import { html, LitElement, nothing, PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import type { SortParam } from '@internetarchive/search-service';
 import { TileDisplayValueProvider } from './tile-display-value-provider';
 import type { TileModel } from '../models';
 import { DateFormat, formatDate } from '../utils/format-date';
+import type { TileAction } from './models';
 
 export abstract class BaseTileComponent extends LitElement {
   @property({ type: Object }) model?: TileModel;
+
+  /** Action buttons to display on this tile (rendered by subclasses) */
+  @property({ type: Array }) tileActions: TileAction[] = [];
 
   @property({ type: Number }) currentWidth?: number;
 
@@ -61,5 +65,57 @@ export abstract class BaseTileComponent extends LitElement {
   protected getFormattedDate(date?: Date, format?: DateFormat): string {
     const { useLocalTime } = this;
     return formatDate(date, format, { useLocalTime });
+  }
+
+  /**
+   * Renders the action buttons configured for this tile, or `nothing` if
+   * there are none. Optional `extraClass` is appended to the container's
+   * class list so subclasses can target their own layout tweaks.
+   */
+  protected renderTileActions(
+    extraClass: string = '',
+  ): TemplateResult | typeof nothing {
+    if (!this.tileActions.length) return nothing;
+
+    const containerClass = extraClass
+      ? `tile-actions ${extraClass}`
+      : 'tile-actions';
+    return html`
+      <div class=${containerClass}>
+        ${this.tileActions.map(
+          action => html`
+            <button
+              class="tile-action-btn"
+              @click=${(e: Event) => this.handleTileActionClick(e, action)}
+            >
+              ${action.label}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * Click handler for tile action buttons. Stops propagation so the click
+   * doesn't activate a wrapping tile link, and dispatches a
+   * `tileActionClicked` event (bubbling + composed) carrying the action ID
+   * and the tile model.
+   */
+  protected handleTileActionClick(e: Event, action: TileAction): void {
+    e.preventDefault();
+    e.stopPropagation();
+    // Pre-set the hover pane controller's clicking flag so that focus
+    // restoration after a consumer-opened modal won't trigger the hover pane.
+    this.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, composed: true }),
+    );
+    this.dispatchEvent(
+      new CustomEvent('tileActionClicked', {
+        detail: { actionId: action.id, model: this.model },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 }

--- a/src/tiles/base-tile-component.ts
+++ b/src/tiles/base-tile-component.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing, PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import type { SortParam } from '@internetarchive/search-service';
 import { TileDisplayValueProvider } from './tile-display-value-provider';
 import type { TileModel } from '../models';
@@ -77,11 +78,13 @@ export abstract class BaseTileComponent extends LitElement {
   ): TemplateResult | typeof nothing {
     if (!this.tileActions.length) return nothing;
 
-    const containerClass = extraClass
-      ? `tile-actions ${extraClass}`
-      : 'tile-actions';
+    const containerClasses = classMap({
+      'tile-actions': true,
+      ...(extraClass && { [extraClass]: true }),
+    });
+
     return html`
-      <div class=${containerClass}>
+      <div class=${containerClasses}>
         ${this.tileActions.map(
           action => html`
             <button

--- a/src/tiles/grid/item-tile.ts
+++ b/src/tiles/grid/item-tile.ts
@@ -24,6 +24,7 @@ export class ItemTile extends BaseTileComponent {
   /*
    * Reactive properties inherited from BaseTileComponent:
    *  - model?: TileModel;
+   *  - tileActions: TileAction[] = [];
    *  - currentWidth?: number;
    *  - currentHeight?: number;
    *  - baseNavigationUrl?: string;

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -1,5 +1,6 @@
 import { css, html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { msg } from '@lit/localize';
 import { BaseTileComponent } from '../base-tile-component';
 
@@ -23,9 +24,14 @@ export class TileListCompactHeader extends BaseTileComponent {
 
   render() {
     const hasActions = this.tileActions.length > 0;
-    const headerClasses = `${this.classSize}${hasActions ? ' has-actions' : ''}`;
+    const headerClasses = classMap({
+      mobile: this.classSize === 'mobile',
+      desktop: this.classSize === 'desktop',
+      'has-actions': hasActions,
+    });
+
     return html`
-      <div id="list-line-header" class="${headerClasses}">
+      <div id="list-line-header" class=${headerClasses}>
         <div id="thumb"></div>
         ${hasActions ? html`<div id="actions-header"></div>` : nothing}
         <div id="title">${msg('Title')}</div>

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -1,4 +1,4 @@
-import { css, html } from 'lit';
+import { css, html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { msg } from '@lit/localize';
 import { BaseTileComponent } from '../base-tile-component';
@@ -8,6 +8,7 @@ export class TileListCompactHeader extends BaseTileComponent {
   /*
    * Reactive properties inherited from BaseTileComponent:
    *  - model?: TileModel;
+   *  - tileActions: TileAction[] = [];
    *  - currentWidth?: number;
    *  - currentHeight?: number;
    *  - baseNavigationUrl?: string;
@@ -21,9 +22,12 @@ export class TileListCompactHeader extends BaseTileComponent {
    */
 
   render() {
+    const hasActions = this.tileActions.length > 0;
+    const headerClasses = `${this.classSize}${hasActions ? ' has-actions' : ''}`;
     return html`
-      <div id="list-line-header" class="${this.classSize}">
+      <div id="list-line-header" class="${headerClasses}">
         <div id="thumb"></div>
+        ${hasActions ? html`<div id="actions-header"></div>` : nothing}
         <div id="title">${msg('Title')}</div>
         <div id="creator">${msg('Creator')}</div>
         <div id="date">
@@ -80,6 +84,22 @@ export class TileListCompactHeader extends BaseTileComponent {
 
       #list-line-header.desktop {
         grid-template-columns: 51px 3fr 2fr 95px 30px 115px;
+      }
+
+      /*
+       * When tile actions are present in the rows below, reserve a matching
+       * column here so the columns stay aligned with each row.
+       */
+      #list-line-header.mobile.has-actions {
+        grid-template-columns:
+          36px var(--tileActionColumnWidth, 90px) 3fr 2fr
+          68px 35px;
+      }
+
+      #list-line-header.desktop.has-actions {
+        grid-template-columns:
+          51px var(--tileActionColumnWidth, 100px) 3fr 2fr
+          95px 30px 115px;
       }
     `;
   }

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -1,5 +1,6 @@
 import { css, html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import DOMPurify from 'dompurify';
 import type { SortParam } from '@internetarchive/search-service';
 import { BaseTileComponent } from '../base-tile-component';
@@ -33,11 +34,15 @@ export class TileListCompact extends BaseTileComponent {
    */
 
   render() {
-    const lineClasses = `${this.classSize}${
-      this.tileActions.length > 0 ? ' has-actions' : ''
-    }`;
+    const hasActions = this.tileActions.length > 0;
+    const lineClasses = classMap({
+      mobile: this.classSize === 'mobile',
+      desktop: this.classSize === 'desktop',
+      'has-actions': hasActions,
+    });
+
     return html`
-      <div id="list-line" class="${lineClasses}">
+      <div id="list-line" class=${lineClasses}>
         <image-block
           .model=${this.model}
           .baseImageUrl=${this.baseImageUrl}
@@ -48,7 +53,7 @@ export class TileListCompact extends BaseTileComponent {
           .suppressBlurring=${this.suppressBlurring}
         >
         </image-block>
-        ${this.tileActions.length > 0
+        ${hasActions
           ? html`<div id="actions">
               ${this.renderTileActions('list-compact')}
             </div>`

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -7,6 +7,7 @@ import { BaseTileComponent } from '../base-tile-component';
 import { formatCount, NumberFormat } from '../../utils/format-count';
 import type { DateFormat } from '../../utils/format-date';
 import { isFirstMillisecondOfUTCYear } from '../../utils/local-date-from-utc';
+import { tileActionStyles } from '../../styles/tile-action-styles';
 
 import '../image-block';
 import '../tile-mediatype-icon';
@@ -16,6 +17,7 @@ export class TileListCompact extends BaseTileComponent {
   /*
    * Reactive properties inherited from BaseTileComponent:
    *  - model?: TileModel;
+   *  - tileActions: TileAction[] = [];
    *  - currentWidth?: number;
    *  - currentHeight?: number;
    *  - baseNavigationUrl?: string;
@@ -31,8 +33,11 @@ export class TileListCompact extends BaseTileComponent {
    */
 
   render() {
+    const lineClasses = `${this.classSize}${
+      this.tileActions.length > 0 ? ' has-actions' : ''
+    }`;
     return html`
-      <div id="list-line" class="${this.classSize}">
+      <div id="list-line" class="${lineClasses}">
         <image-block
           .model=${this.model}
           .baseImageUrl=${this.baseImageUrl}
@@ -43,6 +48,11 @@ export class TileListCompact extends BaseTileComponent {
           .suppressBlurring=${this.suppressBlurring}
         >
         </image-block>
+        ${this.tileActions.length > 0
+          ? html`<div id="actions">
+              ${this.renderTileActions('list-compact')}
+            </div>`
+          : nothing}
         <a href=${this.href} id="title"
           >${DOMPurify.sanitize(this.model?.title ?? '')}</a
         >
@@ -161,79 +171,103 @@ export class TileListCompact extends BaseTileComponent {
   }
 
   static get styles() {
-    return css`
-      html {
-        font-size: unset;
-      }
+    return [
+      tileActionStyles,
+      css`
+        html {
+          font-size: unset;
+        }
 
-      div {
-        font-size: 14px;
-      }
+        div {
+          font-size: 14px;
+        }
 
-      #list-line {
-        display: grid;
-        column-gap: 10px;
-        border-top: 1px solid #ddd;
-        align-items: center;
-        line-height: 20px;
-        padding-top: 5px;
-        margin-bottom: -5px;
-      }
+        #list-line {
+          display: grid;
+          column-gap: 10px;
+          border-top: 1px solid #ddd;
+          align-items: center;
+          line-height: 20px;
+          padding-top: 5px;
+          margin-bottom: -5px;
+        }
 
-      #list-line.mobile {
-        grid-template-columns: 36px 3fr 2fr 68px 35px;
-      }
+        #list-line.mobile {
+          grid-template-columns: 36px 3fr 2fr 68px 35px;
+        }
 
-      #list-line.desktop {
-        grid-template-columns: 51px 3fr 2fr 95px 30px 115px;
-      }
+        #list-line.desktop {
+          grid-template-columns: 51px 3fr 2fr 95px 30px 115px;
+        }
 
-      #list-line:hover #title {
-        text-decoration: underline;
-      }
+        /*
+         * When tile actions are present, insert an extra column for them
+         * between the thumbnail and the title.
+         */
+        #list-line.mobile.has-actions {
+          grid-template-columns:
+            36px var(--tileActionColumnWidth, 90px)
+            3fr 2fr 68px 35px;
+        }
 
-      #title {
-        text-decoration: none;
-      }
+        #list-line.desktop.has-actions {
+          grid-template-columns:
+            51px var(--tileActionColumnWidth, 100px)
+            3fr 2fr 95px 30px 115px;
+        }
 
-      #title:link {
-        color: var(--ia-theme-link-color, #4b64ff);
-      }
+        #actions {
+          /* The flex container inside is what holds the action buttons */
+          display: flex;
+        }
 
-      #title,
-      #creator {
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-      }
+        #list-line:hover #title {
+          text-decoration: underline;
+        }
 
-      #icon {
-        margin-left: 2px;
-      }
+        #title {
+          text-decoration: none;
+        }
 
-      #views {
-        text-align: right;
-        padding-right: 8px;
-      }
+        #title:link {
+          color: var(--ia-theme-link-color, #4b64ff);
+        }
 
-      .mobile #views {
-        display: none;
-      }
+        #title,
+        #creator {
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
 
-      .mobile tile-mediatype-icon {
-        --iconHeight: 14px;
-        --iconWidth: 14px;
-      }
+        #icon {
+          margin-left: 2px;
+        }
 
-      .desktop #icon {
-        --iconHeight: 20px;
-        --iconWidth: 20px;
-      }
+        #views {
+          text-align: right;
+          padding-right: 8px;
+        }
 
-      item-image {
-        --imgHeight: 100%;
-        --imgWidth: 100%;
-      }
-    `;
+        .mobile #views {
+          display: none;
+        }
+
+        .mobile tile-mediatype-icon {
+          --iconHeight: 14px;
+          --iconWidth: 14px;
+        }
+
+        .desktop #icon {
+          --iconHeight: 20px;
+          --iconWidth: 20px;
+        }
+
+        item-image {
+          --imgHeight: 100%;
+          --imgWidth: 100%;
+        }
+      `,
+    ];
   }
 }

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -15,6 +15,7 @@ import { BaseTileComponent } from '../base-tile-component';
 import { formatCount, NumberFormat } from '../../utils/format-count';
 import type { DateFormat } from '../../utils/format-date';
 import { isFirstMillisecondOfUTCYear } from '../../utils/local-date-from-utc';
+import { tileActionStyles } from '../../styles/tile-action-styles';
 
 import '../image-block';
 import '../review-block';
@@ -26,6 +27,7 @@ export class TileList extends BaseTileComponent {
   /*
    * Reactive properties inherited from BaseTileComponent:
    *  - model?: TileModel;
+   *  - tileActions: TileAction[] = [];
    *  - currentWidth?: number;
    *  - currentHeight?: number;
    *  - baseNavigationUrl?: string;
@@ -61,7 +63,9 @@ export class TileList extends BaseTileComponent {
   private get mobileTemplate() {
     return html`
       <div id="list-line-top">
-        <div id="list-line-left">${this.imageBlockTemplate}</div>
+        <div id="list-line-left">
+          ${this.imageBlockTemplate} ${this.renderTileActions('list-detail')}
+        </div>
         <div id="list-line-right">
           <div id="title-line">
             <div id="title">${this.titleTemplate}</div>
@@ -75,7 +79,9 @@ export class TileList extends BaseTileComponent {
 
   private get desktopTemplate() {
     return html`
-      <div id="list-line-left">${this.imageBlockTemplate}</div>
+      <div id="list-line-left">
+        ${this.imageBlockTemplate} ${this.renderTileActions('list-detail')}
+      </div>
       <div id="list-line-right">
         <div id="title-line">
           <div id="title">${this.titleTemplate}</div>
@@ -511,190 +517,202 @@ export class TileList extends BaseTileComponent {
   }
 
   static get styles() {
-    return css`
-      html {
-        font-size: unset;
-      }
+    return [
+      tileActionStyles,
+      css`
+        html {
+          font-size: unset;
+        }
 
-      div {
-        font-size: 14px;
-      }
+        div {
+          font-size: 14px;
+        }
 
-      div a {
-        text-decoration: none;
-      }
+        div a {
+          text-decoration: none;
+        }
 
-      div a:link {
-        color: var(--ia-theme-link-color, #4b64ff);
-      }
+        div a:link {
+          color: var(--ia-theme-link-color, #4b64ff);
+        }
 
-      .label {
-        font-weight: bold;
-      }
+        .label {
+          font-weight: bold;
+        }
 
-      #list-line.mobile {
-        --infiniteScrollerRowGap: 20px;
-        --infiniteScrollerRowHeight: auto;
-      }
+        #list-line.mobile {
+          --infiniteScrollerRowGap: 20px;
+          --infiniteScrollerRowHeight: auto;
+        }
 
-      #list-line.desktop {
-        --infiniteScrollerRowGap: 30px;
-        --infiniteScrollerRowHeight: auto;
-      }
+        #list-line.desktop {
+          --infiniteScrollerRowGap: 30px;
+          --infiniteScrollerRowHeight: auto;
+        }
 
-      /* fields */
-      #icon-right {
-        width: 20px;
-        padding-top: 5px;
-        --iconHeight: 20px;
-        --iconWidth: 20px;
-        --iconTextAlign: right;
-        margin-top: -8px;
-        text-align: right;
-      }
+        /* fields */
+        #icon-right {
+          width: 20px;
+          padding-top: 5px;
+          --iconHeight: 20px;
+          --iconWidth: 20px;
+          --iconTextAlign: right;
+          margin-top: -8px;
+          text-align: right;
+        }
 
-      #title {
-        color: #4b64ff;
-        text-decoration: none;
-        font-size: 22px;
-        font-weight: bold;
-        /* align top of text with image */
-        line-height: 25px;
-        margin-top: -4px;
-        padding-bottom: 2px;
-        flex-grow: 1;
+        #title {
+          color: #4b64ff;
+          text-decoration: none;
+          font-size: 22px;
+          font-weight: bold;
+          /* align top of text with image */
+          line-height: 25px;
+          margin-top: -4px;
+          padding-bottom: 2px;
+          flex-grow: 1;
 
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        overflow: hidden;
-        overflow-wrap: anywhere;
-      }
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 3;
+          overflow: hidden;
+          overflow-wrap: anywhere;
+        }
 
-      .metadata {
-        line-height: 20px;
-      }
+        .metadata {
+          line-height: 20px;
+        }
 
-      #description,
-      #creator,
-      #topics,
-      #source {
-        text-align: left;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        -webkit-box-orient: vertical;
-        display: -webkit-box;
-        word-break: break-word;
-        -webkit-line-clamp: 3; /* number of lines to show */
-        line-clamp: 3;
+        #description,
+        #creator,
+        #topics,
+        #source {
+          text-align: left;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          word-break: break-word;
+          -webkit-line-clamp: 3; /* number of lines to show */
+          line-clamp: 3;
 
-        /*
+          /*
          * Safari doesn't always respect the line-clamping rules above,
          * so we add this to ensure these fields still get truncated
          */
-        max-height: 60px;
-      }
+          max-height: 60px;
+        }
 
-      #collections {
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        overflow: hidden;
-        overflow-wrap: anywhere;
-      }
+        #collections {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 3;
+          overflow: hidden;
+          overflow-wrap: anywhere;
+        }
 
-      #collections > a {
-        display: inline-block;
-      }
+        #collections > a {
+          display: inline-block;
+        }
 
-      #icon {
-        padding-top: 5px;
-      }
+        #icon {
+          padding-top: 5px;
+        }
 
-      #description {
-        padding-top: 10px;
-      }
+        #description {
+          padding-top: 10px;
+        }
 
-      /* Top level container */
-      #list-line {
-        display: flex;
-      }
+        /* Top level container */
+        #list-line {
+          display: flex;
+        }
 
-      #list-line.mobile {
-        flex-direction: column;
-      }
+        #list-line.mobile {
+          flex-direction: column;
+        }
 
-      #list-line.desktop {
-        column-gap: 10px;
-      }
+        #list-line.desktop {
+          column-gap: 10px;
+        }
 
-      #list-line-top {
-        display: flex;
-        column-gap: 7px;
-      }
+        #list-line-top {
+          display: flex;
+          column-gap: 7px;
+        }
 
-      #list-line-bottom {
-        padding-top: 4px;
-      }
+        #list-line-bottom {
+          padding-top: 4px;
+        }
 
-      #list-line-right,
-      #list-line-top,
-      #list-line-bottom {
-        width: 100%;
-      }
+        #list-line-right,
+        #list-line-top,
+        #list-line-bottom {
+          width: 100%;
+        }
 
-      /*
+        /*
        * If the container becomes very tiny, don't let the thumbnail side take
        * up too much space. Shouldn't make a difference on ordinary viewport sizes.
        */
-      #list-line-left {
-        max-width: 25%;
+        #list-line-left {
+          max-width: 25%;
 
-        display: flex;
-        flex-direction: column;
-        row-gap: 5px;
-      }
+          display: flex;
+          flex-direction: column;
+          row-gap: 5px;
+        }
 
-      div a:hover {
-        text-decoration: underline;
-      }
+        div a:hover {
+          text-decoration: underline;
+        }
 
-      /* Lines containing multiple div as row */
-      #item-line,
-      #dates-line,
-      #views-line,
-      #title-line {
-        display: flex;
-        flex-direction: row;
-        column-gap: 10px;
-      }
+        /* Lines containing multiple div as row */
+        #item-line,
+        #dates-line,
+        #views-line,
+        #title-line {
+          display: flex;
+          flex-direction: row;
+          column-gap: 10px;
+        }
 
-      /*
+        /*
        * With the exception of the title line, allow these to wrap if
        * the space becomes too small to accommodate them together.
        *
        * The title line is excluded because it contains the mediatype icon
        * which we don't want to wrap.
        */
-      #item-line,
-      #dates-line,
-      #views-line {
-        flex-wrap: wrap;
-      }
+        #item-line,
+        #dates-line,
+        #views-line {
+          flex-wrap: wrap;
+        }
 
-      .capture-dates {
-        margin: 0;
-        padding: 0;
-        list-style-type: none;
-      }
+        .capture-dates {
+          margin: 0;
+          padding: 0;
+          list-style-type: none;
+        }
 
-      .capture-dates a:link {
-        text-decoration: none;
-        color: var(--ia-theme-link-color, #4b64ff);
-      }
-      .capture-dates a:hover {
-        text-decoration: underline;
-      }
-    `;
+        .capture-dates a:link {
+          text-decoration: none;
+          color: var(--ia-theme-link-color, #4b64ff);
+        }
+        .capture-dates a:hover {
+          text-decoration: underline;
+        }
+
+        /*
+       * Tile-list (extended) action row sits under the thumbnail in the left
+       * column. The image-block above already has its own bottom padding via
+       * the parent's row-gap, so we don't need extra spacing here.
+       */
+        .tile-actions.list-detail {
+          width: 100%;
+        }
+      `,
+    ];
   }
 }

--- a/src/tiles/models.ts
+++ b/src/tiles/models.ts
@@ -6,3 +6,19 @@
  *  - `minimal`: Show neither tile stats nor the text snippets.
  */
 export type LayoutType = 'default' | 'stats-only' | 'snippets-only' | 'minimal';
+
+/**
+ * Describes an action button to render at the bottom of a tile.
+ * Styling is controlled via CSS custom properties on the host:
+ *  - `--tileActionColor` (default: #333)
+ *  - `--tileActionBg` (default: #fff)
+ *  - `--tileActionHoverBg` (default: #f0f0f0)
+ *  - `--tileActionSeparatorColor` (default: #ddd)
+ */
+export interface TileAction {
+  /** Unique identifier for this action */
+  id: string;
+
+  /** Label text displayed on the button */
+  label: string;
+}

--- a/src/tiles/models.ts
+++ b/src/tiles/models.ts
@@ -8,17 +8,14 @@
 export type LayoutType = 'default' | 'stats-only' | 'snippets-only' | 'minimal';
 
 /**
- * Describes an action button to render at the bottom of a tile.
- * Styling is controlled via CSS custom properties on the host:
- *  - `--tileActionColor` (default: #333)
- *  - `--tileActionBg` (default: #fff)
- *  - `--tileActionHoverBg` (default: #f0f0f0)
- *  - `--tileActionSeparatorColor` (default: #ddd)
+ * Describes an action button to render on a tile.
+ * Styling is controlled via the CSS custom properties documented in
+ * `src/styles/tile-action-styles.ts`.
  */
 export interface TileAction {
-  /** Unique identifier for this action */
+  /** Unique identifier for this action, included in the `tileActionClicked` event */
   id: string;
 
-  /** Label text displayed on the button */
+  /** Visible label text displayed on the button */
   label: string;
 }

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -1,5 +1,6 @@
 import { css, html, nothing, PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { msg } from '@lit/localize';
 import type {
@@ -18,7 +19,7 @@ import './list/tile-list-compact';
 import './list/tile-list-compact-header';
 import type { TileHoverPane } from './hover/tile-hover-pane';
 import { BaseTileComponent } from './base-tile-component';
-import { LayoutType } from './models';
+import { LayoutType, type TileAction } from './models';
 import {
   HoverPaneController,
   HoverPaneControllerInterface,
@@ -72,6 +73,9 @@ export class TileDispatcher
     'Remove this item from the list',
   );
 
+  /** Action buttons to display at the bottom of the tile (grid mode only) */
+  @property({ type: Array }) tileActions: TileAction[] = [];
+
   private hoverPaneController?: HoverPaneControllerInterface;
 
   @query('#container')
@@ -104,14 +108,20 @@ export class TileDispatcher
 
   render() {
     const isGridMode = this.tileDisplayMode === 'grid';
+    const hasTileActions = isGridMode && this.showTileActions;
     const hoverPaneTemplate =
       this.hoverPaneController?.getTemplate() ?? nothing;
+    const containerClasses = classMap({
+      hoverable: isGridMode,
+      'has-tile-actions': hasTileActions,
+    });
     return html`
-      <div id="container" class=${isGridMode ? 'hoverable' : ''}>
+      <div id="container" class=${containerClasses}>
         ${this.tileDisplayMode === 'list-header'
           ? this.headerTemplate
           : this.tileTemplate}
-        ${this.manageCheckTemplate} ${hoverPaneTemplate}
+        ${this.tileActionsTemplate} ${this.manageCheckTemplate}
+        ${hoverPaneTemplate}
       </div>
     `;
   }
@@ -306,6 +316,60 @@ export class TileDispatcher
     });
   }
 
+  /** Whether tile action buttons should be rendered */
+  private get showTileActions(): boolean {
+    return (
+      this.tileActions.length > 0 &&
+      !this.isManageView &&
+      this.tileDisplayMode === 'grid'
+    );
+  }
+
+  private get tileActionsTemplate() {
+    if (!this.showTileActions) return nothing;
+
+    return html`
+      <div
+        class="tile-actions"
+        @mouseenter=${this.handleTileActionsMouseEnter}
+        @mousemove=${(e: Event) => e.stopPropagation()}
+      >
+        ${this.tileActions.map(
+          action => html`
+            <button
+              class="tile-action-btn"
+              @click=${(e: Event) => this.handleTileActionClick(e, action)}
+            >
+              ${action.label}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * When the mouse enters the tile actions area, dispatch a synthetic mouseleave
+   * on the host to cancel the hover pane's show timer and hide any visible pane.
+   */
+  private handleTileActionsMouseEnter = (): void => {
+    this.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+  };
+
+  private handleTileActionClick(e: Event, action: TileAction): void {
+    e.stopPropagation();
+    // Pre-set the hover pane controller's clicking flag so that focus
+    // restoration after a consumer-opened modal won't trigger the hover pane.
+    this.dispatchEvent(new PointerEvent('pointerdown'));
+    this.dispatchEvent(
+      new CustomEvent('tileActionClicked', {
+        detail: { actionId: action.id, model: this.model },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
   private get tile() {
     const {
       model,
@@ -466,8 +530,43 @@ export class TileDispatcher
           border-radius: 4px;
         }
 
-        #container.hoverable a:focus,
-        #container.hoverable a:hover {
+        /*
+         * When tile actions are present, the container becomes the visual "card"
+         * so that the tile content and action buttons appear as one unified element.
+         */
+        /*
+         * When tile actions are present, the container takes over the tile's
+         * border-radius and box-shadow so that the action bar appears as part
+         * of the same card. The inner tile's own shadow/radius are disabled
+         * via CSS variable overrides so there is no visual duplication.
+         */
+        #container.has-tile-actions {
+          display: flex;
+          flex-direction: column;
+          overflow: hidden;
+          box-shadow: var(--tileShadow, 1px 1px 2px 0);
+          --tileBoxShadow: none;
+          --tileCornerRadius: 0;
+        }
+
+        #container.has-tile-actions .tile-link {
+          flex: 1;
+          min-height: 0;
+          overflow: hidden;
+          border-radius: 0;
+        }
+
+        /* Move hover shadow to container level when tile actions are present */
+        #container.hoverable:not(.has-tile-actions) a:focus,
+        #container.hoverable:not(.has-tile-actions) a:hover {
+          box-shadow: var(
+            --tileHoverBoxShadow,
+            0 0 6px 2px rgba(8, 8, 32, 0.8)
+          );
+          transition: box-shadow 0.1s ease;
+        }
+
+        #container.hoverable.has-tile-actions:hover {
           box-shadow: var(
             --tileHoverBoxShadow,
             0 0 6px 2px rgba(8, 8, 32, 0.8)
@@ -520,6 +619,32 @@ export class TileDispatcher
           top: 0;
           left: -9999px;
           z-index: 2;
+        }
+
+        .tile-actions {
+          flex-shrink: 0;
+          display: flex;
+          border-top: 1px solid var(--tileActionSeparatorColor, #ddd);
+        }
+
+        .tile-action-btn {
+          flex: 1;
+          padding: 8px;
+          border: none;
+          border-radius: 0;
+          font-size: 1.2rem;
+          cursor: pointer;
+          color: var(--tileActionColor, #333);
+          background: var(--tileActionBg, #fff);
+          transition: background 0.15s;
+        }
+
+        .tile-action-btn + .tile-action-btn {
+          border-left: 1px solid var(--tileActionSeparatorColor, #ddd);
+        }
+
+        .tile-action-btn:hover {
+          background: var(--tileActionHoverBg, #f0f0f0);
         }
       `,
     ];

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -19,7 +19,7 @@ import './list/tile-list-compact';
 import './list/tile-list-compact-header';
 import type { TileHoverPane } from './hover/tile-hover-pane';
 import { BaseTileComponent } from './base-tile-component';
-import { LayoutType, type TileAction } from './models';
+import { LayoutType } from './models';
 import {
   HoverPaneController,
   HoverPaneControllerInterface,
@@ -27,6 +27,7 @@ import {
   HoverPaneProviderInterface,
 } from './hover/hover-pane-controller';
 import { srOnlyStyle } from '../styles/sr-only';
+import { tileActionStyles } from '../styles/tile-action-styles';
 
 @customElement('tile-dispatcher')
 export class TileDispatcher
@@ -38,6 +39,7 @@ export class TileDispatcher
   /*
    * Reactive properties inherited from BaseTileComponent:
    *  - model?: TileModel;
+   *  - tileActions: TileAction[] = [];
    *  - currentWidth?: number;
    *  - currentHeight?: number;
    *  - baseNavigationUrl?: string;
@@ -73,9 +75,6 @@ export class TileDispatcher
     'Remove this item from the list',
   );
 
-  /** Action buttons to display at the bottom of the tile (grid mode only) */
-  @property({ type: Array }) tileActions: TileAction[] = [];
-
   private hoverPaneController?: HoverPaneControllerInterface;
 
   @query('#container')
@@ -108,7 +107,7 @@ export class TileDispatcher
 
   render() {
     const isGridMode = this.tileDisplayMode === 'grid';
-    const hasTileActions = isGridMode && this.showTileActions;
+    const hasTileActions = isGridMode && this.showGridTileActions;
     const hoverPaneTemplate =
       this.hoverPaneController?.getTemplate() ?? nothing;
     const containerClasses = classMap({
@@ -120,7 +119,7 @@ export class TileDispatcher
         ${this.tileDisplayMode === 'list-header'
           ? this.headerTemplate
           : this.tileTemplate}
-        ${this.tileActionsTemplate} ${this.manageCheckTemplate}
+        ${this.gridTileActionsTemplate} ${this.manageCheckTemplate}
         ${hoverPaneTemplate}
       </div>
     `;
@@ -144,6 +143,7 @@ export class TileDispatcher
         .currentWidth=${currentWidth}
         .sortParam=${sortParam ?? defaultSortParam}
         .mobileBreakpoint=${mobileBreakpoint}
+        .tileActions=${this.tileActions}
       >
       </tile-list-compact-header>
     `;
@@ -316,8 +316,8 @@ export class TileDispatcher
     });
   }
 
-  /** Whether tile action buttons should be rendered */
-  private get showTileActions(): boolean {
+  /** Whether tile action buttons should be rendered in grid mode */
+  private get showGridTileActions(): boolean {
     return (
       this.tileActions.length > 0 &&
       !this.isManageView &&
@@ -325,13 +325,18 @@ export class TileDispatcher
     );
   }
 
-  private get tileActionsTemplate() {
-    if (!this.showTileActions) return nothing;
+  /**
+   * Template for the grid-mode action buttons. Rendered alongside the inner
+   * tile link inside the dispatcher's shadow root so the action buttons can
+   * suppress the hover pane on hover.
+   */
+  private get gridTileActionsTemplate() {
+    if (!this.showGridTileActions) return nothing;
 
     return html`
       <div
-        class="tile-actions"
-        @mouseenter=${this.handleTileActionsMouseEnter}
+        class="tile-actions grid-tile-actions"
+        @mouseenter=${this.handleGridActionsMouseEnter}
         @mousemove=${(e: Event) => e.stopPropagation()}
       >
         ${this.tileActions.map(
@@ -349,26 +354,13 @@ export class TileDispatcher
   }
 
   /**
-   * When the mouse enters the tile actions area, dispatch a synthetic mouseleave
-   * on the host to cancel the hover pane's show timer and hide any visible pane.
+   * When the mouse enters the grid-mode tile actions area, dispatch a
+   * synthetic mouseleave on the host to cancel the hover pane's show timer
+   * and hide any visible pane.
    */
-  private handleTileActionsMouseEnter = (): void => {
+  private handleGridActionsMouseEnter = (): void => {
     this.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
   };
-
-  private handleTileActionClick(e: Event, action: TileAction): void {
-    e.stopPropagation();
-    // Pre-set the hover pane controller's clicking flag so that focus
-    // restoration after a consumer-opened modal won't trigger the hover pane.
-    this.dispatchEvent(new PointerEvent('pointerdown'));
-    this.dispatchEvent(
-      new CustomEvent('tileActionClicked', {
-        detail: { actionId: action.id, model: this.model },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-  }
 
   private get tile() {
     const {
@@ -466,6 +458,7 @@ export class TileDispatcher
           .baseImageUrl=${this.baseImageUrl}
           .loggedIn=${this.loggedIn}
           .suppressBlurring=${this.suppressBlurring}
+          .tileActions=${this.isManageView ? [] : this.tileActions}
           ?useLocalTime=${this.useLocalTime}
         >
         </tile-list-compact>`;
@@ -484,6 +477,7 @@ export class TileDispatcher
           .baseImageUrl=${this.baseImageUrl}
           .loggedIn=${this.loggedIn}
           .suppressBlurring=${this.suppressBlurring}
+          .tileActions=${this.isManageView ? [] : this.tileActions}
           ?useLocalTime=${this.useLocalTime}
         >
         </tile-list>`;
@@ -495,6 +489,7 @@ export class TileDispatcher
   static get styles() {
     return [
       srOnlyStyle,
+      tileActionStyles,
       css`
         :host {
           display: block;
@@ -531,14 +526,12 @@ export class TileDispatcher
         }
 
         /*
-         * When tile actions are present, the container becomes the visual "card"
-         * so that the tile content and action buttons appear as one unified element.
-         */
-        /*
-         * When tile actions are present, the container takes over the tile's
-         * border-radius and box-shadow so that the action bar appears as part
-         * of the same card. The inner tile's own shadow/radius are disabled
-         * via CSS variable overrides so there is no visual duplication.
+         * When tile actions are present, the container takes on the role of
+         * the tile's visual card so the tile content and action row appear
+         * as a single unified element. The inner tile's own shadow/radius
+         * are disabled via CSS variable overrides to avoid visual
+         * duplication, and the action row sits as a footer inside the same
+         * card.
          */
         #container.has-tile-actions {
           display: flex;
@@ -556,7 +549,7 @@ export class TileDispatcher
           border-radius: 0;
         }
 
-        /* Move hover shadow to container level when tile actions are present */
+        /* Normal hover shadow lives on the inner anchor for plain tiles */
         #container.hoverable:not(.has-tile-actions) a:focus,
         #container.hoverable:not(.has-tile-actions) a:hover {
           box-shadow: var(
@@ -566,6 +559,10 @@ export class TileDispatcher
           transition: box-shadow 0.1s ease;
         }
 
+        /*
+         * When the container owns the card visuals, the hover shadow needs
+         * to move up to the container so it wraps the action row too.
+         */
         #container.hoverable.has-tile-actions:hover {
           box-shadow: var(
             --tileHoverBoxShadow,
@@ -621,30 +618,18 @@ export class TileDispatcher
           z-index: 2;
         }
 
-        .tile-actions {
-          flex-shrink: 0;
-          display: flex;
-          border-top: 1px solid var(--tileActionSeparatorColor, #ddd);
+        /*
+         * Grid-mode action row sits flush against the bottom of the card —
+         * the buttons' own borders form the visible bottom edge. The outer
+         * buttons get rounded bottom corners to match the container so the
+         * red border traces cleanly around the card's bottom corners.
+         */
+        .grid-tile-actions .tile-action-btn:first-child {
+          border-bottom-left-radius: 4px;
         }
 
-        .tile-action-btn {
-          flex: 1;
-          padding: 8px;
-          border: none;
-          border-radius: 0;
-          font-size: 1.2rem;
-          cursor: pointer;
-          color: var(--tileActionColor, #333);
-          background: var(--tileActionBg, #fff);
-          transition: background 0.15s;
-        }
-
-        .tile-action-btn + .tile-action-btn {
-          border-left: 1px solid var(--tileActionSeparatorColor, #ddd);
-        }
-
-        .tile-action-btn:hover {
-          background: var(--tileActionHoverBg, #f0f0f0);
+        .grid-tile-actions .tile-action-btn:last-child {
+          border-bottom-right-radius: 4px;
         }
       `,
     ];


### PR DESCRIPTION
We would like to add additional buttons to tiles in certain cases. This PR adds a new `tileActions` property which can be used to add custom action buttons to tiles that will emit events when clicked.