### PR TITLE
WEBDEV-7939 Upgrade infinite-scroller to new version with CSS-transform-based virtualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.3",
+    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.4",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.8",
+    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.10",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.10",
+    "@internetarchive/infinite-scroller": "^2.0.0",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.6",
+    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.8",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.4",
+    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.6",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/histogram-date-range": "^1.4.2",
     "@internetarchive/ia-dropdown": "^2.0.0",
     "@internetarchive/iaux-item-metadata": "^1.0.5",
-    "@internetarchive/infinite-scroller": "^1.0.1",
+    "@internetarchive/infinite-scroller": "1.1.0-alpha-webdev7939.3",
     "@internetarchive/modal-manager": "^2.0.5",
     "@internetarchive/search-service": "^2.7.1",
     "@internetarchive/shared-resize-observer": "^0.2.0",

--- a/src/app-root.ts
+++ b/src/app-root.ts
@@ -112,6 +112,9 @@ export class AppRoot extends LitElement {
     const page = this.currentPage ?? 1;
     if (page > 1) {
       this.collectionBrowser.goToPage(page);
+    } else {
+      // Ensure we reset the initial page
+      this.collectionBrowser.initialPageNumber = 1;
     }
   }
 

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -917,6 +917,7 @@ export class CollectionBrowser
       itemCount=${this.placeholderType ? 0 : nothing}
       ariaLandmarkLabel="Search results"
       .estimatedCellHeight=${this.estimatedTileHeight}
+      .minBufferMarginCells=${this.pageSize}
       .cellProvider=${this}
       .placeholderCellTemplate=${this.placeholderCellTemplate}
       @scrollThresholdReached=${this.scrollThresholdReached}

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -866,6 +866,7 @@ export class CollectionBrowser
       class=${this.infiniteScrollerClasses}
       itemCount=${this.placeholderType ? 0 : nothing}
       ariaLandmarkLabel="Search results"
+      .estimatedCellHeight=${this.estimatedTileHeight}
       .cellProvider=${this}
       .placeholderCellTemplate=${this.placeholderCellTemplate}
       @scrollThresholdReached=${this.scrollThresholdReached}
@@ -885,6 +886,25 @@ export class CollectionBrowser
       [this.displayMode ?? '']: !!this.displayMode,
       hidden: !!this.placeholderType,
     });
