### PR TITLE
v4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version upgrades the `histogram-date-range` dependency to pull in a fix for usage with Lit 3 (#580).