### PR TITLE
WEBDEV-8182 Default value for `omitHideButton` property

### DIFF
--- a/src/collection-facets/facet-row.ts
+++ b/src/collection-facets/facet-row.ts
@@ -35,7 +35,7 @@ export class FacetRow extends LitElement {
    * Has no effect if the facet bucket is itself hidden, in which case the hide
    * button *must* be shown to represent the state accurately.
    */
-  @property({ type: Boolean }) omitHideButton?: boolean;
+  @property({ type: Boolean, reflect: true }) omitHideButton = false;
 
   /** The collection name cache for converting collection identifiers to titles */
   @property({ type: Object })


### PR DESCRIPTION
The recently-added `omitHideButton` property defaults to `undefined`, which is non-ideal. This PR makes it non-optional and defaulting to `false`, as well as reflecting it for consistency with most of our other components' boolean properties.