### PR TITLE
v4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version includes more descriptive labeling for view counts (#578) and logic to fall back to metadata search for empty FTS queries in collections (#577).