### PR TITLE
WEBDEV-8710 Fix flaky hover pane controller tests

### DIFF
--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -584,10 +584,18 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     if (this.hoverPane && !this.hoverPane.matches(':popover-open')) {
       this.hoverPane.showPopover?.();
     }
-    await new Promise(resolve => {
-      // Pane sizes aren't accurate until next frame
-      requestAnimationFrame(resolve);
-    });
+    // Pane sizes aren't accurate until the pane's full descendant tree has
+    // rendered. The next animation frame guarantees that to be true, but
+    // frames are skipped when the page is not visible, so fall back to a
+    // short timer as a backstop in such cases.
+    await Promise.race([
+      new Promise(resolve => {
+        requestAnimationFrame(resolve);
+      }),
+      new Promise(resolve => {
+        setTimeout(resolve, 50);
+      }),
+    ]);
 
     // Apply the correct positioning to the hover pane
     this.repositionHoverPane(options.anchor);

--- a/test/tiles/hover/hover-pane-controller.test.ts
+++ b/test/tiles/hover/hover-pane-controller.test.ts
@@ -1,4 +1,4 @@
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture, waitUntil } from '@open-wc/testing';
 import { html, LitElement, nothing, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import {
@@ -403,12 +403,10 @@ describe('Hover Pane Controller', () => {
       const getBoundingClientRectSpy = sinon.spy(host, 'getBoundingClientRect');
 
       host.dispatchEvent(new FocusEvent('focus'));
-      // Need to wait a tick for the event handlers to run
-      await new Promise(resolve => {
-        setTimeout(resolve, 0);
-      });
-
-      expect(getBoundingClientRectSpy.called).to.be.true;
+      await waitUntil(
+        () => getBoundingClientRectSpy.called,
+        'host getBoundingClientRect was never consulted for positioning',
+      );
     });
 
     it('should show hover pane on focus', async () => {
@@ -419,12 +417,15 @@ describe('Hover Pane Controller', () => {
       );
 
       host.dispatchEvent(new FocusEvent('focus'));
-      // Need to wait a tick for the event handlers to run
-      await new Promise(resolve => {
-        setTimeout(resolve, 0);
-      });
 
-      expect(host.controller?.getTemplate()).not.to.equal(nothing); // Is a TemplateResult
+      // The controller template becomes available synchronously with the focus event
+      expect(host.controller?.getTemplate()).not.to.equal(nothing);
+
+      // The pane element then renders and opens as a popover
+      await waitUntil(
+        () => host.getHoverPane()?.matches(':popover-open') ?? false,
+        'Hover pane never opened as a popover',
+      );
     });
 
     it('should hide hover pane on blur', async () => {
@@ -435,20 +436,16 @@ describe('Hover Pane Controller', () => {
       );
 
       host.dispatchEvent(new FocusEvent('focus'));
-      // Need to wait a tick for the event handlers to run
-      await new Promise(resolve => {
-        setTimeout(resolve, 0);
-      });
-
-      expect(host.controller?.getTemplate()).not.to.equal(nothing); // Is a TemplateResult
+      await waitUntil(
+        () => host.getHoverPane()?.matches(':popover-open') ?? false,
+        'Hover pane never opened as a popover',
+      );
 
       host.dispatchEvent(new FocusEvent('blur'));
-      // Need to wait for the fade out transition
-      await new Promise(resolve => {
-        setTimeout(resolve, 150);
-      });
-
-      expect(host.controller?.getTemplate()).to.equal(nothing);
+      await waitUntil(
+        () => !host.getHoverPane(),
+        'Hover pane was not removed after blur',
+      );
     });
   });
 });

--- a/test/tiles/hover/hover-pane-controller.test.ts
+++ b/test/tiles/hover/hover-pane-controller.test.ts
@@ -448,4 +448,35 @@ describe('Hover Pane Controller', () => {
       );
     });
   });
+
+  describe('frame-starved environments', () => {
+    let realRaf: typeof window.requestAnimationFrame;
+
+    before(() => {
+      realRaf = window.requestAnimationFrame;
+      // Simulate an environment that never produces rendering frames:
+      // callbacks are accepted but never invoked.
+      window.requestAnimationFrame = () => 0;
+    });
+
+    after(() => {
+      window.requestAnimationFrame = realRaf;
+    });
+
+    it('should position the hover pane even when animation frames never fire', async () => {
+      const host = await fixture<HostElement>(
+        html`<host-element
+          .controllerOptions=${{ showDelay: 0, hideDelay: 0 }}
+        ></host-element>`,
+      );
+
+      const getBoundingClientRectSpy = sinon.spy(host, 'getBoundingClientRect');
+
+      host.dispatchEvent(new FocusEvent('focus'));
+      await waitUntil(
+        () => getBoundingClientRectSpy.called,
+        'host getBoundingClientRect was never consulted for positioning',
+      );
+    });
+  });
 });


### PR DESCRIPTION
A handful of our unit tests for the hover pane controller occasionally fail in flaky ways due to brittle timed waits. This PR replaces those with more robust `waitUntil` assertions to make the tests more consistent, and adds a fallback for resolving the `showHoverPane` promise in frame-starved environments.