+  }
+
+  /**
+   * Best-effort hint of how tall a single rendered tile is, by display mode.
+   * The scroller uses this to better estimate the size its initial scroll
+   * spacer and buffer position before real cell heights are measured.
+   * Should roughly match the placeholder heights since the initial render
+   * of a new page generally shows placeholders only anyway.
+   */
+  private get estimatedTileHeight(): number {
+    switch (this.displayMode) {
+      case 'list-detail':
+        return 80;
+      case 'list-compact':
+        return 45;
+      case 'grid':
+      default:
+        return 225;
+    }
   }
 
   /**
@@ -2323,25 +2343,34 @@ export class CollectionBrowser
     });
   }
 
-  private scrollToPage(pageNumber: number): Promise<void> {
-    return new Promise(resolve => {
-      const cellIndexToScrollTo = this.pageSize * (pageNumber - 1);
-      // without this setTimeout, Safari just pauses until the `fetchPage` is complete
-      // then scrolls to the cell
-      setTimeout(() => {
-        this.isScrollingToCell = true;
-        this.infiniteScroller?.scrollToCell(cellIndexToScrollTo, true);
-        // This timeout is to give the scroll animation time to finish
-        // then updating the infinite scroller once we're done scrolling
-        // There's no scroll animation completion callback so we're
-        // giving it 0.5s to finish.
-        setTimeout(() => {
-          this.isScrollingToCell = false;
-          this.infiniteScroller?.refreshAllVisibleCells();
-          resolve();
-        }, 500);
-      }, 0);
+  private async scrollToPage(pageNumber: number): Promise<void> {
+    const cellIndexToScrollTo = this.pageSize * (pageNumber - 1);
+
+    // Wait for the infinite scroller be rendered before proceeding
+    let waitAttempts = 0;
+    while (!this.infiniteScroller && waitAttempts < 20) {
+      await this.updateComplete;
+      waitAttempts++;
+    }
+    if (!this.infiniteScroller) return;
+
+    // The scroller have its default `itemCount=0`, so propagate our estimated
+    // tile count before jumping to the desired page.
+    if (this.infiniteScroller.itemCount < this.estimatedTileCount) {
+      this.infiniteScroller.itemCount = this.estimatedTileCount;
+      await this.updateComplete;
+    }
+
+    // Without this setTimeout(0), Safari just pauses until the `fetchPage`
+    // is complete then scrolls to the cell.
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
     });
+
+    this.isScrollingToCell = true;
+    await this.infiniteScroller.scrollToCell(cellIndexToScrollTo, true);
+    this.isScrollingToCell = false;
+    this.infiniteScroller.refreshAllVisibleCells();
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1168,7 +1168,7 @@ export class CollectionBrowser
     if ((this.currentPage ?? 1) > 1) {
       this.goToPage(1);
     }
-    this.currentPage = 1;
+    this.setCurrentPage(1);
   }
 
   /**
@@ -2198,27 +2198,45 @@ export class CollectionBrowser
   private visibleCellsChanged(
     e: CustomEvent<{ visibleCellIndices: number[] }>,
   ) {
+    this.updateVisiblePage(e.detail.visibleCellIndices);
+  }
+
+  /**
+   * Recomputes the current page from the given set of visible cell indices
+   * and emits `visiblePageChanged` if the page actually changed.
+   */
+  private updateVisiblePage(visibleCellIndices: number[]): void {
     if (this.isScrollingToCell) return;
-    const { visibleCellIndices } = e.detail;
     if (visibleCellIndices.length === 0) return;
+
+    // The indices aren't necessarily sorted, so sort them here to ensure our
+    // calculations below find the right cell/page.
+    const sorted = [...visibleCellIndices].sort((a, b) => a - b);
 
     // For page determination, do not count more than a single page of visible cells,
     // since otherwise patrons using very tall screens will be treated as one page
     // further than they actually are.
     const lastIndexWithinCurrentPage =
-      Math.min(this.pageSize, visibleCellIndices.length) - 1;
-    const lastVisibleCellIndex = visibleCellIndices[lastIndexWithinCurrentPage];
+      Math.min(this.pageSize, sorted.length) - 1;
+    const lastVisibleCellIndex = sorted[lastIndexWithinCurrentPage];
     const lastVisibleCellPage =
       Math.floor(lastVisibleCellIndex / this.pageSize) + 1;
-    if (this.currentPage !== lastVisibleCellPage) {
-      this.currentPage = lastVisibleCellPage;
-    }
-    const event = new CustomEvent('visiblePageChanged', {
-      detail: {
-        pageNumber: lastVisibleCellPage,
-      },
-    });
-    this.dispatchEvent(event);
+
+    this.setCurrentPage(lastVisibleCellPage);
+  }
+
+  /**
+   * Sets the current page number and emits a `visiblePageChanged`
+   * event if the new page differs from the previous one.
+   */
+  private setCurrentPage(pageNumber: number): void {
+    if (this.currentPage === pageNumber) return;
+    this.currentPage = pageNumber;
+    this.dispatchEvent(
+      new CustomEvent('visiblePageChanged', {
+        detail: { pageNumber },
+      }),
+    );
   }
 
   // we only want to scroll on the very first query change
@@ -2318,10 +2336,10 @@ export class CollectionBrowser
     this.selectedCreatorFilter = restorationState.selectedCreatorFilter ?? null;
     this.selectedFacets = restorationState.selectedFacets;
     if (!this.suppressURLQuery) this.baseQuery = restorationState.baseQuery;
-    this.currentPage = restorationState.currentPage ?? 1;
+    this.setCurrentPage(restorationState.currentPage ?? 1);
     this.minSelectedDate = restorationState.minSelectedDate;
     this.maxSelectedDate = restorationState.maxSelectedDate;
