### PR TITLE
WEBDEV-8221 Improve consistency of date picker behavior in tvarchive

### DIFF
--- a/src/collection-browser.ts
+++ b/src/collection-browser.ts
@@ -1684,19 +1684,8 @@ export class CollectionBrowser
     this.analyticsHandler?.sendEvent({
       category: this.searchContext,
       action: analyticsActions.histogramChanged,
-      label: this.dateRangeQueryClause,
+      label: this.dataSource.dateRangeQueryClause,
     });
-  }
-
-  /**
-   * The Lucene query corresponding to the current date range.
-   */
-  private get dateRangeQueryClause() {
-    if (!this.minSelectedDate || !this.maxSelectedDate) {
-      return undefined;
-    }
-
-    return `year:[${this.minSelectedDate} TO ${this.maxSelectedDate}]`;
   }
 
   /**

--- a/src/data-source/collection-browser-data-source-interface.ts
+++ b/src/data-source/collection-browser-data-source-interface.ts
@@ -72,6 +72,12 @@ export interface CollectionBrowserDataSourceInterface
   readonly pageSpecifierParams: PageSpecifierParams | null;
 
   /**
+   * The Lucene query clause corresponding to the current date range,
+   * e.g. `year:[2000 TO 2020]` or `date:[2020-01 TO 2020-12]`.
+   */
+  readonly dateRangeQueryClause: string | undefined;
+
+  /**
    * A FilterMap object representing all filters applied to the current search,
    * including any facets, letter filters, and date ranges.
    */

--- a/src/data-source/collection-browser-data-source.ts
+++ b/src/data-source/collection-browser-data-source.ts
@@ -33,6 +33,7 @@ import type { CollectionBrowserDataSourceInterface } from './collection-browser-
 import type { CollectionBrowserSearchInterface } from './collection-browser-query-state';
 import { sha1 } from '../utils/sha1';
 import { mergeSelectedFacets } from '../utils/facet-utils';
+import { dateFilterField } from '../utils/date-filter-field';
 
 export class CollectionBrowserDataSource
   implements CollectionBrowserDataSourceInterface
@@ -746,7 +747,10 @@ export class CollectionBrowserDataSource
       selectedCreatorFilter,
     } = this.host;
 
