### PR TITLE
WEVDEV-8697 Guard `:popover-open` match to avoid errors in older browsers

### DIFF
--- a/src/tiles/hover/hover-pane-controller.ts
+++ b/src/tiles/hover/hover-pane-controller.ts
@@ -581,7 +581,7 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     // as it might have been removed by the previous update.
     if (!this.hoverPane?.isConnected) return;
 
-    if (this.hoverPane && !this.hoverPane.matches(':popover-open')) {
+    if (this.hoverPane && !this.isHoverPanePopoverOpen()) {
       this.hoverPane.showPopover?.();
     }
     // Pane sizes aren't accurate until the pane's full descendant tree has
@@ -604,6 +604,18 @@ export class HoverPaneController implements HoverPaneControllerInterface {
     // while being positioned). Since it now has the correct positioning, we
     // can make it visible and begin its fade-in animation.
     this.hoverPane?.classList.add('visible', 'fade-in');
+  }
+
+  /**
+   * Whether the hover pane is currently being shown as an open popover.
+   * Returns `false` in browsers that don't yet recognize `:popover-open`.
+   */
+  private isHoverPanePopoverOpen(): boolean {
+    try {
+      return !!this.hoverPane?.matches(':popover-open');
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/test/tiles/hover/hover-pane-controller.test.ts
+++ b/test/tiles/hover/hover-pane-controller.test.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect, fixture, waitUntil } from '@open-wc/testing';
 import { html, LitElement, nothing, TemplateResult } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import {
@@ -215,6 +215,42 @@ describe('Hover Pane Controller', () => {
 
     // ...but should NOT call showPopover() again
     expect(showPopoverSpy.called).to.be.false;
+    expect(host.getHoverPane()?.matches(':popover-open')).to.be.true;
+  });
+
+  it('should still show the hover pane when :popover-open is not a supported selector', async () => {
+    const host = await fixture<HostElement>(
+      html`<host-element
+        .controllerOptions=${{ showDelay: 0, hideDelay: 0 }}
+      ></host-element>`,
+    );
+
+    // Simulate a browser that doesn't recognize the :popover-open pseudo and throws when matched against it
+    const originalMatches = Element.prototype.matches;
+    const matchesStub = sinon
+      .stub(Element.prototype, 'matches')
+      .callsFake(function (this: Element, selector: string): boolean {
+        if (selector.includes(':popover-open')) {
+          throw new DOMException(
+            `Failed to execute 'matches' on 'Element': '${selector}' is not a valid selector.`,
+            'SyntaxError',
+          );
+        }
+        return originalMatches.call(this, selector);
+      });
+
+    const showPopoverSpy = sinon.spy(HTMLElement.prototype, 'showPopover');
+
+    try {
+      host.dispatchEvent(new MouseEvent('mousemove'));
+      await aTimeout(10);
+      await host.updateComplete;
+    } finally {
+      matchesStub.restore();
+      showPopoverSpy.restore();
+    }
+
+    expect(showPopoverSpy.calledOnce).to.be.true;
     expect(host.getHoverPane()?.matches(':popover-open')).to.be.true;
   });
 


### PR DESCRIPTION
Currently we are seeing errors in Sentry from older browsers that do not support popovers, because we match against the :popover-open pseudo-class before opening a tile's hover pane. While there should be a popover polyfill present in such cases, we should account for the possibility it failed to load or has not yet arrived. This PR guards the match with a try-catch block to ensure we don't error out of showing the hover pane entirely in those cases, and adds a unit test to simulate that case.