### PR TITLE
WEBDEV-7901 Indicate "Weekly" or "All-time" views on tile labels

### DIFF
--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -79,7 +79,7 @@ export class TileListCompactHeader extends BaseTileComponent {
       }
 
       #list-line-header.desktop {
-        grid-template-columns: 51px 3fr 2fr 95px 30px 100px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 115px;
       }
     `;
   }

--- a/src/tiles/list/tile-list-compact-header.ts
+++ b/src/tiles/list/tile-list-compact-header.ts
@@ -30,7 +30,7 @@ export class TileListCompactHeader extends BaseTileComponent {
           ${this.displayValueProvider.dateLabel || msg('Published')}
         </div>
         <div id="icon">${msg('Type')}</div>
-        <div id="views">${msg('Views')}</div>
+        <div id="views">${this.displayValueProvider.viewsLabel}</div>
       </div>
     `;
   }
@@ -79,7 +79,7 @@ export class TileListCompactHeader extends BaseTileComponent {
       }
 
       #list-line-header.desktop {
-        grid-template-columns: 51px 3fr 2fr 95px 30px 60px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 100px;
       }
     `;
   }

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -185,7 +185,7 @@ export class TileListCompact extends BaseTileComponent {
       }
 
       #list-line.desktop {
-        grid-template-columns: 51px 3fr 2fr 95px 30px 60px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 100px;
       }
 
       #list-line:hover #title {

--- a/src/tiles/list/tile-list-compact.ts
+++ b/src/tiles/list/tile-list-compact.ts
@@ -185,7 +185,7 @@ export class TileListCompact extends BaseTileComponent {
       }
 
       #list-line.desktop {
-        grid-template-columns: 51px 3fr 2fr 95px 30px 100px;
+        grid-template-columns: 51px 3fr 2fr 95px 30px 115px;
       }
 
       #list-line:hover #title {

--- a/src/tiles/list/tile-list.ts
+++ b/src/tiles/list/tile-list.ts
@@ -250,10 +250,10 @@ export class TileList extends BaseTileComponent {
   }
 
   private get viewsTemplate() {
-    const viewCount =
-      this.effectiveSort?.field === 'week'
-        ? this.model?.weeklyViewCount // weekly views
-        : this.model?.viewCount; // all-time views
+    const isWeeklySort = this.effectiveSort?.field === 'week';
+    const viewCount = isWeeklySort
+      ? this.model?.weeklyViewCount // weekly views
+      : this.model?.viewCount; // all-time views
     if (viewCount == null) return nothing;
 
     // when its a search-tile, we don't have any stats to show
@@ -263,7 +263,7 @@ export class TileList extends BaseTileComponent {
 
     return this.metadataTemplate(
       `${formatCount(viewCount, this.formatSize)}`,
-      msg('Views'),
+      this.displayValueProvider.viewsLabel,
     );
   }
 

--- a/src/tiles/tile-display-value-provider.ts
+++ b/src/tiles/tile-display-value-provider.ts
@@ -92,6 +92,16 @@ export class TileDisplayValueProvider {
   }
 
   /**
+   * The readable label for the current views column, based on whether
+   * weekly or all-time views are being shown.
+   */
+  get viewsLabel(): string {
+    return this.sortParam?.field === 'week'
+      ? msg('Weekly views')
+      : msg('All-time views');
+  }
+
+  /**
    * Produces a URL pointing at the item page for the given identifier,
    * using the current base URL and the correct path based on whether the
    * item is specified to be a collection (default false).

--- a/test/tiles/list/tile-list-compact-header.test.ts
+++ b/test/tiles/list/tile-list-compact-header.test.ts
@@ -1,0 +1,43 @@
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import type { TileListCompactHeader } from '../../../src/tiles/list/tile-list-compact-header';
+
+import '../../../src/tiles/list/tile-list-compact-header';
+
+describe('List Tile Compact Header', () => {
+  it('should render Weekly views header when sorting by week', async () => {
+    const el = await fixture<TileListCompactHeader>(html`
+      <tile-list-compact-header
+        .sortParam=${{ field: 'week', direction: 'desc' }}
+      >
+      </tile-list-compact-header>
+    `);
+
+    const viewsColumn = el.shadowRoot?.getElementById('views');
+    expect(viewsColumn).to.exist;
+    expect(viewsColumn?.textContent?.trim()).to.equal('Weekly views');
+  });
+
+  it('should render All-time views header when sorting by non-week field', async () => {
+    const el = await fixture<TileListCompactHeader>(html`
+      <tile-list-compact-header
+        .sortParam=${{ field: 'downloads', direction: 'desc' }}
+      >
+      </tile-list-compact-header>
+    `);
+
+    const viewsColumn = el.shadowRoot?.getElementById('views');
+    expect(viewsColumn).to.exist;
+    expect(viewsColumn?.textContent?.trim()).to.equal('All-time views');
+  });
+
+  it('should render All-time views header with no sort param', async () => {
+    const el = await fixture<TileListCompactHeader>(html`
+      <tile-list-compact-header> </tile-list-compact-header>
+    `);
+
+    const viewsColumn = el.shadowRoot?.getElementById('views');
+    expect(viewsColumn).to.exist;
+    expect(viewsColumn?.textContent?.trim()).to.equal('All-time views');
+  });
+});

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -143,7 +143,31 @@ describe('List Tile', () => {
 
     const viewsRow = el.shadowRoot?.getElementById('views-line');
     expect(viewsRow).to.exist;
-    expect(viewsRow?.textContent?.trim()).to.equal('Views:  10');
+    expect(viewsRow?.textContent?.trim()).to.equal('Weekly views:  10');
+  });
+
+  it('should render all-time views when sorting by non-week field', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list
+        .model=${{ viewCount: 50, weeklyViewCount: 10 }}
+        .sortParam=${{ field: 'downloads', direction: 'desc' }}
+      >
+      </tile-list>
+    `);
+
+    const viewsRow = el.shadowRoot?.getElementById('views-line');
+    expect(viewsRow).to.exist;
+    expect(viewsRow?.textContent?.trim()).to.equal('All-time views:  50');
+  });
+
+  it('should render all-time views with no sort param', async () => {
+    const el = await fixture<TileList>(html`
+      <tile-list .model=${{ viewCount: 50, weeklyViewCount: 10 }}> </tile-list>
+    `);
+
+    const viewsRow = el.shadowRoot?.getElementById('views-line');
+    expect(viewsRow).to.exist;
+    expect(viewsRow?.textContent?.trim()).to.equal('All-time views:  50');
   });
 
   it('should render published date when sorting by it', async () => {


### PR DESCRIPTION
On our list and compact-list tiles, we currently update the number of views according to the current sort option. However, on our list and compact-list tiles, this is currently still just labeled "Views" with no indication of which type of views it represents. This PR updates those labels to more precisely indicate whether they represent "Weekly views" or "All-time views".