-    const dateField = this.host.searchType === SearchType.TV ? 'date' : 'year';
+    const dateField = dateFilterField(
+      this.host.minSelectedDate,
+      this.host.maxSelectedDate,
+    );
 
     if (minSelectedDate) {
       builder.addFilter(
@@ -901,12 +905,16 @@ export class CollectionBrowserDataSource
     return this.joinFacetClauses(facetClauses)?.trim();
   }
 
-  private get dateRangeQueryClause(): string | undefined {
+  get dateRangeQueryClause(): string | undefined {
     if (!this.host.minSelectedDate || !this.host.maxSelectedDate) {
       return undefined;
     }
 
-    return `year:[${this.host.minSelectedDate} TO ${this.host.maxSelectedDate}]`;
+    const dateField = dateFilterField(
+      this.host.minSelectedDate,
+      this.host.maxSelectedDate,
+    );
+    return `${dateField}:[${this.host.minSelectedDate} TO ${this.host.maxSelectedDate}]`;
   }
 
   private get sortFilterQueries(): string {
@@ -1069,10 +1077,11 @@ export class CollectionBrowserDataSource
       success.response;
     this.aggregations = aggregations;
 
-    this.histogramAggregation =
-      this.host.searchType === SearchType.TV
-        ? aggregations?.date_histogram
-        : aggregations?.year_histogram;
+    const useDateHistogram =
+      this.host.searchType === SearchType.TV || this.host.isTVCollection;
+    this.histogramAggregation = useDateHistogram
+      ? (aggregations?.date_histogram ?? aggregations?.year_histogram)
+      : aggregations?.year_histogram;
 
     if (collectionTitles) {
       for (const [id, title] of Object.entries(collectionTitles)) {

--- a/src/restoration-state-handler.ts
+++ b/src/restoration-state-handler.ts
@@ -14,6 +14,7 @@ import {
   tvClipURLParamsToFilters,
 } from './models';
 import { arrayEquals } from './utils/array-equals';
+import { dateFilterField } from './utils/date-filter-field';
 
 export interface RestorationState {
   displayMode?: CollectionDisplayMode;
@@ -190,11 +191,10 @@ export class RestorationStateHandler
       }
     }
 
-    const dateField =
-      state.minSelectedDate?.includes('-') ||
-      state.maxSelectedDate?.includes('-')
-        ? 'date'
-        : 'year';
+    const dateField = dateFilterField(
+      state.minSelectedDate,
+      state.maxSelectedDate,
+    );
 
     if (state.minSelectedDate && state.maxSelectedDate) {
       newParams.append(

--- a/src/utils/date-filter-field.ts
+++ b/src/utils/date-filter-field.ts
@@ -1,0 +1,11 @@
+/**
+ * Determines the appropriate search filter field name based on date format.
+ * Dates in YYYY-MM format (containing a hyphen) use the `date` field;
+ * dates in YYYY format use the `year` field.
+ */
+export function dateFilterField(
+  minDate?: string,
+  maxDate?: string,
+): 'date' | 'year' {
+  return minDate?.includes('-') || maxDate?.includes('-') ? 'date' : 'year';
+}

--- a/test/collection-browser.test.ts
+++ b/test/collection-browser.test.ts
@@ -2504,4 +2504,136 @@ describe('Collection Browser', () => {
     const initialResults = el.dataSource.getAllPages();
     expect(Object.keys(initialResults).length).to.deep.equal(numberOfPages);
   });
+
+  it('uses date filter field for YYYY-MM selected dates', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'months';
+    el.searchType = SearchType.TV;
+    el.minSelectedDate = '2001-02';
+    el.maxSelectedDate = '2002-12';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.date?.['2001-02']).to.equal(
+      FilterConstraint.GREATER_OR_EQUAL,
+    );
+    expect(searchService.searchParams?.filters?.date?.['2002-12']).to.equal(
+      FilterConstraint.LESS_OR_EQUAL,
+    );
+    expect(searchService.searchParams?.filters?.year).not.to.exist;
+  });
+
+  it('still uses year filter field for YYYY selected dates', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser .searchService=${searchService}>
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'years';
+    el.minSelectedDate = '1950';
+    el.maxSelectedDate = '1970';
+    await el.updateComplete;
+    await el.initialSearchComplete;
+
+    expect(searchService.searchParams?.filters?.year?.['1950']).to.equal(
+      FilterConstraint.GREATER_OR_EQUAL,
+    );
+    expect(searchService.searchParams?.filters?.year?.['1970']).to.equal(
+      FilterConstraint.LESS_OR_EQUAL,
+    );
+    expect(searchService.searchParams?.filters?.date).not.to.exist;
+  });
+
+  it('selects date_histogram for isTVCollection even with metadata searchType', async () => {
+    const searchService = new MockSearchService();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .suppressPlaceholders=${true}
+      >
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'months';
+    el.isTVCollection = true;
+    el.showHistogramDatePicker = true;
+    await el.updateComplete;
+    await el.initialSearchComplete;
+    await nextTick();
+
+    const facets = el.shadowRoot?.querySelector(
+      'collection-facets',
+    ) as CollectionFacets;
+    await facets?.updateComplete;
+    await nextTick();
+
+    const histogram = facets?.shadowRoot?.querySelector(
+      'histogram-date-range',
+    ) as HistogramDateRange;
+
+    expect(histogram, 'histogram exists').to.exist;
+  });
+
+  it('uses date: query clause for YYYY-MM date ranges', async () => {
+    const searchService = new MockSearchService();
+    const mockAnalyticsHandler = new MockAnalyticsHandler();
+    const el = await fixture<CollectionBrowser>(
+      html`<collection-browser
+        .searchService=${searchService}
+        .analyticsHandler=${mockAnalyticsHandler}
+        .suppressPlaceholders=${true}
+      >
+      </collection-browser>`,
+    );
+
+    el.baseQuery = 'months';
+    el.searchType = SearchType.TV;
+    el.showHistogramDatePicker = true;
+    await el.updateComplete;
+
+    const facets = el.shadowRoot?.querySelector(
+      'collection-facets',
+    ) as CollectionFacets;
+    await facets?.updateComplete;
+
+    await nextTick();
+
+    const histogram = facets?.shadowRoot?.querySelector(
+      'histogram-date-range',
+    ) as HistogramDateRange;
+
+    expect(histogram, 'histogram exists').to.exist;
+
+    // Enter a new min date into the date picker
+    const minDateInput = histogram.shadowRoot?.querySelector(
+      '#date-min',
+    ) as HTMLInputElement;
+
+    const pressEnterEvent = new KeyboardEvent('keyup', {
+      key: 'Enter',
+    });
+
+    minDateInput.value = '2001-02';
+    minDateInput.dispatchEvent(pressEnterEvent);
+
+    // Wait for the histogram's update delay
+    await aTimeout(histogram.updateDelay + 50);
+
+    await el.updateComplete;
+    expect(el.minSelectedDate).to.equal('2001-02');
+    expect(el.maxSelectedDate).to.equal('2002-12');
+
+    // Verify the analytics event used date: not year:
+    expect(mockAnalyticsHandler.callAction).to.equal(
+      analyticsActions.histogramChanged,
+    );
+    expect(mockAnalyticsHandler.callLabel).to.include('date:');
+    expect(mockAnalyticsHandler.callLabel).not.to.include('year:');
+  });
 });


### PR DESCRIPTION
The `tvarchive` collection is materialized by MDS, but is capable of using more granular month-resolution date ranges like other TV collections. However, there is currently a bug where it attempts to set those date ranges using the `year` field instead of `date`. This stems from some inconsistencies in how we determine the correct date field for TV vs. non-TV collections. This PR aims to make our logic more consistent around determining which collections do/do not count for this TV special handling, and which date field they should be using for their date ranges, fixing the `tvarchive` bug in the process.