### PR TITLE
WEBDEV-8182 Don't show the "hide" button in facet groups with only one option

### DIFF
--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -30,6 +30,13 @@ export class FacetRow extends LitElement {
   /** The facet bucket containing details about the state, count, and key for this row */
   @property({ type: Object }) bucket?: FacetBucket;
 
+  /**
+   * Whether to omit the negative/hide button from this facet row if possible.
+   * Has no effect if the facet bucket is itself hidden, in which case the hide
+   * button *must* be shown to represent the state accurately.
+   */
+  @property({ type: Boolean }) omitHideButton?: boolean;
+
   /** The collection name cache for converting collection identifiers to titles */
   @property({ type: Object })
   collectionTitles?: CollectionTitles;
@@ -102,7 +109,10 @@ export class FacetRow extends LitElement {
             id=${showOnlyCheckboxId}
             data-testid=${showOnlyCheckboxId}
           />
-          <div class="hide-facet-container">
+          <div
+            class="hide-facet-container"
+            ?hidden=${this.omitHideButton && !facetHidden}
+          >
             <input
               type="checkbox"
               id=${negativeCheckboxId}

--- a/src/collection-facets/facets-template.ts
+++ b/src/collection-facets/facets-template.ts
@@ -36,6 +36,7 @@ export class FacetsTemplate extends LitElement {
     if (!facetGroup) return nothing;
 
     const facetBuckets = facetGroup.buckets as FacetBucket[];
+    const isLoneBucket = facetBuckets.length === 1;
 
     // Added data-testid for Playwright testing
     // Using className and aria-labels is not ideal for Playwright locator
@@ -49,6 +50,7 @@ export class FacetsTemplate extends LitElement {
               .facetType=${facetGroup.key}
               .bucket=${bucket}
               .collectionTitles=${this.collectionTitles}
+              ?omitHideButton=${isLoneBucket}
               @facetClick=${this.facetClicked}
             ></facet-row>`,
         )}

--- a/test/collection-facets/facet-row.test.ts
+++ b/test/collection-facets/facet-row.test.ts
@@ -122,6 +122,52 @@ describe('Facet row', () => {
     );
   });
 
+  it('omits hide button when property is specified (and facet state is not hidden)', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'none' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetType=${'subject'}
+        .bucket=${bucket}
+        omitHideButton
+      ></facet-row>`,
+    );
+
+    // Hide button's container is hidden
+    expect(
+      el.shadowRoot
+        ?.querySelector('.hide-facet-container')
+        ?.hasAttribute('hidden'),
+    ).to.be.true;
+  });
+
+  it('does not omit hide button when facet state is hidden, even if property specified', async () => {
+    const bucket = {
+      key: 'foo',
+      state: 'hidden' as FacetState,
+      count: 5,
+    };
+
+    const el = await fixture<FacetRow>(
+      html`<facet-row
+        .facetType=${'subject'}
+        .bucket=${bucket}
+        omitHideButton
+      ></facet-row>`,
+    );
+
+    // Hide button's container is NOT hidden (i.e., we SHOW the hide button like normal)
+    expect(
+      el.shadowRoot
+        ?.querySelector('.hide-facet-container')
+        ?.hasAttribute('hidden'),
+    ).to.be.false;
+  });
+
   it('renders correct accessible label for unchecked negative facets', async () => {
     const bucket = {
       key: 'foo',


### PR DESCRIPTION
If a facet group has only a single bucket representing all results, currently it is still possible to click the eye icon to hide that facet, predictably causing a "no results" page. In such cases, we should instead not show the button to hide that facet's results in the first place, preventing that undesired no-results scenario.

This PR adds an `omitHideButton` property to facet rows, and enables it when there is only a single facet row in a group.