### PR TITLE
WEBDEV-8495 Upgrade date picker to fix regression in Lit 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@internetarchive/elements": "^0.2.2",
     "@internetarchive/feature-feedback": "^1.0.0",
     "@internetarchive/field-parsers": "^1.0.0",
-    "@internetarchive/histogram-date-range": "^1.4.1",
+    "@internetarchive/histogram-date-range": "1.4.2-alpha-webdev8495.0",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@internetarchive/elements": "^0.2.2",
     "@internetarchive/feature-feedback": "^1.0.0",
     "@internetarchive/field-parsers": "^1.0.0",
-    "@internetarchive/histogram-date-range": "1.4.2-alpha-webdev8495.0",
+    "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-1.0.0.tgz"
   integrity sha512-cbD0FtJOjzBm7exxFrzrkHnqbmalKbEXA4i7KrwhUGBojF/QTTLAvaIRXH/bfoiTyCh6YT1/E/mULAQPdB6yvQ==
 
-"@internetarchive/histogram-date-range@1.4.2-alpha-webdev8495.0":
-  version "1.4.2-alpha-webdev8495.0"
-  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.4.2-alpha-webdev8495.0.tgz#c1b661d6459bd3c11a93ad502b40e818e2373ce2"
-  integrity sha512-kpL0heC0D/K9yHJxY1PQXilMHZn2Ioy/46QKRlhbkp1TvZkcGs54MSGz2Vt4lyU1+P2iPkMErISDzE2wVjT2FA==
+"@internetarchive/histogram-date-range@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.4.2.tgz#16669037155ce8c5e6393d4572bc0e4fd092562a"
+  integrity sha512-7zBl8nmVJ8fVsOpWPLujNoHYJ6MBWrxibGPxhoFHV5AYd59MyOIEEnf5davXGZFLmGmGGLmdfqh4hm+ZCuQw3w==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.6"
     dayjs "^1.11.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,10 +209,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-1.0.0.tgz"
   integrity sha512-cbD0FtJOjzBm7exxFrzrkHnqbmalKbEXA4i7KrwhUGBojF/QTTLAvaIRXH/bfoiTyCh6YT1/E/mULAQPdB6yvQ==
 
-"@internetarchive/histogram-date-range@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/@internetarchive/histogram-date-range/-/histogram-date-range-1.4.1.tgz"
-  integrity sha512-kQ29P8lJqIMHbBfGH6d9TMjZQbJ35Imuv8NiRHeMPXMwOydrsVwejA2gTUpDvlOlFkJxr9DKBcGEFJBvhf6XPw==
+"@internetarchive/histogram-date-range@1.4.2-alpha-webdev8495.0":
+  version "1.4.2-alpha-webdev8495.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/histogram-date-range/-/histogram-date-range-1.4.2-alpha-webdev8495.0.tgz#c1b661d6459bd3c11a93ad502b40e818e2373ce2"
+  integrity sha512-kpL0heC0D/K9yHJxY1PQXilMHZn2Ioy/46QKRlhbkp1TvZkcGs54MSGz2Vt4lyU1+P2iPkMErISDzE2wVjT2FA==
   dependencies:
     "@internetarchive/ia-activity-indicator" "^0.0.6"
     dayjs "^1.11.13"


### PR DESCRIPTION
When the version of Lit in use is overridden to Lit 3, the `histogram-date-range` component currently has a bug where it does not emit any events when the date range is updated. This PR just upgrades that component to a fixed version.