### PR TITLE
WEBDEV-8334 Fix percent-encoded URLs for web archives capture links

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.3.2-rc-webdev-8334.4",
+  "version": "4.3.2-rc-webdev-8334.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^2.0.0",
     "@internetarchive/modal-manager": "^2.0.5",
-    "@internetarchive/search-service": "2.7.2-rc-webdev-8334.2",
+    "@internetarchive/search-service": "2.7.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.12.2",
     "dompurify": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.3.2-rc-webdev-8334.0",
+  "version": "4.3.2-rc-webdev-8334.4",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^2.0.0",
     "@internetarchive/modal-manager": "^2.0.5",
-    "@internetarchive/search-service": "^2.7.1",
+    "@internetarchive/search-service": "2.7.2-rc-webdev-8334.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.12.2",
     "dompurify": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.4.1",
+  "version": "4.4.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.4.0",
+  "version": "4.3.2-rc-webdev-8334.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.3.2-rc-webdev-8334.5",
+  "version": "4.3.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.3.2",
+  "version": "4.4.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -176,21 +176,7 @@ export class TileDispatcher
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
     if (this.model.href) {
-      // Decode over-encoded Wayback target URLs from old stored data (%3A%2F%2F
-      // is an unambiguous sign the whole URL was percent-encoded). Only decode
-      // the segment after /web/{timestamp}/ to avoid corrupting the prefix.
-      const href = this.model.href.replace(
-        /(\/web\/\d+\/)(.+)/,
-        (_, prefix, target) => {
-          if (!/%3A%2F%2F/i.test(target)) return `${prefix}${target}`;
-          try {
-            return `${prefix}${decodeURIComponent(target)}`;
-          } catch {
-            return `${prefix}${target}`;
-          }
-        },
-      );
-      return `${this.baseNavigationUrl}${href}`;
+      return `${this.baseNavigationUrl}${this.model.href}`;
     }
 
     return this.displayValueProvider.itemPageUrl(

--- a/src/tiles/tile-dispatcher.ts
+++ b/src/tiles/tile-dispatcher.ts
@@ -176,7 +176,21 @@ export class TileDispatcher
     // Use the server-specified href if available.
     // Otherwise, construct a details page URL from the item identifier.
     if (this.model.href) {
-      return `${this.baseNavigationUrl}${this.model.href}`;
+      // Decode over-encoded Wayback target URLs from old stored data (%3A%2F%2F
+      // is an unambiguous sign the whole URL was percent-encoded). Only decode
+      // the segment after /web/{timestamp}/ to avoid corrupting the prefix.
+      const href = this.model.href.replace(
+        /(\/web\/\d+\/)(.+)/,
+        (_, prefix, target) => {
+          if (!/%3A%2F%2F/i.test(target)) return `${prefix}${target}`;
+          try {
+            return `${prefix}${decodeURIComponent(target)}`;
+          } catch {
+            return `${prefix}${target}`;
+          }
+        },
+      );
+      return `${this.baseNavigationUrl}${href}`;
     }
 
     return this.displayValueProvider.itemPageUrl(

--- a/src/tiles/tile-display-value-provider.ts
+++ b/src/tiles/tile-display-value-provider.ts
@@ -124,9 +124,8 @@ export class TileDisplayValueProvider {
       .toISOString()
       .replace(/[TZ:-]/g, '')
       .replace(/\..*/, '');
-    const captureHref = `https://web.archive.org/web/${captureDateStr}/${encodeURIComponent(
-      url,
-    )}`;
+    // url must not be percent-encoded — Wayback Machine matches on the raw URL
+    const captureHref = `https://web.archive.org/web/${captureDateStr}/${url}`;
     const captureText = formatDate(date, 'long');
 
     return html` <a href=${captureHref}> ${captureText} </a> `;

--- a/test/tiles/grid/item-tile.test.ts
+++ b/test/tiles/grid/item-tile.test.ts
@@ -453,7 +453,7 @@ describe('Item Tile', () => {
     const firstDateLink = captureDatesUl?.children[0]?.querySelector('a[href]');
     expect(firstDateLink, 'first date link').to.exist;
     expect(firstDateLink?.getAttribute('href')).to.equal(
-      'https://web.archive.org/web/20100102123456/https%3A%2F%2Fexample.com%2F',
+      'https://web.archive.org/web/20100102123456/https://example.com/',
     );
     expect(firstDateLink?.textContent?.trim()).to.equal('Jan 02, 2010');
 
@@ -461,7 +461,7 @@ describe('Item Tile', () => {
       captureDatesUl?.children[1]?.querySelector('a[href]');
     expect(secondDateLink, 'second date link').to.exist;
     expect(secondDateLink?.getAttribute('href')).to.equal(
-      'https://web.archive.org/web/20110203124321/https%3A%2F%2Fexample.com%2F',
+      'https://web.archive.org/web/20110203124321/https://example.com/',
     );
     expect(secondDateLink?.textContent?.trim()).to.equal('Feb 03, 2011');
   });

--- a/test/tiles/list/tile-list.test.ts
+++ b/test/tiles/list/tile-list.test.ts
@@ -509,7 +509,7 @@ describe('List Tile', () => {
     const firstDateLink = captureDatesUl?.children[0]?.querySelector('a[href]');
     expect(firstDateLink, 'first date link').to.exist;
     expect(firstDateLink?.getAttribute('href')).to.equal(
-      'https://web.archive.org/web/20100102123456/https%3A%2F%2Fexample.com%2F',
+      'https://web.archive.org/web/20100102123456/https://example.com/',
     );
     expect(firstDateLink?.textContent?.trim()).to.equal('Jan 02, 2010');
 
@@ -517,7 +517,7 @@ describe('List Tile', () => {
       captureDatesUl?.children[1]?.querySelector('a[href]');
     expect(secondDateLink, 'second date link').to.exist;
     expect(secondDateLink?.getAttribute('href')).to.equal(
-      'https://web.archive.org/web/20110203124321/https%3A%2F%2Fexample.com%2F',
+      'https://web.archive.org/web/20110203124321/https://example.com/',
     );
     expect(secondDateLink?.textContent?.trim()).to.equal('Feb 03, 2011');
   });

--- a/test/tiles/tile-dispatcher.test.ts
+++ b/test/tiles/tile-dispatcher.test.ts
@@ -110,7 +110,7 @@ describe('Tile Dispatcher', () => {
     window.open = oldWindowOpen;
   });
 
-  it('should use model href as-is when not percent-encoded', async () => {
+  it('should use model href as link href', async () => {
     const el = await fixture<TileDispatcher>(html`
       <tile-dispatcher
         .model=${{
@@ -128,45 +128,6 @@ describe('Tile Dispatcher', () => {
     expect(tileLink.getAttribute('href')).to.equal(
       'https://web.archive.org/web/20180613065659/http://www.sankei.com/',
     );
-  });
-
-  it('should decode percent-encoded model href before use', async () => {
-    const el = await fixture<TileDispatcher>(html`
-      <tile-dispatcher
-        .model=${{
-          identifier: 'foo',
-          href: 'https://web.archive.org/web/20180613065659/http%3A%2F%2Fwww.sankei.com%2F',
-        }}
-        .baseNavigationUrl=${''}
-      ></tile-dispatcher>
-    `);
-
-    const tileLink = el.shadowRoot?.querySelector(
-      'a[href]',
-    ) as HTMLAnchorElement;
-    expect(tileLink).to.exist;
-    expect(tileLink.getAttribute('href')).to.equal(
-      'https://web.archive.org/web/20180613065659/http://www.sankei.com/',
-    );
-  });
-
-  it('should not decode %3A in Wayback URL path when not an encoded scheme', async () => {
-    // %3A in the path (e.g. /path/%3Asomething) is not a sign of over-encoding;
-    // only %3A%2F%2F (encoded "://") is.
-    const href =
-      'https://web.archive.org/web/20180613065659/https://example.com/path/%3Asomething';
-    const el = await fixture<TileDispatcher>(html`
-      <tile-dispatcher
-        .model=${{ identifier: 'foo', href }}
-        .baseNavigationUrl=${''}
-      ></tile-dispatcher>
-    `);
-
-    const tileLink = el.shadowRoot?.querySelector(
-      'a[href]',
-    ) as HTMLAnchorElement;
-    expect(tileLink).to.exist;
-    expect(tileLink.getAttribute('href')).to.equal(href);
   });
 
   it('should toggle model checked state when manage check clicked', async () => {

--- a/test/tiles/tile-dispatcher.test.ts
+++ b/test/tiles/tile-dispatcher.test.ts
@@ -110,6 +110,65 @@ describe('Tile Dispatcher', () => {
     window.open = oldWindowOpen;
   });
 
+  it('should use model href as-is when not percent-encoded', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .model=${{
+          identifier: 'foo',
+          href: 'https://web.archive.org/web/20180613065659/http://www.sankei.com/',
+        }}
+        .baseNavigationUrl=${''}
+      ></tile-dispatcher>
+    `);
+
+    const tileLink = el.shadowRoot?.querySelector(
+      'a[href]',
+    ) as HTMLAnchorElement;
+    expect(tileLink).to.exist;
+    expect(tileLink.getAttribute('href')).to.equal(
+      'https://web.archive.org/web/20180613065659/http://www.sankei.com/',
+    );
+  });
+
+  it('should decode percent-encoded model href before use', async () => {
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .model=${{
+          identifier: 'foo',
+          href: 'https://web.archive.org/web/20180613065659/http%3A%2F%2Fwww.sankei.com%2F',
+        }}
+        .baseNavigationUrl=${''}
+      ></tile-dispatcher>
+    `);
+
+    const tileLink = el.shadowRoot?.querySelector(
+      'a[href]',
+    ) as HTMLAnchorElement;
+    expect(tileLink).to.exist;
+    expect(tileLink.getAttribute('href')).to.equal(
+      'https://web.archive.org/web/20180613065659/http://www.sankei.com/',
+    );
+  });
+
+  it('should not decode %3A in Wayback URL path when not an encoded scheme', async () => {
+    // %3A in the path (e.g. /path/%3Asomething) is not a sign of over-encoding;
+    // only %3A%2F%2F (encoded "://") is.
+    const href =
+      'https://web.archive.org/web/20180613065659/https://example.com/path/%3Asomething';
+    const el = await fixture<TileDispatcher>(html`
+      <tile-dispatcher
+        .model=${{ identifier: 'foo', href }}
+        .baseNavigationUrl=${''}
+      ></tile-dispatcher>
+    `);
+
+    const tileLink = el.shadowRoot?.querySelector(
+      'a[href]',
+    ) as HTMLAnchorElement;
+    expect(tileLink).to.exist;
+    expect(tileLink.getAttribute('href')).to.equal(href);
+  });
+
   it('should toggle model checked state when manage check clicked', async () => {
     const el = await fixture<TileDispatcher>(html`
       <tile-dispatcher

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,10 +307,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@2.7.2-rc-webdev-8334.2":
-  version "2.7.2-rc-webdev-8334.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.2-rc-webdev-8334.2.tgz#7f14b802a7e88d06335a2168ea3eff9a81d767db"
-  integrity sha512-Zajrr15yYB0NY8eOe4ny+uVnbi6s4Q06q9j4X8mD+mQQg9lKy4zT1F4VL66raVjZ230d7UO6OpKxmtbDnw6L7Q==
+"@internetarchive/search-service@2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.2.tgz#dcb7315ea82386291d3dae0d5dd3b8f152578758"
+  integrity sha512-d5iSVkoI97XM3DK4hyQqRQV385JerzG8K3Yl+8kniFplqp9qpH9gChRGJJiURE5qbonxYElq7nLmD+HejVgQVA==
   dependencies:
     "@internetarchive/iaux-item-metadata" "^1.1.0"
     "@internetarchive/result-type" "^0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,10 +307,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.1.tgz#669f162bdbfa61d5f476ad75fea2460f798ff4e0"
-  integrity sha512-XpZGTYM0ZRBI+LYWLrUYQMlK/3hpU005wqy0uboMZF+adPqhAAPwrKD8oJsgwTOidymBqxoDssv2YmK/0Rwxcw==
+"@internetarchive/search-service@2.7.2-rc-webdev-8334.2":
+  version "2.7.2-rc-webdev-8334.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.2-rc-webdev-8334.2.tgz#7f14b802a7e88d06335a2168ea3eff9a81d767db"
+  integrity sha512-Zajrr15yYB0NY8eOe4ny+uVnbi6s4Q06q9j4X8mD+mQQg9lKy4zT1F4VL66raVjZ230d7UO6OpKxmtbDnw6L7Q==
   dependencies:
     "@internetarchive/iaux-item-metadata" "^1.1.0"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
## Changes
- Remove encodeURIComponent() from the capture href construction
- Decode percent-encoded href values in TileDispatcher to fix broken web archive capture links
- Update tests for percent-encoded href fixes