-    if (this.currentPage > 1) {
+    if (this.currentPage && this.currentPage > 1) {
       this.goToPage(this.currentPage);
     }
   }
@@ -2423,9 +2441,18 @@ export class CollectionBrowser
     });
 
     this.isScrollingToCell = true;
-    await this.infiniteScroller.scrollToCell(cellIndexToScrollTo, true);
+    const scrolled = await this.infiniteScroller.scrollToCell(
+      cellIndexToScrollTo,
+      true,
+    );
     this.isScrollingToCell = false;
     this.infiniteScroller.refreshAllVisibleCells();
+
+    // After we finish scrolling, recompute the visible page from the new state
+    // so that it doesn't fall out of sync.
+    if (scrolled) {
+      this.updateVisiblePage(this.infiniteScroller.getVisibleCellIndices());
+    }
   }
 
   /**

--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -421,7 +421,7 @@ export class CollectionBrowser
     const model = this.dataSource.getTileModelAt(index);
     /**
      * If we encounter a model we don't have yet and we're not in the middle of an
-     * automated scroll, fetch the page and just return undefined.
+     * automated scroll, schedule a fetch for the missing page and return undefined.
      * The datasource will be updated once the page is loaded and the cell will be rendered.
      *
      * We disable it during the automated scroll since we don't want to fetch pages for intervening cells the
@@ -429,9 +429,59 @@ export class CollectionBrowser
      */
     if (!model && !this.isScrollingToCell && this.dataSource.queryInitialized) {
       const pageNumber = Math.floor(index / this.pageSize) + 1;
-      this.dataSource.fetchPage(pageNumber);
+      this.scheduleDeferredPageFetch(pageNumber);
     }
     return model;
+  }
+
+  /**
+   * Debounce delay for page fetches initiated by new cells becoming visible.
+   * Tuned so quick scrolling through unloaded regions doesn't send rapid-fire
+   * search requests for every page we pass through, but to still feel responsive
+   * when the scroll ends.
+   */
+  private static readonly DEFERRED_FETCH_DELAY_MS = 150;
+
+  private deferredFetchTimer = 0;
+
+  /**
+   * Schedules a fetch for the given page, debounced to ensure we don't
+   * rapid-fire fetches while scrolling through pages quickly.
+   *
+   * If there's no pending fetch timer yet, it will fire a fetch immediately.
+   * Otherwise, it will reset any existing timer. In either case, a deferred
+   * fetch for the visible pages is scheduled after a brief delay to account
+   * for whatever pages we land on after scrolling.
+   */
+  private scheduleDeferredPageFetch(pageNumber: number): void {
+    if (!this.deferredFetchTimer) {
+      this.dataSource.fetchPage(pageNumber);
+    } else {
+      window.clearTimeout(this.deferredFetchTimer);
+    }
+
+    this.deferredFetchTimer = window.setTimeout(() => {
+      this.deferredFetchTimer = 0;
+      this.fetchVisiblePages();
+    }, CollectionBrowser.DEFERRED_FETCH_DELAY_MS);
+  }
+
+  /**
+   * Fetch each currently-visible page whose first cell still has no
+   * loaded model.
+   */
+  private fetchVisiblePages(): void {
+    const visibleIndices = this.infiniteScroller?.getVisibleCellIndices() ?? [];
+    const visiblePages = new Set(
+      visibleIndices.map(i => Math.floor(i / this.pageSize) + 1),
+    );
+
+    for (const page of visiblePages) {
+      const firstCellOfPage = (page - 1) * this.pageSize;
+      if (!this.dataSource.getTileModelAt(firstCellOfPage)) {
+        this.dataSource.fetchPage(page);
+      }
+    }
   }
 
   // this is the total number of tiles we expect if
@@ -1889,6 +1939,11 @@ export class CollectionBrowser
     }
     if (this.boundNavigationHandler) {
       window.removeEventListener('popstate', this.boundNavigationHandler);
+    }
+
+    if (this.deferredFetchTimer) {
+      window.clearTimeout(this.deferredFetchTimer);
+      this.deferredFetchTimer = 0;
     }
 
     this.leftColIntersectionObserver?.disconnect();

