### PR TITLE
v4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The Internet Archive Collection Browser.",
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@internetarchive/iaux-item-metadata": "^1.0.5",
     "@internetarchive/infinite-scroller": "^2.0.0",
     "@internetarchive/modal-manager": "^2.0.5",
-    "@internetarchive/search-service": "2.7.2",
+    "@internetarchive/search-service": "^2.7.2",
     "@internetarchive/shared-resize-observer": "^0.2.0",
     "@lit/localize": "^0.12.2",
     "dompurify": "^3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,7 +307,7 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@2.7.2":
+"@internetarchive/search-service@^2.7.2":
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-2.7.2.tgz#dcb7315ea82386291d3dae0d5dd3b8f152578758"
   integrity sha512-d5iSVkoI97XM3DK4hyQqRQV385JerzG8K3Yl+8kniFplqp9qpH9gChRGJJiURE5qbonxYElq7nLmD+HejVgQVA==


### PR DESCRIPTION
Version adds the option to include action buttons on tiles, and a fix that removes the unhelpful "hide" buttons on facets that are the only option in their group.