--- a/src/tiles/item-image.ts
+++ b/src/tiles/item-image.ts
@@ -1,4 +1,11 @@
-import { css, CSSResultGroup, html, LitElement, nothing } from 'lit';
+import {
+  css,
+  CSSResultGroup,
+  html,
+  LitElement,
+  nothing,
+  PropertyValues,
+} from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ClassInfo, classMap } from 'lit/directives/class-map.js';
 
@@ -12,6 +19,14 @@ import { searchIcon } from '../assets/img/icons/mediatype/search';
 
 @customElement('item-image')
 export class ItemImage extends LitElement {
+  /**
+   * Map to cache which identifiers have waveform-style thumbnails, so that
+   * they can have their waveform styling applied immediately, rather than
+   * waiting for the image content to load before applying it (which can
+   * cause noticeable flicker when such tiles refresh).
+   */
+  private static readonly waveformByIdentifier = new Map<string, boolean>();
+
   @property({ type: Object }) model?: TileModel;
 
   @property({ type: String }) baseImageUrl?: string;
@@ -29,6 +44,15 @@ export class ItemImage extends LitElement {
   @state() private isNotFound = false;
 
   @query('img') private baseImage!: HTMLImageElement;
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has('model')) {
+      // If this identifier is known to have a waveform image, then set isWaveform upfront
+      const identifier = this.model?.identifier;
+      this.isWaveform =
+        ItemImage.waveformByIdentifier.get(identifier as string) === true;
+    }
+  }
 
   render() {
     return html`
@@ -149,6 +173,9 @@ export class ItemImage extends LitElement {
       this.baseImage.naturalWidth / this.baseImage.naturalHeight === 4
     ) {
       this.isWaveform = true;
+      if (this.model?.identifier) {
+        ItemImage.waveformByIdentifier.set(this.model.identifier, true);
+      }
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,10 +269,10 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.6":
-  version "1.1.0-alpha-webdev7939.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.6.tgz#d756907488f7673075738a81d7dada277b702a3b"
-  integrity sha512-MG6UzLG9jlBTIXniCT+9cWEBG1+vwy7xSUeZvO6MXoykPxUd7Yk+DludCIucEHMlZQ9gC5SkDwLVymPpRMJ5oQ==
+"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.8":
+  version "1.1.0-alpha-webdev7939.8"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.8.tgz#f28f231cce82abd57fef51afbc60becb299ecaa0"
+  integrity sha512-uLF1Hw4nV2gicZoELtW8uY3e7CO3KyMlNkZjwcRcgT/gWfnNpk2g7v84fuKrBz6SzSe1xUKUQboD3vl9bdQpOg==
   dependencies:
     lit "^2.8.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,10 +269,10 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.3":
-  version "1.1.0-alpha-webdev7939.3"
-  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.3.tgz#3bcb24b293f3a93d3c39a6475e1ff661463bcdd6"
-  integrity sha512-rH6v/KbYi6KdaI7C04PZCnwtCG7GJeNjCnhBphviV3Cd7RmM1daMw2pvGJwOM75Y9rmtNF94YmoGRYZ17JSCxw==
+"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.4":
+  version "1.1.0-alpha-webdev7939.4"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.4.tgz#b8be01c7b4f1355378b706cf129b4c5f4da989a7"
+  integrity sha512-hL7hb4ULni+vT5vP/FZVuRmITp/zlE1swPJsClhFsksODoqG72VMdhYKcyUScODdQyPlC9rEt9B2rcBZjuNZig==
   dependencies:
     lit "^2.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,12 +269,12 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.10":
-  version "1.1.0-alpha-webdev7939.10"
-  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.10.tgz#877fd1dab29e5a68a3ee8d9f2cadc08452e5286a"
-  integrity sha512-9LNNFR0euX/y6gnog3GnoDLabNvOCWuIwyRl0jG+3hQtwR4NZh4oakFz2aUNc8nejem05ePRspJCsG1svvPWnQ==
+"@internetarchive/infinite-scroller@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-2.0.0.tgz#b7fbc9ad94c12225653b3718174d0712838638be"
+  integrity sha512-PGfi0eqdSfsVd3xS2W9abY+iAJQPcw/Z8x9kWYARhiwot35eAMWxFzCXm5FaRTTjEQjZFEOBdXrQFNlO8GBNsQ==
   dependencies:
-    lit "^2.8.0"
+    lit "^2.8.0 || ^3.3.2"
 
 "@internetarchive/lazy-loader-service@^0.2.0":
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,10 +269,10 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.8":
-  version "1.1.0-alpha-webdev7939.8"
-  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.8.tgz#f28f231cce82abd57fef51afbc60becb299ecaa0"
-  integrity sha512-uLF1Hw4nV2gicZoELtW8uY3e7CO3KyMlNkZjwcRcgT/gWfnNpk2g7v84fuKrBz6SzSe1xUKUQboD3vl9bdQpOg==
+"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.10":
+  version "1.1.0-alpha-webdev7939.10"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.10.tgz#877fd1dab29e5a68a3ee8d9f2cadc08452e5286a"
+  integrity sha512-9LNNFR0euX/y6gnog3GnoDLabNvOCWuIwyRl0jG+3hQtwR4NZh4oakFz2aUNc8nejem05ePRspJCsG1svvPWnQ==
   dependencies:
     lit "^2.8.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,10 +269,10 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@internetarchive/infinite-scroller/-/infinite-scroller-1.0.1.tgz"
-  integrity sha512-wzl7bQLidNZ4uXgP0H8AA3HoAXxueoHaVcpgQMXR7bspHKGvgLy8EvLbprBps1dFNK5yZRH9PHdLRtJgpcWKtQ==
+"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.3":
+  version "1.1.0-alpha-webdev7939.3"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.3.tgz#3bcb24b293f3a93d3c39a6475e1ff661463bcdd6"
+  integrity sha512-rH6v/KbYi6KdaI7C04PZCnwtCG7GJeNjCnhBphviV3Cd7RmM1daMw2pvGJwOM75Y9rmtNF94YmoGRYZ17JSCxw==
   dependencies:
     lit "^2.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,12 +269,12 @@
   dependencies:
     lit-html "^1.2.1"
 
-"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.4":
-  version "1.1.0-alpha-webdev7939.4"
-  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.4.tgz#b8be01c7b4f1355378b706cf129b4c5f4da989a7"
-  integrity sha512-hL7hb4ULni+vT5vP/FZVuRmITp/zlE1swPJsClhFsksODoqG72VMdhYKcyUScODdQyPlC9rEt9B2rcBZjuNZig==
+"@internetarchive/infinite-scroller@1.1.0-alpha-webdev7939.6":
+  version "1.1.0-alpha-webdev7939.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/infinite-scroller/-/infinite-scroller-1.1.0-alpha-webdev7939.6.tgz#d756907488f7673075738a81d7dada277b702a3b"
+  integrity sha512-MG6UzLG9jlBTIXniCT+9cWEBG1+vwy7xSUeZvO6MXoykPxUd7Yk+DludCIucEHMlZQ9gC5SkDwLVymPpRMJ5oQ==
   dependencies:
-    lit "^2.0.2"
+    lit "^2.8.0"
 
 "@internetarchive/lazy-loader-service@^0.2.0":
   version "0.2.0"
@@ -4056,7 +4056,7 @@ lit-html@^3.3.0:
     lit-element "^4.2.0"
     lit-html "^3.3.0"
 
-lit@^2.0.2, lit@^2.2.7, lit@^2.3.0, lit@^2.8.0:
+lit@^2.2.7, lit@^2.3.0, lit@^2.8.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz"
   integrity sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==


### PR DESCRIPTION
The infinite-scroller component used by collection browser to render its results view currently has issues with deep paging, due to sizing its scroll window with empty DOM nodes. This PR switches it to an upgraded version that instead uses CSS transforms for virtualized scrolling that should remain performant even when hundreds of pages into a result set. We also make use of the new scroller's improved `scrollToCell` behavior for smoothly jumping to a page.